### PR TITLE
fix: use old getdetail API with platform/comboChannel to fix channel error

### DIFF
--- a/desktop/src-tauri/src/dm_config.rs
+++ b/desktop/src-tauri/src/dm_config.rs
@@ -22,7 +22,7 @@ pub const SEC_CH_UA: &str =
     "\"Google Chrome\";v=\"146\", \"Chromium\";v=\"146\", \";Not A Brand\";v=\"24\"";
 
 // 各接口独立版本号（出现在 URL path 中）
-pub const API_VERSION_DETAIL: &str = "1.0"; // mtop.damai.item.detail.getdetail
+pub const API_VERSION_DETAIL: &str = "1.2"; // mtop.alibaba.damai.detail.getdetail
 pub const API_VERSION_SKU: &str = "2.0"; // mtop.alibaba.detail.subpage.getdetail
 pub const API_VERSION_ORDER_BUILD: &str = "1.0"; // mtop.damai.trade.order.build.h5
 pub const API_VERSION_ORDER_CREATE: &str = "1.0"; // mtop.damai.trade.order.create.h5

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -59,16 +59,19 @@ async fn get_info(
     address: String,
 ) -> Result<String, Box<dyn Error>> {
     let base = dm_config::build_base_url(
-        "mtop.damai.item.detail.getdetail",
+        "mtop.alibaba.damai.detail.getdetail",
         dm_config::API_VERSION_DETAIL,
         t, sign,
     );
     let url = format!(
-        "{}&api=mtop.damai.item.detail.getdetail&v=1.0&H5Request=true\
-         &type=json&timeout=10000&dataType=json&valueType=string\
-         &forceAntiCreep=true&AntiCreep=true\
-         &data=%7B%22itemId%22%3A%22{}%22%2C%22platform%22%3A%228%22\
-         %2C%22comboChannel%22%3A%222%22%2C%22dmChannel%22%3A%22damai%40damaih5_h5%22%7D",
+        "{}&type=originaljson&dataType=json&v=2.0&H5Request=true\
+         &AntiCreep=true&forceAntiCreep=true&timeout=10000\
+         &api=mtop.alibaba.damai.detail.getdetail\
+         &data=%7B%22itemId%22%3A%22{}%22%2C%22bizCode%22%3A%22ali.china.damai%22\
+         %2C%22scenario%22%3A%22itemsku%22%2C%22exParams%22%3A%22%7B%5C%22dataType%5C%22%3A4\
+         %2C%5C%22dataId%5C%22%3A%5C%22%5C%22%2C%5C%22privilegeActId%5C%22%3A%5C%22%5C%22%7D%22\
+         %2C%22platform%22%3A%228%22%2C%22comboChannel%22%3A%222%22\
+         %2C%22dmChannel%22%3A%22damai%40damaih5_h5%22%7D",
         base, itemid
     );
 

--- a/desktop/src/components/dm/Product.vue
+++ b/desktop/src/components/dm/Product.vue
@@ -38,7 +38,7 @@ const lastCountDownVal = computed(() => countDownVal.value + timeFix.value)
 // 从 store 获取 form
 const form = computed(() => store.state.dm.form)
 async function getProductInfo() {
-    const data = `{"itemId":"${form.value.itemId}","bizCode":"ali.china.damai","scenario":"itemsku","exParams":"{\\"dataType\\":4,\\"dataId\\":\\"\\",\\"privilegeActId\\":\\"\\"}","dmChannel":"damai@damaih5_h5"}`;
+    const data = `{"itemId":"${form.value.itemId}","bizCode":"ali.china.damai","scenario":"itemsku","exParams":"{\\"dataType\\":4,\\"dataId\\":\\"\\",\\"privilegeActId\\":\\"\\"}","platform":"8","comboChannel":"2","dmChannel":"damai@damaih5_h5"}`;
     const [t, sign] = getSign(data, form.value.token);
 
     try {


### PR DESCRIPTION
## Summary

- Reverts `get_info` API from `mtop.damai.item.detail.getdetail` v1.0 back to `mtop.alibaba.damai.detail.getdetail` v1.2 — the new API lacks `detailViewComponentMap` response structure that the frontend parses
- Adds missing `bizCode`, `scenario`, `exParams` fields to Rust URL data to match JS sign computation (fixes sign mismatch → request rejection)
- Adds `platform:"8"` and `comboChannel:"2"` to both Rust URL and JS sign data to fix `buyBtnStatus="100"` (该渠道不支持购票)

This was commit `f9c9713` on `desktop-api-update` that was pushed after PR #1 was merged.

## Test plan

- [ ] `cargo check` passes
- [ ] `vite build` passes
- [ ] Sign data in Product.vue matches Rust URL data exactly
- [ ] getProductInfo returns `detailViewComponentMap` in response
- [ ] `buyBtnStatus` is not `100` for supported products