### PR TITLE
fix(mobile): W1 P0 修复栈 — #32 selenium 守门 + #29 立即预订文案

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ tmp_*.png
 tmp_*.xml
 mobile/tmp_*.png
 mobile/tmp_*.xml
+
+# Internal R&D PM workspace (not for public consumption)
+reference/

--- a/mobile/buy_button_guard.py
+++ b/mobile/buy_button_guard.py
@@ -17,26 +17,32 @@ except ImportError:
 
 logger = get_logger(__name__)
 
-SAFE_TEXTS = frozenset({
-    "立即购买",
-    "立即购票",
-    "立即抢票",
-    "立即预定",
-    "选座购买",
-    "购买",
-    "抢票",
-    "预定",
-})
+SAFE_TEXTS = frozenset(
+    {
+        "立即购买",
+        "立即购票",
+        "立即抢票",
+        "立即预定",
+        "立即预订",  # 大麦 2026-04 后新增（issue #29）
+        "Book Now",  # 国际化场景兜底（issue #29）
+        "选座购买",
+        "购买",
+        "抢票",
+        "预定",
+    }
+)
 
-BLOCKED_TEXTS = frozenset({
-    "预约抢票",
-    "预约",
-    "预售",
-    "即将开抢",
-    "待开售",
-    "未开售",
-    "提交抢票预约",
-})
+BLOCKED_TEXTS = frozenset(
+    {
+        "预约抢票",
+        "预约",
+        "预售",
+        "即将开抢",
+        "待开售",
+        "未开售",
+        "提交抢票预约",
+    }
+)
 
 _BUY_BUTTON_RESOURCE_ID = "cn.damai:id/btn_buy_view"
 

--- a/mobile/damai_app.py
+++ b/mobile/damai_app.py
@@ -6,6 +6,8 @@ __Description__ = "大麦app抢票自动化 - 优化版"
 __Created__ = 2025/09/13 19:27
 """
 
+from __future__ import annotations
+
 import re
 import time
 from contextlib import contextmanager

--- a/mobile/damai_app.py
+++ b/mobile/damai_app.py
@@ -11,7 +11,14 @@ import time
 from contextlib import contextmanager
 from datetime import datetime, timezone, timedelta
 
-from selenium.webdriver.common.by import By
+try:
+    from selenium.webdriver.common.by import By
+except ModuleNotFoundError as e:
+    raise SystemExit(
+        "依赖缺失：selenium 未安装。\n"
+        "→ 请在项目根目录运行：poetry install\n"
+        "→ 然后通过 mobile/scripts/start_ticket_grabbing.sh 启动而非直接运行 .py"
+    ) from e
 
 try:
     from mobile.config import Config
@@ -1739,9 +1746,7 @@ class DamaiBot(UIPrimitives):
                                     duration=25,
                                 )
                             except Exception:
-                                self.ultra_fast_click(
-                                    By.ID, "cn.damai:id/btn_buy_view"
-                                )
+                                self.ultra_fast_click(By.ID, "cn.damai:id/btn_buy_view")
                 else:
                     if not self.ultra_fast_click(By.ID, "cn.damai:id/btn_buy_view"):
                         self.ultra_fast_click(

--- a/mobile/damai_app.py
+++ b/mobile/damai_app.py
@@ -75,10 +75,22 @@ _PRICE_UNAVAILABLE_TAGS = {
     "不可选",
     "暂不可售",
 }
-_CTA_READY_KEYWORDS = (
-    "立即购买",
-    "立即抢票",
+# 开售后大麦详情页 / 票务面板上"可点购票"的安全文案集合（issue #29）。
+# 任意一个文案出现即视为开售已开放购买入口；不在此列的文案（如"预约抢票""即将开抢"）
+# 一律视为未开售，避免误点预约入口。
+SALE_READY_TEXTS: tuple[str, ...] = (
+    "立即购票",
     "立即预定",
+    "立即预订",  # 大麦 2026-04 后新增（issue #29）
+    "立即抢票",
+    "Book Now",  # 国际化场景兜底
+)
+# UiSelector textMatches 用：基于 SALE_READY_TEXTS 自动生成的正则联合
+# （新增/修改 SALE_READY_TEXTS 时此处自动同步，避免文案分散）
+_SALE_READY_TEXT_REGEX_OR = "|".join(f".*{t}.*" for t in SALE_READY_TEXTS)
+_CTA_READY_KEYWORDS = (
+    *SALE_READY_TEXTS,
+    "立即购买",
     "选座购买",
     "购买",
     "抢票",
@@ -851,10 +863,11 @@ class DamaiBot(UIPrimitives):
                 timeout=0.2,
             )
             if not _buy_clicked:
+                # 文案集合源 SALE_READY_TEXTS（issue #29）+ 旧文案兜底
                 _buy_clicked = self._cached_tap(
                     "detail_buy",
                     ANDROID_UIAUTOMATOR,
-                    'new UiSelector().textMatches(".*购票.*|.*抢票.*|.*购买.*|.*立即.*")',
+                    f'new UiSelector().textMatches("{_SALE_READY_TEXT_REGEX_OR}|.*购票.*|.*抢票.*|.*购买.*")',
                     timeout=0.25,
                 )
             if _buy_clicked:
@@ -864,6 +877,7 @@ class DamaiBot(UIPrimitives):
                 if next_probe["state"] in {"sku_page", "order_confirm_page"}:
                     return next_probe
 
+        # 文案集合源 SALE_READY_TEXTS（issue #29）+ 旧"预约/购买"兜底
         book_selectors = [
             (
                 By.ID,
@@ -871,7 +885,7 @@ class DamaiBot(UIPrimitives):
             ),
             (
                 ANDROID_UIAUTOMATOR,
-                'new UiSelector().textMatches(".*预约.*|.*购买.*|.*立即.*")',
+                f'new UiSelector().textMatches("{_SALE_READY_TEXT_REGEX_OR}|.*预约.*|.*购买.*")',
             ),
             (By.XPATH, '//*[contains(@text,"预约") or contains(@text,"购买")]'),
         ]
@@ -923,16 +937,25 @@ class DamaiBot(UIPrimitives):
         return any(normalize_text(keyword) in merged for keyword in _CTA_READY_KEYWORDS)
 
     def _is_sale_ready(self):
-        """Check whether the current UI state is actionable for purchase."""
-        ready_selectors = [
-            (ANDROID_UIAUTOMATOR, 'new UiSelector().textContains("立即购买")'),
-            (ANDROID_UIAUTOMATOR, 'new UiSelector().textContains("立即抢票")'),
-            (ANDROID_UIAUTOMATOR, 'new UiSelector().textContains("选座购买")'),
-            (ANDROID_UIAUTOMATOR, 'new UiSelector().textContains("立即提交")'),
-            (ANDROID_UIAUTOMATOR, 'new UiSelector().textContains("提交订单")'),
-        ]
-        for by, value in ready_selectors:
-            if self._has_element(by, value):
+        """Check whether the current UI state is actionable for purchase.
+
+        Sale-readiness is detected via :data:`SALE_READY_TEXTS` (开售文案) plus
+        a small set of post-confirm CTAs ("立即购买" / "选座购买" / "提交订单" 等)
+        that may appear once the user has already entered the SKU/order page.
+        """
+        ready_texts = (
+            *SALE_READY_TEXTS,
+            "立即购买",
+            "选座购买",
+            "立即提交",
+            "提交订单",
+        )
+        for text in ready_texts:
+            if self._has_element(
+                ANDROID_UIAUTOMATOR,
+                f'new UiSelector().textContains("{text}")',
+            ):
+                self._last_sale_ready_text = text
                 return True
 
         if self._has_element(
@@ -985,13 +1008,16 @@ class DamaiBot(UIPrimitives):
 
         # Tight polling loop with multiple purchase signals until the page becomes actionable.
         deadline = sell_time + timedelta(seconds=8)
+        polls = 0
         while datetime.now(tz=_tz_shanghai) < deadline:
+            polls += 1
             if self._is_sale_ready():
-                logger.info("检测到可购买按钮，开售已开始")
+                cta_text = getattr(self, "_last_sale_ready_text", None) or "?"
+                logger.info(f"CTA_MATCH: text={cta_text!r} polls={polls} (开售已开始)")
                 return
             time.sleep(0.08)
 
-        logger.warning("等待开售超时，继续执行")
+        logger.warning(f"等待开售超时（轮询 {polls} 次），继续执行")
 
     def verify_order_result(self, timeout=5):
         """验证订单提交结果"""

--- a/mobile/hot_path_benchmark.py
+++ b/mobile/hot_path_benchmark.py
@@ -7,10 +7,12 @@ import argparse
 import json
 import logging
 import os
+import re
 import sys
 import time
 from pathlib import Path
 from statistics import mean
+from typing import Optional
 
 try:
     from mobile.config import CONFIG_OVERRIDE_ENV_VAR, Config
@@ -24,12 +26,28 @@ START_STATE = "detail_page"
 
 
 class StepTimelineRecorder(logging.Handler):
-    """Collect run-time step logs and per-step deltas from damai_app logger."""
+    """Collect run-time step logs and per-step deltas from damai_app logger.
+
+    Tracks two additional fields populated when a CTA-match log line is seen
+    (issue #29 — UI 文案变更回归追踪)：
+
+    - ``cta_text_seen``: 命中的 sale-ready 文案（如"立即预订" / "Book Now"），
+      若整轮未命中则为 None。
+    - ``polls_before_match``: ``wait_for_sale_start`` 命中前的轮询次数。
+    """
+
+    # 解析 wait_for_sale_start 的 CTA_MATCH 日志行
+    # 例：CTA_MATCH: text='立即预订' polls=3 (开售已开始)
+    _CTA_MATCH_PATTERN = re.compile(
+        r"CTA_MATCH:\s*text=['\"](?P<text>[^'\"]+)['\"]\s+polls=(?P<polls>\d+)"
+    )
 
     def __init__(self):
         super().__init__(level=logging.INFO)
         self.events = []
         self._last_created = None
+        self.cta_text_seen: Optional[str] = None
+        self.polls_before_match: int = 0
 
     def emit(self, record: logging.LogRecord):
         if record.levelno < logging.INFO:
@@ -38,13 +56,27 @@ class StepTimelineRecorder(logging.Handler):
         if not message:
             return
 
-        delta = 0.0 if self._last_created is None else round(record.created - self._last_created, 2)
+        delta = (
+            0.0
+            if self._last_created is None
+            else round(record.created - self._last_created, 2)
+        )
         self._last_created = record.created
-        self.events.append({
-            "level": record.levelname,
-            "message": message,
-            "delta_seconds": delta,
-        })
+        self.events.append(
+            {
+                "level": record.levelname,
+                "message": message,
+                "delta_seconds": delta,
+            }
+        )
+
+        match = self._CTA_MATCH_PATTERN.search(message)
+        if match:
+            self.cta_text_seen = match.group("text")
+            try:
+                self.polls_before_match = int(match.group("polls"))
+            except (TypeError, ValueError):
+                self.polls_before_match = 0
 
 
 def _attach_timeline_recorder():
@@ -88,10 +120,17 @@ def parse_args(argv=None):
     )
     parser.add_argument("--runs", type=int, default=3, help="压测轮次，默认 3")
     parser.add_argument("--price", help="覆盖当前配置中的票档文本，例如 580元")
-    parser.add_argument("--price-index", type=int, dest="price_index", help="覆盖当前配置中的 price_index")
+    parser.add_argument(
+        "--price-index",
+        type=int,
+        dest="price_index",
+        help="覆盖当前配置中的 price_index",
+    )
     parser.add_argument("--city", help="覆盖当前配置中的城市")
     parser.add_argument("--date", help="覆盖当前配置中的场次日期，例如 04.18")
-    parser.add_argument("--json", action="store_true", dest="json_output", help="输出 JSON 结果")
+    parser.add_argument(
+        "--json", action="store_true", dest="json_output", help="输出 JSON 结果"
+    )
     return parser.parse_args(argv)
 
 
@@ -108,22 +147,28 @@ def build_benchmark_config(base_config: Config, args) -> Config:
     if args.date is not None:
         config_data["date"] = args.date
 
-    config_data.update({
-        "target_title": None,
-        "target_venue": None,
-        "auto_navigate": False,
-        "rush_mode": True,
-        "if_commit_order": False,
-        "probe_only": False,
-        "sell_start_time": None,
-        "wait_cta_ready_timeout_ms": 0,
-    })
+    config_data.update(
+        {
+            "target_title": None,
+            "target_venue": None,
+            "auto_navigate": False,
+            "rush_mode": True,
+            "if_commit_order": False,
+            "probe_only": False,
+            "sell_start_time": None,
+            "wait_cta_ready_timeout_ms": 0,
+        }
+    )
     return Config(**config_data)
 
 
 _DETAIL_PAGE_PROBE = {
-    "state": "detail_page", "purchase_button": True, "price_container": False,
-    "quantity_picker": False, "submit_button": False, "reservation_mode": False,
+    "state": "detail_page",
+    "purchase_button": True,
+    "price_container": False,
+    "quantity_picker": False,
+    "submit_button": False,
+    "reservation_mode": False,
     "pending_order_dialog": False,
 }
 
@@ -135,9 +180,13 @@ def _fast_check_detail_page(bot: DamaiBot) -> dict | None:
     Falls back to the full probe when the fast check is ambiguous.
     """
     from selenium.webdriver.common.by import By
+
     try:
         if hasattr(bot, "_find_all"):
-            els = bot._find_all(By.ID, "cn.damai:id/trade_project_detail_purchase_status_bar_container_fl")
+            els = bot._find_all(
+                By.ID,
+                "cn.damai:id/trade_project_detail_purchase_status_bar_container_fl",
+            )
         else:
             els = bot.driver.find_elements(
                 by=By.ID,
@@ -230,7 +279,11 @@ def _require_detail_start(bot: DamaiBot, run_label: str) -> dict:
 def summarize_results(results: list[dict]) -> dict:
     """Summarise benchmark results across all runs."""
     elapsed_values = [item["elapsed_seconds"] for item in results]
-    recovery_values = [item["recovery_seconds"] for item in results if item["recovery_seconds"] is not None]
+    recovery_values = [
+        item["recovery_seconds"]
+        for item in results
+        if item["recovery_seconds"] is not None
+    ]
 
     return {
         "runs": len(results),
@@ -238,11 +291,15 @@ def summarize_results(results: list[dict]) -> dict:
         "avg_elapsed_seconds": round(mean(elapsed_values), 2),
         "min_elapsed_seconds": round(min(elapsed_values), 2),
         "max_elapsed_seconds": round(max(elapsed_values), 2),
-        "avg_recovery_seconds": round(mean(recovery_values), 2) if recovery_values else None,
+        "avg_recovery_seconds": round(mean(recovery_values), 2)
+        if recovery_values
+        else None,
     }
 
 
-def _run_one(bot: DamaiBot, run_start_probe: dict, run_label: str) -> tuple[bool, float, dict, list]:
+def _run_one(
+    bot: DamaiBot, run_start_probe: dict, run_label: str
+) -> tuple[bool, float, dict, list]:
     """Execute one timed ticket-grabbing attempt and return (success, elapsed, final_probe, timeline)."""
     recorder, attached_loggers = _attach_timeline_recorder()
     try:
@@ -271,7 +328,11 @@ def run_benchmark(bot: DamaiBot, runs: int) -> dict:
 
     results = []
     for index in range(runs):
-        run_start_probe = initial_probe if index == 0 else _require_detail_start(bot, f"第 {index + 1} 轮开始")
+        run_start_probe = (
+            initial_probe
+            if index == 0
+            else _require_detail_start(bot, f"第 {index + 1} 轮开始")
+        )
 
         success, elapsed_seconds, final_probe, timeline = _run_one(
             bot, run_start_probe, f"第 {index + 1} 轮"
@@ -285,16 +346,18 @@ def run_benchmark(bot: DamaiBot, runs: int) -> dict:
             recovery_seconds = round(time.time() - recovery_start, 2)
             recovery_state = recovery_probe["state"]
 
-        results.append({
-            "run": index + 1,
-            "success": success,
-            "elapsed_seconds": elapsed_seconds,
-            "final_state": final_probe["state"],
-            "submit_button_ready": bool(final_probe.get("submit_button")),
-            "recovery_seconds": recovery_seconds,
-            "recovery_state": recovery_state,
-            "step_timeline": timeline,
-        })
+        results.append(
+            {
+                "run": index + 1,
+                "success": success,
+                "elapsed_seconds": elapsed_seconds,
+                "final_state": final_probe["state"],
+                "submit_button_ready": bool(final_probe.get("submit_button")),
+                "recovery_seconds": recovery_seconds,
+                "recovery_state": recovery_state,
+                "step_timeline": timeline,
+            }
+        )
 
     return {
         "title": initial_title,
@@ -335,21 +398,23 @@ def format_report(payload: dict) -> str:
                 )
 
     summary = payload["summary"]
-    lines.extend([
-        "",
-        "汇总:",
-        f"runs={summary['runs']}, success={summary['success_count']}/{summary['runs']}",
-        (
-            f"avg/min/max = {summary['avg_elapsed_seconds']:.2f}s / "
-            f"{summary['min_elapsed_seconds']:.2f}s / {summary['max_elapsed_seconds']:.2f}s"
-            f"  (n={summary['runs']})"
-        ),
-        (
-            "recovery avg = "
-            f"{summary['avg_recovery_seconds']:.2f}s" if summary["avg_recovery_seconds"] is not None else
-            "recovery avg = -"
-        ),
-    ])
+    lines.extend(
+        [
+            "",
+            "汇总:",
+            f"runs={summary['runs']}, success={summary['success_count']}/{summary['runs']}",
+            (
+                f"avg/min/max = {summary['avg_elapsed_seconds']:.2f}s / "
+                f"{summary['min_elapsed_seconds']:.2f}s / {summary['max_elapsed_seconds']:.2f}s"
+                f"  (n={summary['runs']})"
+            ),
+            (
+                f"recovery avg = {summary['avg_recovery_seconds']:.2f}s"
+                if summary["avg_recovery_seconds"] is not None
+                else "recovery avg = -"
+            ),
+        ]
+    )
     return "\n".join(lines)
 
 

--- a/mobile/scripts/start_ticket_grabbing.sh
+++ b/mobile/scripts/start_ticket_grabbing.sh
@@ -4,6 +4,21 @@
 #   正式抢票: ./start_ticket_grabbing.sh [--yes] [--config mobile/config.local.jsonc]
 #   安全探测: ./start_ticket_grabbing.sh --probe [--yes] [--config mobile/config.local.jsonc]
 
+# 依赖预检：Poetry + 关键 Python 包（issue #32）
+if ! command -v poetry >/dev/null 2>&1; then
+    echo "❌ Poetry 未安装。请先安装 Poetry: https://python-poetry.org/docs/#installation"
+    exit 2
+fi
+
+if ! poetry run python -c "import selenium, uiautomator2, adbutils" >/dev/null 2>&1; then
+    echo "⚠ 检测到关键 Python 依赖缺失（selenium / uiautomator2 / adbutils）"
+    echo "→ 自动执行: poetry install"
+    if ! poetry install; then
+        echo "❌ poetry install 失败。请手动检查 pyproject.toml 与网络后重试。"
+        exit 3
+    fi
+fi
+
 ASSUME_YES=false
 CONFIG_OVERRIDE=""
 PROBE_MODE=false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,14 +176,12 @@ def mock_damai_bot(mobile_config, mock_u2_driver):
     mock_u2_driver.find_element = Mock()
     mock_u2_driver.find_elements = Mock(return_value=[])
 
-    with (
-        patch("mobile.damai_app.Config.load_config", return_value=mobile_config),
-        patch("uiautomator2.connect", return_value=mock_u2_driver),
-    ):
-        from mobile.damai_app import DamaiBot
+    with patch("mobile.damai_app.Config.load_config", return_value=mobile_config):
+        with patch("uiautomator2.connect", return_value=mock_u2_driver):
+            from mobile.damai_app import DamaiBot
 
-        bot = DamaiBot()
-        yield bot
+            bot = DamaiBot()
+            yield bot
 
 
 @pytest.fixture

--- a/tests/unit/test_environment_check.py
+++ b/tests/unit/test_environment_check.py
@@ -1,0 +1,72 @@
+# -*- coding: UTF-8 -*-
+"""Environment-check tests for missing-dependency guardrails (issue #32).
+
+These tests assert that running ``mobile/damai_app.py`` in an environment
+without ``selenium`` raises ``SystemExit`` with a hint pointing the user at
+``poetry install`` rather than letting a raw ``ModuleNotFoundError`` bubble up.
+
+The negative case is run in a **subprocess** so that mutating ``sys.modules``
+does not leak into the rest of the test suite (reloading ``mobile.damai_app``
+in-process detaches its ``logger`` reference from the one other tests patch).
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.mark.unit
+def test_damai_app_exits_with_poetry_hint_when_selenium_missing():
+    """Importing mobile.damai_app without selenium raises SystemExit with poetry install hint."""
+    # ``sys.modules['selenium'] = None`` is the documented trick that forces a
+    # ``ModuleNotFoundError`` on subsequent ``import selenium`` (PEP 328 / docs).
+    # We also block the submodule the actual import statement names.
+    snippet = textwrap.dedent(
+        """
+        import sys
+        sys.modules["selenium"] = None
+        sys.modules["selenium.webdriver"] = None
+        sys.modules["selenium.webdriver.common"] = None
+        sys.modules["selenium.webdriver.common.by"] = None
+        try:
+            import mobile.damai_app  # noqa: F401
+        except SystemExit as exc:
+            print("__GUARD_MSG_START__", end="")
+            print(exc, end="")
+            print("__GUARD_MSG_END__")
+            sys.exit(0)
+        # If the import unexpectedly succeeded, exit non-zero so the test fails loudly.
+        sys.exit(99)
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, (
+        "Subprocess should catch SystemExit cleanly. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+    start = result.stdout.find("__GUARD_MSG_START__")
+    end = result.stdout.find("__GUARD_MSG_END__")
+    assert start != -1 and end != -1, (
+        "Subprocess never reached the SystemExit branch — guard missing? "
+        f"stdout={result.stdout!r}"
+    )
+
+    message = result.stdout[start + len("__GUARD_MSG_START__") : end]
+    assert "poetry install" in message, (
+        "SystemExit message must mention 'poetry install' for actionable guidance, "
+        f"got: {message!r}"
+    )
+    assert "selenium" in message, (
+        "SystemExit message should explicitly name the missing dependency, "
+        f"got: {message!r}"
+    )

--- a/tests/unit/test_mobile_damai_app.py
+++ b/tests/unit/test_mobile_damai_app.py
@@ -130,9 +130,10 @@ def bot():
         probe_only=False,
     )
 
-    with \
-        patch("mobile.damai_app.Config.load_config", return_value=mock_config), \
-        patch("uiautomator2.connect", return_value=mock_driver):
+    with (
+        patch("mobile.damai_app.Config.load_config", return_value=mock_config),
+        patch("uiautomator2.connect", return_value=mock_driver),
+    ):
         bot = DamaiBot()
     return bot
 
@@ -161,9 +162,10 @@ class TestInitialization:
             probe_only=True,
         )
 
-        with \
-            patch("uiautomator2.connect", return_value=mock_driver), \
-            patch("mobile.damai_app.Config.load_config") as load_config:
+        with (
+            patch("uiautomator2.connect", return_value=mock_driver),
+            patch("mobile.damai_app.Config.load_config") as load_config,
+        ):
             bot = DamaiBot(config=injected_config)
 
         assert bot.config is injected_config
@@ -294,9 +296,10 @@ class TestCachedTap:
     def test_cache_hit_clicks_coordinates_and_returns_true(self, bot):
         """Warm path: cached (x, y) → single _click_coordinates call, True."""
         bot._cached_hot_path_coords["city"] = (300, 500)
-        with \
-            patch.object(bot, "_click_coordinates") as click_coords, \
-            patch.object(bot, "ultra_fast_click") as ufc:
+        with (
+            patch.object(bot, "_click_coordinates") as click_coords,
+            patch.object(bot, "ultra_fast_click") as ufc,
+        ):
             result = bot._cached_tap("city", By.ID, "some.id", timeout=0.3)
         assert result is True
         click_coords.assert_called_once_with(300, 500)
@@ -309,9 +312,10 @@ class TestCachedTap:
         mock_selector.info = {
             "bounds": {"left": 100, "top": 200, "right": 300, "bottom": 260}
         }
-        with \
-            patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector), \
-            patch.object(bot, "_click_coordinates") as click_coords:
+        with (
+            patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector),
+            patch.object(bot, "_click_coordinates") as click_coords,
+        ):
             result = bot._cached_tap(
                 "city",
                 ANDROID_UIAUTOMATOR,
@@ -342,9 +346,10 @@ class TestCachedTap:
         mock_selector.wait.return_value = True
         mock_selector.info = {"bounds": None}
         mock_selector.get.return_value = mock_el
-        with \
-            patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector), \
-            patch.object(bot, "_click_element_center") as click_center:
+        with (
+            patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector),
+            patch.object(bot, "_click_element_center") as click_center,
+        ):
             result = bot._cached_tap("k", By.ID, "id", timeout=0.1)
         assert result is True
         click_center.assert_called_once_with(mock_el, duration=50)
@@ -367,9 +372,10 @@ class TestCachedTap:
         mock_selector.info = {
             "bounds": {"left": 50, "top": 100, "right": 150, "bottom": 140}
         }
-        with \
-            patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector), \
-            patch.object(bot, "_click_coordinates") as click_coords:
+        with (
+            patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector),
+            patch.object(bot, "_click_coordinates") as click_coords,
+        ):
             bot._cached_tap("btn", By.ID, "id", timeout=0.2)  # cold
             bot._cached_tap("btn", By.ID, "id", timeout=0.2)  # warm
         assert click_coords.call_count == 2
@@ -385,9 +391,10 @@ class TestBatchClick:
     def test_batch_click_all_success(self, bot):
         """ultra_fast_click called for each element pair."""
         elements = [("by1", "v1"), ("by2", "v2"), ("by3", "v3")]
-        with \
-            patch.object(bot, "ultra_fast_click", return_value=True) as ufc, \
-            patch("mobile.damai_app.time") as mock_time:
+        with (
+            patch.object(bot, "ultra_fast_click", return_value=True) as ufc,
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             bot.batch_click(elements, delay=0.1)
 
         assert ufc.call_count == 3
@@ -398,10 +405,11 @@ class TestBatchClick:
     def test_batch_click_some_fail(self, bot, caplog):
         """Failed clicks log a warning but processing continues."""
         elements = [("by1", "v1"), ("by2", "v2")]
-        with \
-            caplog.at_level("WARNING", logger="mobile.ui_primitives"), \
-            patch.object(bot, "ultra_fast_click", side_effect=[False, True]) as ufc, \
-            patch("mobile.ui_primitives.time"):
+        with (
+            caplog.at_level("WARNING", logger="mobile.ui_primitives"),
+            patch.object(bot, "ultra_fast_click", side_effect=[False, True]) as ufc,
+            patch("mobile.ui_primitives.time"),
+        ):
             bot.batch_click(elements, delay=0.1)
 
         assert ufc.call_count == 2
@@ -419,10 +427,11 @@ class TestUltraBatchClick:
         el1 = _make_mock_element(x=10, y=20, width=100, height=50)
         el2 = _make_mock_element(x=200, y=300, width=60, height=30)
 
-        with \
-            caplog.at_level("DEBUG", logger="mobile.ui_primitives"), \
-            patch.object(bot, "_wait_for_element", side_effect=[el1, el2]), \
-            patch("mobile.ui_primitives.time"):
+        with (
+            caplog.at_level("DEBUG", logger="mobile.ui_primitives"),
+            patch.object(bot, "_wait_for_element", side_effect=[el1, el2]),
+            patch("mobile.ui_primitives.time"),
+        ):
             bot.ultra_batch_click([(By.ID, "v1"), (By.ID, "v2")], timeout=2)
 
         assert "成功找到 2 个用户" in caplog.text
@@ -431,12 +440,13 @@ class TestUltraBatchClick:
         """Timed-out elements are skipped; found ones are still clicked."""
         el1 = _make_mock_element(x=10, y=20, width=100, height=50)
 
-        with \
-            caplog.at_level("DEBUG", logger="mobile.ui_primitives"), \
+        with (
+            caplog.at_level("DEBUG", logger="mobile.ui_primitives"),
             patch.object(
                 bot, "_wait_for_element", side_effect=[el1, TimeoutException("timeout")]
-            ), \
-            patch("mobile.ui_primitives.time"):
+            ),
+            patch("mobile.ui_primitives.time"),
+        ):
             bot.ultra_batch_click([(By.ID, "v1"), (By.ID, "v2")], timeout=2)
 
         assert "超时未找到用户: v2" in caplog.text
@@ -529,11 +539,11 @@ class TestAutoNavigation:
             assert bot._current_page_matches_target({"state": "sku_page"}) is False
 
     def test_exit_non_target_event_context_backs_out_until_search_page(self, bot):
-        with \
+        with (
             patch.object(
                 bot, "_current_page_matches_target", side_effect=[False, False]
-            ), \
-            patch.object(bot, "dismiss_startup_popups"), \
+            ),
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -541,7 +551,8 @@ class TestAutoNavigation:
                     {"state": "detail_page"},
                     {"state": "search_page"},
                 ],
-            ):
+            ),
+        ):
             result = bot._exit_non_target_event_context({"state": "sku_page"})
 
         assert result["state"] == "search_page"
@@ -550,21 +561,21 @@ class TestAutoNavigation:
     def test_discover_target_event_exits_wrong_sku_page_before_search(self, bot):
         bot.config.keyword = "余佳运 演唱会"
 
-        with \
+        with (
             patch.object(
                 bot, "_recover_to_navigation_start", return_value={"state": "sku_page"}
-            ), \
+            ),
             patch.object(
                 bot, "_current_page_matches_target", side_effect=[False, False]
-            ), \
+            ),
             patch.object(
                 bot,
                 "_exit_non_target_event_context",
                 return_value={"state": "search_page"},
-            ) as exit_context, \
+            ) as exit_context,
             patch.object(
                 bot, "_submit_search_keyword", return_value=True
-            ) as submit_keyword, \
+            ) as submit_keyword,
             patch.object(
                 bot,
                 "_open_target_from_search_results",
@@ -572,10 +583,11 @@ class TestAutoNavigation:
                     "opened": True,
                     "search_results": [{"score": 80, "title": "余佳运演唱会"}],
                 },
-            ), \
+            ),
             patch.object(
                 bot, "probe_current_page", return_value={"state": "detail_page"}
-            ):
+            ),
+        ):
             result = bot.discover_target_event(
                 ["余佳运 演唱会"], initial_probe={"state": "sku_page"}
             )
@@ -585,18 +597,19 @@ class TestAutoNavigation:
         submit_keyword.assert_called_once()
 
     def test_navigate_to_target_event_from_search_page(self, bot):
-        with \
+        with (
             patch.object(
                 bot,
                 "_recover_to_navigation_start",
                 return_value={"state": "search_page"},
-            ), \
+            ),
             patch.object(
                 bot, "_submit_search_keyword", return_value=True
-            ) as submit_keyword, \
+            ) as submit_keyword,
             patch.object(
                 bot, "_open_target_from_search_results", return_value=True
-            ) as open_target:
+            ) as open_target,
+        ):
             result = bot.navigate_to_target_event({"state": "unknown"})
 
         assert result is True
@@ -604,11 +617,12 @@ class TestAutoNavigation:
         open_target.assert_called_once()
 
     def test_recover_to_navigation_start_handles_back_key_failure(self, bot):
-        with \
-            patch.object(bot, "_press_keycode_safe", return_value=False), \
-            patch.object(bot, "probe_current_page", return_value={"state": "unknown"}), \
-            patch.object(bot.d, "app_start") as app_start, \
-            patch("mobile.damai_app.time.sleep"):
+        with (
+            patch.object(bot, "_press_keycode_safe", return_value=False),
+            patch.object(bot, "probe_current_page", return_value={"state": "unknown"}),
+            patch.object(bot.d, "app_start") as app_start,
+            patch("mobile.damai_app.time.sleep"),
+        ):
             result = bot._recover_to_navigation_start({"state": "unknown"})
 
         app_start.assert_called_once_with(bot.config.app_package, stop=False)
@@ -617,17 +631,18 @@ class TestAutoNavigation:
     def test_fast_retry_does_not_submit_when_commit_disabled(self, bot):
         bot.config.if_commit_order = False
 
-        with \
+        with (
             patch.object(
                 bot, "probe_current_page", return_value={"state": "order_confirm_page"}
-            ), \
+            ),
             patch.object(
                 bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ), \
+            ),
             patch.object(
                 bot, "smart_wait_for_element", return_value=True
-            ) as wait_for_element, \
-            patch.object(bot, "smart_wait_and_click") as smart_click:
+            ) as wait_for_element,
+            patch.object(bot, "smart_wait_and_click") as smart_click,
+        ):
             result = bot._fast_retry_from_current_state()
 
         assert result is True
@@ -635,13 +650,14 @@ class TestAutoNavigation:
         smart_click.assert_not_called()
 
     def test_run_with_retry_stops_on_terminal_failure(self, bot):
-        with \
-            patch("mobile.damai_app.time.sleep"), \
+        with (
+            patch("mobile.damai_app.time.sleep"),
             patch.object(
                 bot, "run_ticket_grabbing", side_effect=self._mark_terminal_failure(bot)
-            ), \
-            patch.object(bot, "_fast_retry_from_current_state") as fast_retry, \
-            patch.object(bot, "_setup_driver") as setup_driver:
+            ),
+            patch.object(bot, "_fast_retry_from_current_state") as fast_retry,
+            patch.object(bot, "_setup_driver") as setup_driver,
+        ):
             result = bot.run_with_retry(max_retries=3)
 
         assert result is False
@@ -666,12 +682,12 @@ class TestRunTicketGrabbing:
     def test_run_ticket_grabbing_auto_navigates_from_homepage(self, bot):
         bot.config.probe_only = True
 
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
-            patch.object(bot, "check_session_valid", return_value=True), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
+            patch.object(bot, "check_session_valid", return_value=True),
             patch.object(
                 bot, "navigate_to_target_event", return_value=True
-            ) as navigate, \
+            ) as navigate,
             patch.object(
                 bot,
                 "probe_current_page",
@@ -693,8 +709,9 @@ class TestRunTicketGrabbing:
                         "reservation_mode": False,
                     },
                 ],
-            ), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.3)
             result = bot.run_ticket_grabbing()
 
@@ -705,8 +722,8 @@ class TestRunTicketGrabbing:
         """Homepage or other non-detail states fail fast with a clear result."""
         bot.config.auto_navigate = False
 
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -717,9 +734,10 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "smart_wait_and_click") as smart_click, \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "smart_wait_and_click") as smart_click,
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.return_value = 0.0
             result = bot.run_ticket_grabbing()
 
@@ -730,8 +748,8 @@ class TestRunTicketGrabbing:
         """probe_only stops before purchase when detail-page essentials are present."""
         bot.config.probe_only = True
 
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -742,9 +760,10 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "smart_wait_and_click") as smart_click, \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "smart_wait_and_click") as smart_click,
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
             result = bot.run_ticket_grabbing()
 
@@ -755,9 +774,9 @@ class TestRunTicketGrabbing:
         """The first runtime log should clearly state this is only a probe."""
         bot.config.probe_only = True
 
-        with \
-            caplog.at_level("INFO", logger="mobile.damai_app"), \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            caplog.at_level("INFO", logger="mobile.damai_app"),
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -768,8 +787,9 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
             result = bot.run_ticket_grabbing()
 
@@ -783,8 +803,8 @@ class TestRunTicketGrabbing:
         """probe_only reports failure when detail-page essentials are missing."""
         bot.config.probe_only = True
 
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -795,8 +815,9 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.return_value = 0.0
             result = bot.run_ticket_grabbing()
 
@@ -806,8 +827,8 @@ class TestRunTicketGrabbing:
         """probe_only succeeds when the ticket sku page is already open."""
         bot.config.probe_only = True
 
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -818,9 +839,10 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "smart_wait_and_click") as smart_click, \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "smart_wait_and_click") as smart_click,
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
             result = bot.run_ticket_grabbing()
 
@@ -829,8 +851,8 @@ class TestRunTicketGrabbing:
 
     def test_run_ticket_grabbing_success(self, bot):
         """All phases succeed, returns True."""
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -841,8 +863,8 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
+            ),
+            patch.object(bot, "wait_for_sale_start"),
             patch.object(
                 bot,
                 "_enter_purchase_flow_from_detail_page",
@@ -851,13 +873,14 @@ class TestRunTicketGrabbing:
                     "price_container": True,
                     "reservation_mode": False,
                 },
-            ), \
-            patch.object(bot, "_wait_for_submit_ready", return_value=True), \
-            patch.object(bot, "smart_wait_and_click", return_value=True), \
-            patch.object(bot, "ultra_fast_click", return_value=True), \
-            patch.object(bot, "ultra_batch_click"), \
-            patch.object(bot, "_submit_order_fast", return_value="success"), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "_wait_for_submit_ready", return_value=True),
+            patch.object(bot, "smart_wait_and_click", return_value=True),
+            patch.object(bot, "ultra_fast_click", return_value=True),
+            patch.object(bot, "ultra_batch_click"),
+            patch.object(bot, "_submit_order_fast", return_value="success"),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             # Provide enough time.time() values for the confirm-retry loop
             mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
             # Mock find_element for price container + target_price
@@ -877,8 +900,8 @@ class TestRunTicketGrabbing:
         bot.config.rush_mode = True
         bot.config.if_commit_order = False
 
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -889,8 +912,8 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
+            ),
+            patch.object(bot, "wait_for_sale_start"),
             patch.object(
                 bot,
                 "_enter_purchase_flow_from_detail_page",
@@ -901,18 +924,19 @@ class TestRunTicketGrabbing:
                     "price_coords": (240, 1560),
                     "buy_button_coords": (320, 1880),
                 },
-            ) as enter_purchase_flow, \
+            ) as enter_purchase_flow,
             patch.object(
                 bot, "_select_price_option", return_value=True
-            ) as select_price, \
-            patch.object(bot, "_wait_for_submit_ready", return_value=True), \
+            ) as select_price,
+            patch.object(bot, "_wait_for_submit_ready", return_value=True),
             patch.object(
                 bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ), \
-            patch.object(bot, "_burst_click_coordinates") as burst_click_coords, \
-            patch.object(bot, "ultra_fast_click", return_value=True), \
-            patch.object(bot, "ultra_batch_click"), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "_burst_click_coordinates") as burst_click_coords,
+            patch.object(bot, "ultra_fast_click", return_value=True),
+            patch.object(bot, "ultra_batch_click"),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.9)
             mock_price_container = Mock()
             mock_target = _make_mock_element()
@@ -933,8 +957,8 @@ class TestRunTicketGrabbing:
         """if_commit_order=False waits for confirm page but never clicks submit."""
         bot.config.if_commit_order = False
 
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -945,8 +969,8 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
+            ),
+            patch.object(bot, "wait_for_sale_start"),
             patch.object(
                 bot,
                 "_enter_purchase_flow_from_detail_page",
@@ -955,17 +979,18 @@ class TestRunTicketGrabbing:
                     "price_container": True,
                     "reservation_mode": False,
                 },
-            ), \
+            ),
             patch.object(
                 bot, "_wait_for_submit_ready", return_value=True
-            ) as wait_submit_ready, \
+            ) as wait_submit_ready,
             patch.object(
                 bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ), \
-            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click, \
-            patch.object(bot, "ultra_fast_click", return_value=True), \
-            patch.object(bot, "ultra_batch_click"), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click,
+            patch.object(bot, "ultra_fast_click", return_value=True),
+            patch.object(bot, "ultra_batch_click"),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 1.2)
             mock_price_container = Mock()
             mock_target = _make_mock_element()
@@ -982,9 +1007,9 @@ class TestRunTicketGrabbing:
         """Commit-disabled runs should be labeled as developer validation in logs."""
         bot.config.if_commit_order = False
 
-        with \
-            caplog.at_level("INFO", logger="mobile.damai_app"), \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            caplog.at_level("INFO", logger="mobile.damai_app"),
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -995,8 +1020,8 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
+            ),
+            patch.object(bot, "wait_for_sale_start"),
             patch.object(
                 bot,
                 "_enter_purchase_flow_from_detail_page",
@@ -1005,14 +1030,15 @@ class TestRunTicketGrabbing:
                     "price_container": True,
                     "reservation_mode": False,
                 },
-            ), \
-            patch.object(bot, "_wait_for_submit_ready", return_value=True), \
+            ),
+            patch.object(bot, "_wait_for_submit_ready", return_value=True),
             patch.object(
                 bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ), \
-            patch.object(bot, "ultra_fast_click", return_value=True), \
-            patch.object(bot, "ultra_batch_click"), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "ultra_fast_click", return_value=True),
+            patch.object(bot, "ultra_batch_click"),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
             mock_price_container = Mock()
             mock_target = _make_mock_element()
@@ -1032,8 +1058,8 @@ class TestRunTicketGrabbing:
         """sku_page can continue directly to confirm page without returning to detail."""
         bot.config.if_commit_order = False
 
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -1044,18 +1070,19 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
+            ),
+            patch.object(bot, "wait_for_sale_start"),
             patch.object(
                 bot, "_wait_for_submit_ready", return_value=True
-            ) as wait_submit_ready, \
+            ) as wait_submit_ready,
             patch.object(
                 bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ), \
-            patch.object(bot, "smart_wait_and_click") as smart_click, \
-            patch.object(bot, "ultra_fast_click", return_value=True), \
-            patch.object(bot, "ultra_batch_click"), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "smart_wait_and_click") as smart_click,
+            patch.object(bot, "ultra_fast_click", return_value=True),
+            patch.object(bot, "ultra_batch_click"),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
             mock_price_container = Mock()
             mock_target = _make_mock_element()
@@ -1075,9 +1102,9 @@ class TestRunTicketGrabbing:
         """Reservation-only sku pages stop safely before tapping the bottom action."""
         bot.config.if_commit_order = False
 
-        with \
-            caplog.at_level("WARNING", logger="mobile.damai_app"), \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            caplog.at_level("WARNING", logger="mobile.damai_app"),
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -1107,10 +1134,11 @@ class TestRunTicketGrabbing:
                         "reservation_mode": True,
                     },
                 ],
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
-            patch.object(bot, "ultra_fast_click") as fast_click, \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "wait_for_sale_start"),
+            patch.object(bot, "ultra_fast_click") as fast_click,
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.return_value = 0.0
 
             result = bot.run_ticket_grabbing()
@@ -1130,9 +1158,9 @@ class TestRunTicketGrabbing:
         """Commit-disabled mode fails safely if the confirm page never becomes ready."""
         bot.config.if_commit_order = False
 
-        with \
-            caplog.at_level("WARNING", logger="mobile.damai_app"), \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            caplog.at_level("WARNING", logger="mobile.damai_app"),
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -1143,8 +1171,8 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
+            ),
+            patch.object(bot, "wait_for_sale_start"),
             patch.object(
                 bot,
                 "_enter_purchase_flow_from_detail_page",
@@ -1153,12 +1181,13 @@ class TestRunTicketGrabbing:
                     "price_container": True,
                     "reservation_mode": False,
                 },
-            ), \
-            patch.object(bot, "_wait_for_submit_ready", return_value=False), \
-            patch.object(bot, "smart_wait_and_click", return_value=True), \
-            patch.object(bot, "ultra_fast_click", return_value=True), \
-            patch.object(bot, "ultra_batch_click", return_value=0), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "_wait_for_submit_ready", return_value=False),
+            patch.object(bot, "smart_wait_and_click", return_value=True),
+            patch.object(bot, "ultra_fast_click", return_value=True),
+            patch.object(bot, "ultra_batch_click", return_value=0),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_monotonic(0.0, 2.0)
             mock_price_container = Mock()
             mock_target = _make_mock_element()
@@ -1173,8 +1202,8 @@ class TestRunTicketGrabbing:
 
     def test_run_ticket_grabbing_city_fail(self, bot):
         """City selection fails, returns False immediately."""
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -1185,10 +1214,11 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
-            patch.object(bot, "_select_city_from_detail_page", return_value=False), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "wait_for_sale_start"),
+            patch.object(bot, "_select_city_from_detail_page", return_value=False),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.return_value = 0.0
             result = bot.run_ticket_grabbing()
 
@@ -1196,8 +1226,8 @@ class TestRunTicketGrabbing:
 
     def test_run_ticket_grabbing_book_fail(self, bot):
         """Booking button fails, returns False."""
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -1208,13 +1238,14 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
+            ),
+            patch.object(bot, "wait_for_sale_start"),
             patch.object(
                 bot, "_enter_purchase_flow_from_detail_page", return_value=None
-            ), \
-            patch.object(bot, "ultra_batch_click"), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "ultra_batch_click"),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.return_value = 0.0
             result = bot.run_ticket_grabbing()
 
@@ -1222,8 +1253,8 @@ class TestRunTicketGrabbing:
 
     def test_run_ticket_grabbing_exception_returns_false(self, bot):
         """Unexpected exception in flow returns False."""
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -1234,10 +1265,11 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
-            patch.object(bot, "smart_wait_and_click", side_effect=RuntimeError("boom")), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "wait_for_sale_start"),
+            patch.object(bot, "smart_wait_and_click", side_effect=RuntimeError("boom")),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.return_value = 0.0
             result = bot.run_ticket_grabbing()
 
@@ -1247,8 +1279,8 @@ class TestRunTicketGrabbing:
         self, bot
     ):
         """Submit timeout should fail closed to avoid false success and duplicate submit."""
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -1259,8 +1291,8 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
+            ),
+            patch.object(bot, "wait_for_sale_start"),
             patch.object(
                 bot,
                 "_enter_purchase_flow_from_detail_page",
@@ -1269,15 +1301,16 @@ class TestRunTicketGrabbing:
                     "price_container": True,
                     "reservation_mode": False,
                 },
-            ), \
-            patch.object(bot, "_wait_for_submit_ready", return_value=True), \
-            patch.object(bot, "smart_wait_and_click", return_value=True), \
-            patch.object(bot, "ultra_fast_click", return_value=True), \
-            patch.object(bot, "ultra_batch_click"), \
+            ),
+            patch.object(bot, "_wait_for_submit_ready", return_value=True),
+            patch.object(bot, "smart_wait_and_click", return_value=True),
+            patch.object(bot, "ultra_fast_click", return_value=True),
+            patch.object(bot, "ultra_batch_click"),
             patch.object(
                 bot, "_submit_order_fast", return_value="timeout"
-            ) as submit_fast, \
-            patch("mobile.damai_app.time") as mock_time:
+            ) as submit_fast,
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
             mock_price_container = Mock()
             mock_target = _make_mock_element()
@@ -1295,8 +1328,8 @@ class TestRunTicketGrabbing:
         self, bot
     ):
         """Existing unpaid order means submit flow already succeeded and only payment is pending."""
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -1307,8 +1340,8 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
+            ),
+            patch.object(bot, "wait_for_sale_start"),
             patch.object(
                 bot,
                 "_enter_purchase_flow_from_detail_page",
@@ -1317,16 +1350,17 @@ class TestRunTicketGrabbing:
                     "price_container": True,
                     "reservation_mode": False,
                 },
-            ), \
-            patch.object(bot, "_wait_for_submit_ready", return_value=True), \
+            ),
+            patch.object(bot, "_wait_for_submit_ready", return_value=True),
             patch.object(
                 bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ), \
-            patch.object(bot, "smart_wait_and_click", return_value=True), \
-            patch.object(bot, "ultra_fast_click", return_value=True), \
-            patch.object(bot, "ultra_batch_click"), \
-            patch.object(bot, "_submit_order_fast", return_value="existing_order"), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "smart_wait_and_click", return_value=True),
+            patch.object(bot, "ultra_fast_click", return_value=True),
+            patch.object(bot, "ultra_batch_click"),
+            patch.object(bot, "_submit_order_fast", return_value="existing_order"),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
             mock_price_container = Mock()
             mock_target = _make_mock_element()
@@ -1343,9 +1377,9 @@ class TestRunTicketGrabbing:
     def test_run_ticket_grabbing_returns_success_when_pending_order_dialog_detected_early(
         self, bot
     ):
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
-            patch.object(bot, "check_session_valid", return_value=True), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
+            patch.object(bot, "check_session_valid", return_value=True),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -1358,7 +1392,8 @@ class TestRunTicketGrabbing:
                     "reservation_mode": False,
                     "pending_order_dialog": True,
                 },
-            ):
+            ),
+        ):
             result = bot.run_ticket_grabbing()
 
         assert result is True
@@ -1380,14 +1415,14 @@ class TestRunTicketGrabbing:
             "reservation_mode": False,
         }
 
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
-            patch.object(bot, "check_session_valid", return_value=True), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
+            patch.object(bot, "check_session_valid", return_value=True),
             patch.object(
                 bot, "probe_current_page", return_value=detail_probe
-            ) as probe_page, \
-            patch.object(bot, "_prepare_detail_page_hot_path") as prepare_detail, \
-            patch.object(bot, "wait_for_sale_start"), \
+            ) as probe_page,
+            patch.object(bot, "_prepare_detail_page_hot_path") as prepare_detail,
+            patch.object(bot, "wait_for_sale_start"),
             patch.object(
                 bot,
                 "_enter_purchase_flow_from_detail_page",
@@ -1396,16 +1431,17 @@ class TestRunTicketGrabbing:
                     "price_container": True,
                     "reservation_mode": False,
                 },
-            ), \
-            patch.object(bot, "_select_price_option", return_value=True), \
-            patch.object(bot, "_wait_for_submit_ready", return_value=True), \
+            ),
+            patch.object(bot, "_select_price_option", return_value=True),
+            patch.object(bot, "_wait_for_submit_ready", return_value=True),
             patch.object(
                 bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ), \
-            patch.object(bot, "_submit_order_fast", return_value="success"), \
-            patch.object(bot, "ultra_fast_click", return_value=True), \
-            patch.object(bot, "ultra_batch_click"), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "_submit_order_fast", return_value="success"),
+            patch.object(bot, "ultra_fast_click", return_value=True),
+            patch.object(bot, "ultra_batch_click"),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
             bot.driver.find_elements.return_value = []
 
@@ -1418,8 +1454,8 @@ class TestRunTicketGrabbing:
 
     def test_run_ticket_grabbing_no_driver_quit_in_finally(self, bot):
         """Verify driver.quit is NOT called inside run_ticket_grabbing's finally block."""
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -1430,10 +1466,11 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
-            patch.object(bot, "smart_wait_and_click", return_value=False), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "wait_for_sale_start"),
+            patch.object(bot, "smart_wait_and_click", return_value=False),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.return_value = 0.0
             bot.run_ticket_grabbing()
 
@@ -1445,8 +1482,8 @@ class TestRunTicketGrabbing:
         """Direct jump to order confirm page should skip manual user selection."""
         bot.config.if_commit_order = False
 
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -1457,15 +1494,16 @@ class TestRunTicketGrabbing:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
-            patch.object(bot, "_wait_for_submit_ready", return_value=True), \
+            ),
+            patch.object(bot, "wait_for_sale_start"),
+            patch.object(bot, "_wait_for_submit_ready", return_value=True),
             patch.object(
                 bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ), \
-            patch.object(bot, "ultra_fast_click", return_value=True), \
-            patch.object(bot, "ultra_batch_click") as batch_click, \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "ultra_fast_click", return_value=True),
+            patch.object(bot, "ultra_batch_click") as batch_click,
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
             mock_price_container = Mock()
             mock_target = _make_mock_element()
@@ -1499,11 +1537,12 @@ class TestPageStateHelpers:
 
         bot.config.keyword = "张杰 演唱会"
 
-        with \
-            patch.object(bot, "_find_all", return_value=[card]), \
+        with (
+            patch.object(bot, "_find_all", return_value=[card]),
             patch.object(
                 bot, "_container_find_elements", side_effect=fake_container_find
-            ):
+            ),
+        ):
             results = bot.collect_search_results()
 
         assert results == [
@@ -1519,18 +1558,22 @@ class TestPageStateHelpers:
         assert results[0]["score"] >= 60
 
     def test_wait_for_purchase_entry_result_detects_sku_without_full_probe(self, bot):
-        with \
-            patch.object(bot, "_has_any_element", side_effect=[False, True]), \
-            patch.object(bot, "is_reservation_sku_mode", return_value=False):
+        with (
+            patch.object(bot, "_has_any_element", side_effect=[False, True]),
+            patch.object(bot, "is_reservation_sku_mode", return_value=False),
+        ):
             result = bot._wait_for_purchase_entry_result(timeout=0.2, poll_interval=0)
 
         assert result["state"] == "sku_page"
         assert result["reservation_mode"] is False
 
-    def test_wait_for_purchase_entry_result_returns_none_without_fallback_probe(self, bot):
-        with patch.object(bot, "_has_any_element", return_value=False), patch.object(
-            bot, "probe_current_page"
-        ) as probe:
+    def test_wait_for_purchase_entry_result_returns_none_without_fallback_probe(
+        self, bot
+    ):
+        with (
+            patch.object(bot, "_has_any_element", return_value=False),
+            patch.object(bot, "probe_current_page") as probe,
+        ):
             result = bot._wait_for_purchase_entry_result(
                 timeout=0.01,
                 poll_interval=0,
@@ -1574,21 +1617,22 @@ class TestPageStateHelpers:
             "buy_button_coords": (540, 2100),
         }
 
-        with \
-            patch.object(bot, "_select_price_option", return_value=True), \
-            patch.object(bot, "_has_element", return_value=False), \
+        with (
+            patch.object(bot, "_select_price_option", return_value=True),
+            patch.object(bot, "_has_element", return_value=False),
             patch.object(
                 bot, "_wait_for_submit_ready", side_effect=[False, True]
-            ) as wait_ready, \
+            ) as wait_ready,
             patch.object(
                 bot, "_click_sku_buy_button_element", return_value=True
-            ) as element_click, \
-            patch.object(bot, "_burst_click_coordinates") as burst_click, \
+            ) as element_click,
+            patch.object(bot, "_burst_click_coordinates") as burst_click,
             patch.object(
                 bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ), \
-            patch("mobile.damai_app.time.sleep"), \
-            patch("mobile.damai_app.time.time", side_effect=_make_time_monotonic()):
+            ),
+            patch("mobile.damai_app.time.sleep"),
+            patch("mobile.damai_app.time.time", side_effect=_make_time_monotonic()),
+        ):
             assert bot.run_ticket_grabbing(initial_page_probe=initial_probe) is True
 
         assert wait_ready.call_count == 2
@@ -1608,21 +1652,22 @@ class TestPageStateHelpers:
             checked_state["value"] = "true"
             return True
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: 'textContains("实名观演人")' in value,
-            ), \
-            patch.object(bot, "_attendee_checkbox_elements", return_value=[checkbox]), \
+            ),
+            patch.object(bot, "_attendee_checkbox_elements", return_value=[checkbox]),
             patch.object(
                 bot, "_attendee_required_count_on_confirm_page", return_value=1
-            ), \
+            ),
             patch.object(
                 bot,
                 "_select_attendee_checkbox_by_name",
                 side_effect=_select_side_effect,
-            ):
+            ),
+        ):
             assert bot._ensure_attendees_selected_on_confirm_page() is True
 
     def test_attendee_selected_count_falls_back_to_page_source(self, bot):
@@ -1643,13 +1688,14 @@ class TestPageStateHelpers:
         checkbox = Mock()
         checkbox.click = Mock()
 
-        with \
+        with (
             patch.object(
                 bot, "_click_element_center", side_effect=Exception("center failed")
-            ), \
-            patch.object(bot, "_burst_click_element_center", return_value=None), \
-            patch.object(bot, "_is_checkbox_selected", return_value=False), \
-            patch.object(bot, "_attendee_selected_count", side_effect=[0, 1]):
+            ),
+            patch.object(bot, "_burst_click_element_center", return_value=None),
+            patch.object(bot, "_is_checkbox_selected", return_value=False),
+            patch.object(bot, "_attendee_selected_count", side_effect=[0, 1]),
+        ):
             assert bot._click_attendee_checkbox(checkbox) is True
 
         checkbox.click.assert_called_once()
@@ -1666,12 +1712,13 @@ class TestPageStateHelpers:
                 return [checkbox]
             return []
 
-        with \
-            patch.object(bot, "_find_all", side_effect=_find_all_side_effect), \
-            patch.object(bot, "_is_checkbox_selected", return_value=False), \
+        with (
+            patch.object(bot, "_find_all", side_effect=_find_all_side_effect),
+            patch.object(bot, "_is_checkbox_selected", return_value=False),
             patch.object(
                 bot, "_click_attendee_checkbox", return_value=True
-            ) as click_checkbox:
+            ) as click_checkbox,
+        ):
             assert bot._select_attendee_checkbox_by_name("张志涛") is True
 
         assert any("contains(normalize-space(@text)" in xpath for xpath in seen_xpaths)
@@ -1680,13 +1727,14 @@ class TestPageStateHelpers:
     def test_ensure_attendees_selected_fails_when_section_visible_but_no_checkbox(
         self, bot
     ):
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: 'textContains("实名观演人")' in value,
-            ), \
-            patch.object(bot, "_attendee_checkbox_elements", return_value=[]):
+            ),
+            patch.object(bot, "_attendee_checkbox_elements", return_value=[]),
+        ):
             assert bot._ensure_attendees_selected_on_confirm_page() is False
 
     def test_ensure_attendees_polls_for_checkbox_in_rush_dev_mode(self, bot):
@@ -1709,12 +1757,13 @@ class TestPageStateHelpers:
                 return []
             return [checkbox1, checkbox2]
 
-        with \
+        with (
             patch.object(
                 bot, "_attendee_checkbox_elements", side_effect=_delayed_checkbox
-            ), \
-            patch.object(bot, "_attendee_selected_count", return_value=0), \
-            patch.object(bot, "_click_attendee_checkbox_fast", return_value=True):
+            ),
+            patch.object(bot, "_attendee_selected_count", return_value=0),
+            patch.object(bot, "_click_attendee_checkbox_fast", return_value=True),
+        ):
             assert (
                 bot._ensure_attendees_selected_on_confirm_page(
                     require_attendee_section=True
@@ -1758,12 +1807,12 @@ class TestPageStateHelpers:
                 return [card_a, card_b]
             return []
 
-        with \
-            patch.object(bot, "_find", return_value=price_container), \
+        with (
+            patch.object(bot, "_find", return_value=price_container),
             patch.object(
                 bot, "_container_find_elements", side_effect=fake_container_find
-            ), \
-            patch.object(bot, "_is_clickable", return_value=True), \
+            ),
+            patch.object(bot, "_is_clickable", return_value=True),
             patch.object(
                 bot,
                 "_collect_descendant_texts",
@@ -1772,7 +1821,8 @@ class TestPageStateHelpers:
                     if c is card_a
                     else ["看台", "380", "无票"]
                 ),
-            ):
+            ),
+        ):
             options = bot.get_visible_price_options()
 
         assert options == [
@@ -1794,14 +1844,16 @@ class TestPageStateHelpers:
 
     def test_purchase_bar_text_ready_distinguishes_reservation_from_purchase(self, bot):
         purchase_bar = Mock()
-        with \
-            patch.object(bot.driver, "find_element", return_value=purchase_bar), \
-            patch.object(bot, "_collect_descendant_texts", return_value=["立即购买"]):
+        with (
+            patch.object(bot.driver, "find_element", return_value=purchase_bar),
+            patch.object(bot, "_collect_descendant_texts", return_value=["立即购买"]),
+        ):
             assert bot._purchase_bar_text_ready() is True
 
-        with \
-            patch.object(bot.driver, "find_element", return_value=purchase_bar), \
-            patch.object(bot, "_collect_descendant_texts", return_value=["抢票预约"]):
+        with (
+            patch.object(bot.driver, "find_element", return_value=purchase_bar),
+            patch.object(bot, "_collect_descendant_texts", return_value=["抢票预约"]),
+        ):
             assert bot._purchase_bar_text_ready() is False
 
     def test_normalize_ocr_price_text(self, bot):
@@ -1851,10 +1903,11 @@ class TestPageStateHelpers:
                 return Mock(stdout=b"13803\n", stderr=b"", returncode=0)
             raise AssertionError(cmd)
 
-        with \
-            patch("mobile.price_selector._MAGICK_BIN", "magick"), \
-            patch("mobile.price_selector._TESSERACT_BIN", "tesseract"), \
-            patch("mobile.price_selector.subprocess.run", side_effect=fake_run) as run:
+        with (
+            patch("mobile.price_selector._MAGICK_BIN", "magick"),
+            patch("mobile.price_selector._TESSERACT_BIN", "tesseract"),
+            patch("mobile.price_selector.subprocess.run", side_effect=fake_run) as run,
+        ):
             result = bot._ocr_price_text_from_card("/tmp/sku.png", rect)
 
         assert result == "1380元"
@@ -1865,38 +1918,41 @@ class TestPageStateHelpers:
         assert first_tesseract_cmd[first_tesseract_cmd.index("--psm") + 1] == "13"
 
     def test_probe_current_page_detects_homepage(self, bot):
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: (
                     (by, value) == (By.ID, "cn.damai:id/homepage_header_search")
                 ),
-            ), \
-            patch.object(bot, "_get_current_activity", return_value=""):
+            ),
+            patch.object(bot, "_get_current_activity", return_value=""),
+        ):
             result = bot._probe_current_page_element_based()
 
             assert result["state"] == "homepage"
             assert result["purchase_button"] is False
 
     def test_probe_current_page_detects_homepage_by_activity(self, bot):
-        with \
-            patch.object(bot, "_has_element", return_value=False), \
+        with (
+            patch.object(bot, "_has_element", return_value=False),
             patch.object(
                 bot, "_get_current_activity", return_value=".homepage.MainActivity"
-            ):
+            ),
+        ):
             result = bot._probe_current_page_element_based()
 
             assert result["state"] == "homepage"
 
     def test_probe_current_page_detects_search_activity(self, bot):
-        with \
-            patch.object(bot, "_has_element", return_value=False), \
+        with (
+            patch.object(bot, "_has_element", return_value=False),
             patch.object(
                 bot,
                 "_get_current_activity",
                 return_value="com.alibaba.pictures.bricks.search.v2.SearchActivity",
-            ):
+            ),
+        ):
             result = bot._probe_current_page_element_based()
 
             assert result["state"] == "search_page"
@@ -1909,17 +1965,18 @@ class TestPageStateHelpers:
             (By.ID, "cn.damai:id/project_detail_price_layout"),
         }
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: (by, value) in present,
-            ), \
+            ),
             patch.object(
                 bot,
                 "_get_current_activity",
                 return_value=".trade.newtradeorder.ui.projectdetail.ui.activity.ProjectDetailActivity",
-            ):
+            ),
+        ):
             result = bot._probe_current_page_element_based()
 
             assert result["state"] == "detail_page"
@@ -1932,17 +1989,18 @@ class TestPageStateHelpers:
             (By.ID, "cn.damai:id/layout_sku"),
         }
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: (by, value) in present,
-            ), \
+            ),
             patch.object(
                 bot,
                 "_get_current_activity",
                 return_value=".commonbusiness.seatbiz.sku.qilin.ui.NcovSkuActivity",
-            ):
+            ),
+        ):
             result = bot._probe_current_page_element_based()
 
             assert result["state"] == "sku_page"
@@ -1956,17 +2014,18 @@ class TestPageStateHelpers:
             (ANDROID_UIAUTOMATOR, 'new UiSelector().text("预约想看场次")'),
         }
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: (by, value) in present,
-            ), \
+            ),
             patch.object(
                 bot,
                 "_get_current_activity",
                 return_value=".commonbusiness.seatbiz.sku.qilin.ui.NcovSkuActivity",
-            ):
+            ),
+        ):
             result = bot._probe_current_page_element_based()
 
             assert result["state"] == "sku_page"
@@ -1977,13 +2036,14 @@ class TestPageStateHelpers:
             (By.ID, "cn.damai:id/damai_theme_dialog_confirm_btn"),
         }
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: (by, value) in present,
-            ), \
-            patch.object(bot, "_get_current_activity", return_value=""):
+            ),
+            patch.object(bot, "_get_current_activity", return_value=""),
+        ):
             result = bot._probe_current_page_element_based()
 
         assert result["state"] == "pending_order_dialog"
@@ -2000,13 +2060,14 @@ class TestPageStateHelpers:
             (By.ID, "cn.damai:id/checkbox"),
         }
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: (by, value) in present,
-            ), \
-            patch.object(bot, "_get_current_activity", return_value=""):
+            ),
+            patch.object(bot, "_get_current_activity", return_value=""),
+        ):
             result = bot._probe_current_page_element_based()
 
             assert result["state"] == "order_confirm_page"
@@ -2025,14 +2086,15 @@ class TestPageStateHelpers:
             (ANDROID_UIAUTOMATOR, 'new UiSelector().text("下次再说")'),
         }
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: (by, value) in present,
-            ), \
-            patch.object(bot, "ultra_fast_click", return_value=True) as fast_click, \
-            patch("mobile.damai_app.time.sleep"):
+            ),
+            patch.object(bot, "ultra_fast_click", return_value=True) as fast_click,
+            patch("mobile.damai_app.time.sleep"),
+        ):
             result = bot.dismiss_startup_popups()
 
             assert result is True
@@ -2057,14 +2119,15 @@ class TestPageStateHelpers:
             (ANDROID_UIAUTOMATOR, 'new UiSelector().text("知道了")'),
         }
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: (by, value) in present,
-            ), \
-            patch.object(bot, "ultra_fast_click", return_value=True) as fast_click, \
-            patch("mobile.damai_app.time.sleep"):
+            ),
+            patch.object(bot, "ultra_fast_click", return_value=True) as fast_click,
+            patch("mobile.damai_app.time.sleep"),
+        ):
             assert bot._dismiss_fast_blocking_dialogs() is True
 
         fast_click.assert_any_call(
@@ -2085,20 +2148,22 @@ class TestPageStateHelpers:
 class TestRunWithRetry:
     def test_run_with_retry_success_first_attempt(self, bot):
         """Succeeds on first attempt, returns True immediately."""
-        with \
-            patch.object(bot, "run_ticket_grabbing", return_value=True), \
-            patch("mobile.damai_app.time"):
+        with (
+            patch.object(bot, "run_ticket_grabbing", return_value=True),
+            patch("mobile.damai_app.time"),
+        ):
             result = bot.run_with_retry(max_retries=3)
 
         assert result is True
 
     def test_run_with_retry_success_second_attempt(self, bot):
         """Fails once, sets up driver again, succeeds second time."""
-        with \
-            patch.object(bot, "run_ticket_grabbing", side_effect=[False, True]), \
-            patch.object(bot, "_fast_retry_from_current_state", return_value=False), \
-            patch.object(bot, "_setup_driver") as mock_setup, \
-            patch("mobile.damai_app.time"):
+        with (
+            patch.object(bot, "run_ticket_grabbing", side_effect=[False, True]),
+            patch.object(bot, "_fast_retry_from_current_state", return_value=False),
+            patch.object(bot, "_setup_driver") as mock_setup,
+            patch("mobile.damai_app.time"),
+        ):
             result = bot.run_with_retry(max_retries=3)
 
         assert result is True
@@ -2106,22 +2171,24 @@ class TestRunWithRetry:
 
     def test_run_with_retry_all_fail(self, bot):
         """All retries fail, returns False."""
-        with \
-            patch.object(bot, "run_ticket_grabbing", return_value=False), \
-            patch.object(bot, "_fast_retry_from_current_state", return_value=False), \
-            patch.object(bot, "_setup_driver"), \
-            patch("mobile.damai_app.time"):
+        with (
+            patch.object(bot, "run_ticket_grabbing", return_value=False),
+            patch.object(bot, "_fast_retry_from_current_state", return_value=False),
+            patch.object(bot, "_setup_driver"),
+            patch("mobile.damai_app.time"),
+        ):
             result = bot.run_with_retry(max_retries=3)
 
         assert result is False
 
     def test_run_with_retry_driver_quit_between_retries(self, bot):
         """Between retries, driver.quit and _setup_driver are called."""
-        with \
-            patch.object(bot, "run_ticket_grabbing", side_effect=[False, False, True]), \
-            patch.object(bot, "_fast_retry_from_current_state", return_value=False), \
-            patch.object(bot, "_setup_driver") as mock_setup, \
-            patch("mobile.damai_app.time"):
+        with (
+            patch.object(bot, "run_ticket_grabbing", side_effect=[False, False, True]),
+            patch.object(bot, "_fast_retry_from_current_state", return_value=False),
+            patch.object(bot, "_setup_driver") as mock_setup,
+            patch("mobile.damai_app.time"),
+        ):
             bot.run_with_retry(max_retries=3)
 
         # quit called before each retry (2 failures, but last one succeeds so only 2 quit calls)
@@ -2132,11 +2199,12 @@ class TestRunWithRetry:
         """driver.quit raises an exception, handled by except block."""
         bot.driver.quit.side_effect = Exception("quit failed")
 
-        with \
-            patch.object(bot, "run_ticket_grabbing", side_effect=[False, True]), \
-            patch.object(bot, "_setup_driver") as mock_setup, \
-            patch.object(bot, "_fast_retry_from_current_state", return_value=False), \
-            patch("mobile.damai_app.time"):
+        with (
+            patch.object(bot, "run_ticket_grabbing", side_effect=[False, True]),
+            patch.object(bot, "_setup_driver") as mock_setup,
+            patch.object(bot, "_fast_retry_from_current_state", return_value=False),
+            patch("mobile.damai_app.time"),
+        ):
             result = bot.run_with_retry(max_retries=3)
 
         # Despite quit failure, retry continued and succeeded
@@ -2144,13 +2212,14 @@ class TestRunWithRetry:
 
     def test_run_with_retry_uses_fast_retry(self, bot):
         """Verify fast retry is attempted before driver recreation."""
-        with \
-            patch.object(bot, "run_ticket_grabbing", side_effect=[False, False]), \
+        with (
+            patch.object(bot, "run_ticket_grabbing", side_effect=[False, False]),
             patch.object(
                 bot, "_fast_retry_from_current_state", return_value=False
-            ) as fast_retry, \
-            patch.object(bot, "_setup_driver"), \
-            patch("mobile.damai_app.time"):
+            ) as fast_retry,
+            patch.object(bot, "_setup_driver"),
+            patch("mobile.damai_app.time"),
+        ):
             bot.run_with_retry(max_retries=2)
 
         # fast_retry called fast_retry_count times per failed attempt
@@ -2158,13 +2227,14 @@ class TestRunWithRetry:
 
     def test_run_with_retry_first_fast_retry_has_no_extra_sleep(self, bot):
         """The first fast retry should execute immediately after a failed attempt."""
-        with \
-            patch.object(bot, "run_ticket_grabbing", return_value=False), \
+        with (
+            patch.object(bot, "run_ticket_grabbing", return_value=False),
             patch.object(
                 bot, "_fast_retry_from_current_state", side_effect=[False, True]
-            ), \
-            patch.object(bot, "_setup_driver"), \
-            patch("mobile.damai_app.time.sleep") as mock_sleep:
+            ),
+            patch.object(bot, "_setup_driver"),
+            patch("mobile.damai_app.time.sleep") as mock_sleep,
+        ):
             result = bot.run_with_retry(max_retries=1)
 
         assert result is True
@@ -2174,11 +2244,12 @@ class TestRunWithRetry:
         """Manual-start mode keeps the driver session instead of rebuilding it."""
         bot.config.auto_navigate = False
 
-        with \
-            patch.object(bot, "run_ticket_grabbing", side_effect=[False, False]), \
-            patch.object(bot, "_fast_retry_from_current_state", return_value=False), \
-            patch.object(bot, "_setup_driver") as mock_setup, \
-            patch("mobile.damai_app.time"):
+        with (
+            patch.object(bot, "run_ticket_grabbing", side_effect=[False, False]),
+            patch.object(bot, "_fast_retry_from_current_state", return_value=False),
+            patch.object(bot, "_setup_driver") as mock_setup,
+            patch("mobile.damai_app.time"),
+        ):
             result = bot.run_with_retry(max_retries=2)
 
         assert result is False
@@ -2190,10 +2261,11 @@ class TestRunWithRetry:
         bot.config.probe_only = True
         bot._last_run_outcome = "probe_ready"
 
-        with \
-            caplog.at_level("INFO", logger="mobile.damai_app"), \
-            patch.object(bot, "run_ticket_grabbing", return_value=True), \
-            patch("mobile.damai_app.time"):
+        with (
+            caplog.at_level("INFO", logger="mobile.damai_app"),
+            patch.object(bot, "run_ticket_grabbing", return_value=True),
+            patch("mobile.damai_app.time"),
+        ):
             result = bot.run_with_retry(max_retries=1)
 
         assert result is True
@@ -2205,10 +2277,11 @@ class TestRunWithRetry:
         bot.config.if_commit_order = False
         bot._last_run_outcome = "validation_ready"
 
-        with \
-            caplog.at_level("INFO", logger="mobile.damai_app"), \
-            patch.object(bot, "run_ticket_grabbing", return_value=True), \
-            patch("mobile.damai_app.time"):
+        with (
+            caplog.at_level("INFO", logger="mobile.damai_app"),
+            patch.object(bot, "run_ticket_grabbing", return_value=True),
+            patch("mobile.damai_app.time"),
+        ):
             result = bot.run_with_retry(max_retries=1)
 
         assert result is True
@@ -2218,10 +2291,11 @@ class TestRunWithRetry:
         """Actual order submission keeps the purchase-success wording."""
         bot._last_run_outcome = "order_submitted"
 
-        with \
-            caplog.at_level("INFO", logger="mobile.damai_app"), \
-            patch.object(bot, "run_ticket_grabbing", return_value=True), \
-            patch("mobile.damai_app.time"):
+        with (
+            caplog.at_level("INFO", logger="mobile.damai_app"),
+            patch.object(bot, "run_ticket_grabbing", return_value=True),
+            patch("mobile.damai_app.time"),
+        ):
             result = bot.run_with_retry(max_retries=1)
 
         assert result is True
@@ -2270,10 +2344,11 @@ class TestWaitForSaleStart:
             # During polling, return past the sale time
             return future_time + timedelta(seconds=1)
 
-        with \
-            patch("mobile.damai_app.datetime") as mock_dt, \
-            patch("mobile.damai_app.time.sleep") as mock_sleep, \
-            patch.object(bot, "_has_element", return_value=True):
+        with (
+            patch("mobile.damai_app.datetime") as mock_dt,
+            patch("mobile.damai_app.time.sleep") as mock_sleep,
+            patch.object(bot, "_has_element", return_value=True),
+        ):
             mock_dt.fromisoformat = datetime.fromisoformat
             mock_dt.now = mock_now
             bot.wait_for_sale_start()
@@ -2288,10 +2363,11 @@ class TestWaitForSaleStart:
         bot.config.sell_start_time = None
         bot.config.wait_cta_ready_timeout_ms = 5000
 
-        with \
-            patch("mobile.damai_app.logger") as mock_logger, \
-            patch("mobile.damai_app.time.sleep") as mock_sleep, \
-            patch.object(bot, "_is_sale_ready") as is_ready:
+        with (
+            patch("mobile.damai_app.logger") as mock_logger,
+            patch("mobile.damai_app.time.sleep") as mock_sleep,
+            patch.object(bot, "_is_sale_ready") as is_ready,
+        ):
             bot.wait_for_sale_start()
 
         is_ready.assert_not_called()
@@ -2306,17 +2382,18 @@ class TestWaitForSaleStart:
         bot.config.sell_start_time = None
         bot.config.wait_cta_ready_timeout_ms = 100
 
-        with \
-            patch("mobile.damai_app.logger"), \
-            patch("mobile.damai_app.time.sleep") as mock_sleep, \
-            patch.object(bot, "_is_sale_ready") as is_ready:
+        with (
+            patch("mobile.damai_app.logger"),
+            patch("mobile.damai_app.time.sleep") as mock_sleep,
+            patch.object(bot, "_is_sale_ready") as is_ready,
+        ):
             bot.wait_for_sale_start()
 
         is_ready.assert_not_called()
         mock_sleep.assert_not_called()
 
     def test_prepare_detail_page_hot_path_preselects_date_and_city(self, bot):
-        with \
+        with (
             patch.object(
                 bot,
                 "probe_current_page",
@@ -2327,11 +2404,12 @@ class TestWaitForSaleStart:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "select_performance_date") as select_date, \
+            ),
+            patch.object(bot, "select_performance_date") as select_date,
             patch.object(
                 bot, "_select_city_from_detail_page", return_value=True
-            ) as select_city:
+            ) as select_city,
+        ):
             result = bot._prepare_detail_page_hot_path()
 
         assert result is True
@@ -2339,10 +2417,11 @@ class TestWaitForSaleStart:
         select_city.assert_called_once_with(timeout=0.6)
 
     def test_prepare_detail_page_hot_path_returns_false_outside_detail_page(self, bot):
-        with \
-            patch.object(bot, "probe_current_page", return_value={"state": "homepage"}), \
-            patch.object(bot, "select_performance_date") as select_date, \
-            patch.object(bot, "_select_city_from_detail_page") as select_city:
+        with (
+            patch.object(bot, "probe_current_page", return_value={"state": "homepage"}),
+            patch.object(bot, "select_performance_date") as select_date,
+            patch.object(bot, "_select_city_from_detail_page") as select_city,
+        ):
             result = bot._prepare_detail_page_hot_path()
 
         assert result is False
@@ -2369,11 +2448,12 @@ class TestDetailPagePurchaseEntry:
         )
 
     def test_enter_purchase_flow_returns_none_when_city_selection_fails(self, bot):
-        with \
-            patch.object(bot, "select_performance_date") as select_date, \
+        with (
+            patch.object(bot, "select_performance_date") as select_date,
             patch.object(
                 bot, "_select_city_from_detail_page", return_value=False
-            ) as select_city:
+            ) as select_city,
+        ):
             result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         assert result is None
@@ -2386,12 +2466,13 @@ class TestDetailPagePurchaseEntry:
         bot.config.rush_mode = True
         next_probe = {"state": "sku_page", "reservation_mode": False}
 
-        with \
-            patch.object(bot, "_cached_tap", return_value=False), \
-            patch.object(bot, "smart_wait_and_click", return_value=True), \
+        with (
+            patch.object(bot, "_cached_tap", return_value=False),
+            patch.object(bot, "smart_wait_and_click", return_value=True),
             patch.object(
                 bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ):
+            ),
+        ):
             result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         assert result == next_probe
@@ -2400,11 +2481,12 @@ class TestDetailPagePurchaseEntry:
         bot.config.rush_mode = True
         next_probe = {"state": "sku_page", "reservation_mode": False}
 
-        with \
-            patch.object(bot, "_cached_tap", return_value=True) as cached_tap, \
+        with (
+            patch.object(bot, "_cached_tap", return_value=True) as cached_tap,
             patch.object(
                 bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ) as wait_result:
+            ) as wait_result,
+        ):
             result = bot._enter_purchase_flow_from_detail_page(prepared=True)
 
         assert result == next_probe
@@ -2414,12 +2496,13 @@ class TestDetailPagePurchaseEntry:
     def test_enter_purchase_flow_falls_back_to_book_selectors(self, bot):
         next_probe = {"state": "order_confirm_page", "submit_button": True}
 
-        with \
-            patch.object(bot, "ultra_fast_click", return_value=False), \
-            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click, \
+        with (
+            patch.object(bot, "ultra_fast_click", return_value=False),
+            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click,
             patch.object(
                 bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ) as wait_result:
+            ) as wait_result,
+        ):
             result = bot._enter_purchase_flow_from_detail_page(prepared=True)
 
         assert result == next_probe
@@ -2427,9 +2510,10 @@ class TestDetailPagePurchaseEntry:
         wait_result.assert_called_once_with(timeout=5, poll_interval=0.08)
 
     def test_enter_purchase_flow_returns_none_when_all_clicks_fail(self, bot):
-        with \
-            patch.object(bot, "ultra_fast_click", return_value=False), \
-            patch.object(bot, "smart_wait_and_click", return_value=False):
+        with (
+            patch.object(bot, "ultra_fast_click", return_value=False),
+            patch.object(bot, "smart_wait_and_click", return_value=False),
+        ):
             result = bot._enter_purchase_flow_from_detail_page(prepared=True)
 
         assert result is None
@@ -2444,9 +2528,10 @@ class TestSaleReadiness:
         self, bot
     ):
         purchase_bar = Mock()
-        with \
-            patch.object(bot.driver, "find_element", return_value=purchase_bar), \
-            patch.object(bot, "_collect_descendant_texts", return_value=["", "   "]):
+        with (
+            patch.object(bot.driver, "find_element", return_value=purchase_bar),
+            patch.object(bot, "_collect_descendant_texts", return_value=["", "   "]),
+        ):
             assert bot._purchase_bar_text_ready() is False
 
     def test_is_sale_ready_detects_ready_selector(self, bot):
@@ -2462,22 +2547,24 @@ class TestSaleReadiness:
     def test_is_sale_ready_uses_sku_mode_to_block_reservation(self, bot):
         present = {(By.ID, "cn.damai:id/project_detail_perform_price_flowlayout")}
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: (by, value) in present,
-            ), \
-            patch.object(bot, "is_reservation_sku_mode", return_value=True):
+            ),
+            patch.object(bot, "is_reservation_sku_mode", return_value=True),
+        ):
             assert bot._is_sale_ready() is False
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: (by, value) in present,
-            ), \
-            patch.object(bot, "is_reservation_sku_mode", return_value=False):
+            ),
+            patch.object(bot, "is_reservation_sku_mode", return_value=False),
+        ):
             assert bot._is_sale_ready() is True
 
     def test_is_sale_ready_uses_purchase_bar_text_when_detail_cta_present(self, bot):
@@ -2485,13 +2572,14 @@ class TestSaleReadiness:
             (By.ID, "cn.damai:id/trade_project_detail_purchase_status_bar_container_fl")
         }
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_has_element",
                 side_effect=lambda by, value: (by, value) in present,
-            ), \
-            patch.object(bot, "_purchase_bar_text_ready", return_value=True):
+            ),
+            patch.object(bot, "_purchase_bar_text_ready", return_value=True),
+        ):
             assert bot._is_sale_ready() is True
 
     def test_is_sale_ready_returns_false_without_any_signal(self, bot):
@@ -2523,12 +2611,13 @@ class TestFastRetry:
         }
         # First call from dismiss_startup_popups fallback returns unknown;
         # second call (in back-loop with fast=True) returns detail_page.
-        with \
+        with (
             patch.object(
                 bot, "probe_current_page", side_effect=[unknown_probe, detail_probe]
-            ), \
-            patch.object(bot, "dismiss_startup_popups"), \
-            patch("mobile.damai_app.time.sleep"):
+            ),
+            patch.object(bot, "dismiss_startup_popups"),
+            patch("mobile.damai_app.time.sleep"),
+        ):
             result = bot._recover_to_detail_page_for_local_retry(
                 initial_probe=unknown_probe
             )
@@ -2538,7 +2627,7 @@ class TestFastRetry:
 
     def test_fast_retry_from_detail_page(self, bot):
         """probe returns detail_page, re-runs full flow."""
-        with \
+        with (
             patch.object(
                 bot,
                 "probe_current_page",
@@ -2549,8 +2638,9 @@ class TestFastRetry:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg:
+            ),
+            patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg,
+        ):
             result = bot._fast_retry_from_current_state()
 
         assert result is True
@@ -2558,7 +2648,7 @@ class TestFastRetry:
 
     def test_fast_retry_from_order_confirm_page(self, bot):
         """probe returns order_confirm_page, re-attempts submit only."""
-        with \
+        with (
             patch.object(
                 bot,
                 "probe_current_page",
@@ -2569,8 +2659,9 @@ class TestFastRetry:
                     "quantity_picker": False,
                     "submit_button": True,
                 },
-            ), \
-            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click:
+            ),
+            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click,
+        ):
             result = bot._fast_retry_from_current_state()
 
         assert result is True
@@ -2581,7 +2672,7 @@ class TestFastRetry:
     ):
         bot.config.if_commit_order = False
 
-        with \
+        with (
             patch.object(
                 bot,
                 "probe_current_page",
@@ -2592,13 +2683,14 @@ class TestFastRetry:
                     "quantity_picker": False,
                     "submit_button": True,
                 },
-            ), \
+            ),
             patch.object(
                 bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ) as ensure_attendees, \
+            ) as ensure_attendees,
             patch.object(
                 bot, "smart_wait_for_element", return_value=True
-            ) as wait_element:
+            ) as wait_element,
+        ):
             result = bot._fast_retry_from_current_state()
 
         assert result is True
@@ -2626,7 +2718,7 @@ class TestFastRetry:
         bot.item_detail = _make_item_detail()
         bot.config.auto_navigate = True
 
-        with \
+        with (
             patch.object(
                 bot,
                 "probe_current_page",
@@ -2637,12 +2729,13 @@ class TestFastRetry:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "_current_page_matches_target", return_value=False), \
+            ),
+            patch.object(bot, "_current_page_matches_target", return_value=False),
             patch.object(
                 bot, "navigate_to_target_event", return_value=True
-            ) as navigate, \
-            patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg:
+            ) as navigate,
+            patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg,
+        ):
             result = bot._fast_retry_from_current_state()
 
         assert result is True
@@ -2653,7 +2746,7 @@ class TestFastRetry:
         bot.item_detail = _make_item_detail()
         bot.config.auto_navigate = False
 
-        with \
+        with (
             patch.object(
                 bot,
                 "probe_current_page",
@@ -2664,10 +2757,11 @@ class TestFastRetry:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "_current_page_matches_target", return_value=False), \
-            patch.object(bot, "navigate_to_target_event") as navigate, \
-            patch.object(bot, "run_ticket_grabbing") as run_tg:
+            ),
+            patch.object(bot, "_current_page_matches_target", return_value=False),
+            patch.object(bot, "navigate_to_target_event") as navigate,
+            patch.object(bot, "run_ticket_grabbing") as run_tg,
+        ):
             result = bot._fast_retry_from_current_state()
 
         assert result is False
@@ -2678,7 +2772,7 @@ class TestFastRetry:
         """Manual-start retry recovers locally before re-running the flow."""
         bot.config.auto_navigate = False
 
-        with \
+        with (
             patch.object(
                 bot,
                 "probe_current_page",
@@ -2689,7 +2783,7 @@ class TestFastRetry:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
+            ),
             patch.object(
                 bot,
                 "_recover_to_detail_page_for_local_retry",
@@ -2700,9 +2794,10 @@ class TestFastRetry:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ) as recover_local, \
-            patch.object(bot, "run_ticket_grabbing", return_value=False) as run_tg, \
-            patch("mobile.damai_app.time.sleep"):
+            ) as recover_local,
+            patch.object(bot, "run_ticket_grabbing", return_value=False) as run_tg,
+            patch("mobile.damai_app.time.sleep"),
+        ):
             result = bot._fast_retry_from_current_state()
 
         recover_local.assert_called_once()
@@ -2713,7 +2808,7 @@ class TestFastRetry:
         """Manual-start retry stops if it cannot recover to a detail/sku page."""
         bot.config.auto_navigate = False
 
-        with \
+        with (
             patch.object(
                 bot,
                 "probe_current_page",
@@ -2724,7 +2819,7 @@ class TestFastRetry:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
+            ),
             patch.object(
                 bot,
                 "_recover_to_detail_page_for_local_retry",
@@ -2735,8 +2830,9 @@ class TestFastRetry:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ) as recover_local, \
-            patch.object(bot, "run_ticket_grabbing") as run_tg:
+            ) as recover_local,
+            patch.object(bot, "run_ticket_grabbing") as run_tg,
+        ):
             result = bot._fast_retry_from_current_state()
 
         recover_local.assert_called_once()
@@ -2746,7 +2842,7 @@ class TestFastRetry:
     def test_fast_retry_from_unknown_uses_auto_navigation_when_enabled(self, bot):
         bot.config.auto_navigate = True
 
-        with \
+        with (
             patch.object(
                 bot,
                 "probe_current_page",
@@ -2757,11 +2853,12 @@ class TestFastRetry:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
+            ),
             patch.object(
                 bot, "navigate_to_target_event", return_value=True
-            ) as navigate, \
-            patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg:
+            ) as navigate,
+            patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg,
+        ):
             result = bot._fast_retry_from_current_state()
 
         assert result is True
@@ -2777,13 +2874,14 @@ class TestFastRetry:
 class TestVerifyOrderResult:
     def test_verify_order_success_payment_activity(self, bot):
         """Activity contains 'Pay', returns 'success'."""
-        with \
+        with (
             patch.object(
                 bot,
                 "_get_current_activity",
                 return_value="com.alipay.android.app.PayActivity",
-            ), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
             result = bot.verify_order_result(timeout=5)
 
@@ -2795,10 +2893,11 @@ class TestVerifyOrderResult:
         def has_element_side_effect(by, value):
             return "立即支付" in value
 
-        with \
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"), \
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect), \
-            patch("mobile.damai_app.time") as mock_time:
+        with (
+            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
+            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
             result = bot.verify_order_result(timeout=5)
 
@@ -2812,11 +2911,12 @@ class TestVerifyOrderResult:
             # Simulate a page containing generic "支付" wording but no payment CTA.
             return 'textContains("支付")' in value and "未支付" not in value
 
-        with \
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"), \
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect), \
-            patch("mobile.damai_app.time.time", side_effect=time_values), \
-            patch("mobile.damai_app.time.sleep"):
+        with (
+            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
+            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
+            patch("mobile.damai_app.time.time", side_effect=time_values),
+            patch("mobile.damai_app.time.sleep"),
+        ):
             result = bot.verify_order_result(timeout=1)
 
         assert result == "timeout"
@@ -2846,11 +2946,12 @@ class TestVerifyOrderResult:
                 return True
             return False
 
-        with \
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"), \
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect), \
-            patch("mobile.damai_app.time.time", side_effect=time_values), \
-            patch("mobile.damai_app.time.sleep"):
+        with (
+            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
+            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
+            patch("mobile.damai_app.time.time", side_effect=time_values),
+            patch("mobile.damai_app.time.sleep"),
+        ):
             result = bot.verify_order_result(timeout=1)
 
         assert result == "timeout"
@@ -2861,10 +2962,11 @@ class TestVerifyOrderResult:
         def has_element_side_effect(by, value):
             return "已售罄" in value
 
-        with \
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"), \
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect), \
-            patch("mobile.damai_app.time") as mock_time:
+        with (
+            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
+            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
             result = bot.verify_order_result(timeout=5)
 
@@ -2879,10 +2981,11 @@ class TestVerifyOrderResult:
             # Return increasing time so we exceed timeout quickly
             return call_count[0] * 3.0
 
-        with \
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"), \
-            patch.object(bot, "_has_element", return_value=False), \
-            patch("mobile.damai_app.time") as mock_time:
+        with (
+            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
+            patch.object(bot, "_has_element", return_value=False),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time = mock_time_func
             mock_time.sleep = Mock()
             result = bot.verify_order_result(timeout=5)
@@ -2902,10 +3005,11 @@ class TestVerifyOrderResult:
                 return True
             return False
 
-        with \
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"), \
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect), \
-            patch("mobile.damai_app.time") as mock_time:
+        with (
+            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
+            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
             result = bot.verify_order_result(timeout=5)
 
@@ -2925,10 +3029,11 @@ class TestVerifyOrderResult:
                 return True
             return False
 
-        with \
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"), \
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect), \
-            patch("mobile.damai_app.time") as mock_time:
+        with (
+            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
+            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
             result = bot.verify_order_result(timeout=5)
 
@@ -2943,9 +3048,10 @@ class TestVerifyOrderResult:
 class TestSelectPerformanceDate:
     def test_select_performance_date_found(self, bot, caplog):
         """Date text found and clicked successfully."""
-        with \
-            caplog.at_level("INFO", logger="mobile.damai_app"), \
-            patch.object(bot, "ultra_fast_click", return_value=True) as ufc:
+        with (
+            caplog.at_level("INFO", logger="mobile.damai_app"),
+            patch.object(bot, "ultra_fast_click", return_value=True) as ufc,
+        ):
             bot.select_performance_date()
 
         ufc.assert_called_once_with(
@@ -2957,9 +3063,10 @@ class TestSelectPerformanceDate:
 
     def test_select_performance_date_not_found(self, bot, caplog):
         """Date not found, continues gracefully without error."""
-        with \
-            caplog.at_level("DEBUG", logger="mobile.damai_app"), \
-            patch.object(bot, "ultra_fast_click", return_value=False) as ufc:
+        with (
+            caplog.at_level("DEBUG", logger="mobile.damai_app"),
+            patch.object(bot, "ultra_fast_click", return_value=False) as ufc,
+        ):
             bot.select_performance_date()
 
         ufc.assert_called_once()
@@ -2982,24 +3089,26 @@ class TestSelectPerformanceDate:
 class TestCheckSessionValid:
     def test_check_session_valid_logged_in(self, bot):
         """No login indicators, returns True."""
-        with \
+        with (
             patch.object(
                 bot, "_get_current_activity", return_value="ProjectDetailActivity"
-            ), \
-            patch.object(bot, "_has_element", return_value=False):
+            ),
+            patch.object(bot, "_has_element", return_value=False),
+        ):
             result = bot.check_session_valid()
 
         assert result is True
 
     def test_check_session_valid_login_activity(self, bot, caplog):
         """LoginActivity detected, returns False."""
-        with \
-            caplog.at_level("ERROR", logger="mobile.damai_app"), \
+        with (
+            caplog.at_level("ERROR", logger="mobile.damai_app"),
             patch.object(
                 bot,
                 "_get_current_activity",
                 return_value="com.taobao.login.LoginActivity",
-            ):
+            ),
+        ):
             result = bot.check_session_valid()
 
         assert result is False
@@ -3007,11 +3116,12 @@ class TestCheckSessionValid:
 
     def test_check_session_valid_sign_activity(self, bot, caplog):
         """SignActivity detected, returns False."""
-        with \
-            caplog.at_level("ERROR", logger="mobile.damai_app"), \
+        with (
+            caplog.at_level("ERROR", logger="mobile.damai_app"),
             patch.object(
                 bot, "_get_current_activity", return_value="com.taobao.SignActivity"
-            ):
+            ),
+        ):
             result = bot.check_session_valid()
 
         assert result is False
@@ -3023,10 +3133,11 @@ class TestCheckSessionValid:
         def has_element_side_effect(by, value):
             return "请先登录" in value
 
-        with \
-            caplog.at_level("ERROR", logger="mobile.damai_app"), \
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"), \
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+        with (
+            caplog.at_level("ERROR", logger="mobile.damai_app"),
+            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
+            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
+        ):
             result = bot.check_session_valid()
 
         assert result is False
@@ -3035,9 +3146,10 @@ class TestCheckSessionValid:
 
 class TestSkuInspectionHelpers:
     def test_dismiss_startup_popups_returns_false_when_nothing_is_clickable(self, bot):
-        with \
-            patch.object(bot, "_has_element", return_value=False), \
-            patch.object(bot, "ultra_fast_click") as fast_click:
+        with (
+            patch.object(bot, "_has_element", return_value=False),
+            patch.object(bot, "ultra_fast_click") as fast_click,
+        ):
             assert bot.dismiss_startup_popups() is False
 
         fast_click.assert_not_called()
@@ -3092,11 +3204,12 @@ class TestSkuInspectionHelpers:
     def test_ensure_sku_page_for_inspection_enters_sku_from_detail_page(self, bot):
         next_probe = {"state": "sku_page", "reservation_mode": False}
 
-        with \
-            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click, \
+        with (
+            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click,
             patch.object(
                 bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ) as wait_entry:
+            ) as wait_entry,
+        ):
             result = bot.ensure_sku_page_for_inspection({"state": "detail_page"})
 
         assert result == next_probe
@@ -3104,11 +3217,12 @@ class TestSkuInspectionHelpers:
         wait_entry.assert_called_once_with(timeout=5, poll_interval=0.04)
 
     def test_ensure_sku_page_for_inspection_returns_probe_when_click_fails(self, bot):
-        with \
-            patch.object(bot, "smart_wait_and_click", return_value=False), \
+        with (
+            patch.object(bot, "smart_wait_and_click", return_value=False),
             patch.object(
                 bot, "probe_current_page", return_value={"state": "detail_page"}
-            ) as probe:
+            ) as probe,
+        ):
             result = bot.ensure_sku_page_for_inspection({"state": "detail_page"})
 
         assert result == {"state": "detail_page"}
@@ -3118,22 +3232,23 @@ class TestSkuInspectionHelpers:
         sku_probe = {"state": "sku_page", "reservation_mode": True}
         prices = [{"index": 5, "text": "看台 899元", "tag": "可选", "source": "ui"}]
 
-        with \
-            patch.object(bot, "smart_wait_and_click", return_value=True), \
-            patch.object(bot, "_dump_hierarchy_xml", return_value=None), \
+        with (
+            patch.object(bot, "smart_wait_and_click", return_value=True),
+            patch.object(bot, "_dump_hierarchy_xml", return_value=None),
             patch.object(
                 bot, "_wait_for_purchase_entry_result", return_value=sku_probe
-            ), \
+            ),
             patch.object(
                 bot, "_get_detail_title_text", side_effect=["", "马思唯上海站"]
-            ), \
+            ),
             patch.object(
                 bot,
                 "_get_detail_venue_text",
                 side_effect=["", "上海市 · 浦发银行东方体育中心"],
-            ), \
-            patch.object(bot, "get_visible_date_options", return_value=["04.04"]), \
-            patch.object(bot, "get_visible_price_options", return_value=prices):
+            ),
+            patch.object(bot, "get_visible_date_options", return_value=["04.04"]),
+            patch.object(bot, "get_visible_price_options", return_value=prices),
+        ):
             summary = bot.inspect_current_target_event({"state": "detail_page"})
 
         assert summary == {
@@ -3146,20 +3261,21 @@ class TestSkuInspectionHelpers:
         }
 
     def test_inspect_current_target_event_skips_price_reads_outside_sku_page(self, bot):
-        with \
-            patch.object(bot, "smart_wait_and_click", return_value=True), \
-            patch.object(bot, "_dump_hierarchy_xml", return_value=None), \
+        with (
+            patch.object(bot, "smart_wait_and_click", return_value=True),
+            patch.object(bot, "_dump_hierarchy_xml", return_value=None),
             patch.object(
                 bot,
                 "_wait_for_purchase_entry_result",
                 return_value={"state": "detail_page"},
-            ), \
-            patch.object(bot, "_get_detail_title_text", return_value="马思唯上海站"), \
+            ),
+            patch.object(bot, "_get_detail_title_text", return_value="马思唯上海站"),
             patch.object(
                 bot, "_get_detail_venue_text", return_value="浦发银行东方体育中心"
-            ), \
-            patch.object(bot, "get_visible_date_options") as get_dates, \
-            patch.object(bot, "get_visible_price_options") as get_prices:
+            ),
+            patch.object(bot, "get_visible_date_options") as get_dates,
+            patch.object(bot, "get_visible_price_options") as get_prices,
+        ):
             summary = bot.inspect_current_target_event({"state": "detail_page"})
 
         assert summary["state"] == "detail_page"
@@ -3174,10 +3290,11 @@ class TestSkuInspectionHelpers:
         def has_element_side_effect(by, value):
             return "登录/注册" in value
 
-        with \
-            caplog.at_level("ERROR", logger="mobile.damai_app"), \
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"), \
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+        with (
+            caplog.at_level("ERROR", logger="mobile.damai_app"),
+            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
+            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
+        ):
             result = bot.check_session_valid()
 
         assert result is False
@@ -3346,13 +3463,14 @@ class TestXmlHierarchyHelpers:
         bot.d.dump_hierarchy = Mock(return_value="<hierarchy><node/></hierarchy>")
         sku_probe = {"state": "sku_page", "reservation_mode": False}
 
-        with \
-            patch.object(bot, "probe_current_page", return_value=sku_probe), \
-            patch.object(bot, "ensure_sku_page_for_inspection", return_value=sku_probe), \
-            patch.object(bot, "_get_detail_title_text", return_value="演唱会"), \
-            patch.object(bot, "_get_detail_venue_text", return_value="场馆"), \
-            patch.object(bot, "get_visible_date_options", return_value=["04.06"]), \
-            patch.object(bot, "get_visible_price_options", return_value=[]):
+        with (
+            patch.object(bot, "probe_current_page", return_value=sku_probe),
+            patch.object(bot, "ensure_sku_page_for_inspection", return_value=sku_probe),
+            patch.object(bot, "_get_detail_title_text", return_value="演唱会"),
+            patch.object(bot, "_get_detail_venue_text", return_value="场馆"),
+            patch.object(bot, "get_visible_date_options", return_value=["04.06"]),
+            patch.object(bot, "get_visible_price_options", return_value=[]),
+        ):
             bot.inspect_current_target_event()
 
         # Hierarchy should only be dumped once (no re-dump since page didn't navigate).
@@ -3371,11 +3489,12 @@ class TestPriceSelection:
         bot.config.rush_mode = True
         bot.config.price_index = 5
 
-        with \
+        with (
             patch.object(
                 bot, "_click_price_option_by_config_index", return_value=True
-            ) as click_index, \
-            patch.object(bot, "get_visible_price_options") as get_visible:
+            ) as click_index,
+            patch.object(bot, "get_visible_price_options") as get_visible,
+        ):
             result = bot._select_price_option_fast()
 
         assert result is True
@@ -3385,11 +3504,12 @@ class TestPriceSelection:
     def test_select_price_option_fast_rush_mode_uses_cached_coordinates(self, bot):
         bot.config.rush_mode = True
 
-        with \
+        with (
             patch.object(
                 bot, "_click_price_option_by_config_index", return_value=True
-            ) as click_index, \
-            patch.object(bot, "get_visible_price_options") as get_visible:
+            ) as click_index,
+            patch.object(bot, "get_visible_price_options") as get_visible,
+        ):
             result = bot._select_price_option_fast(cached_coords=(240, 1560))
 
         assert result is True
@@ -3400,17 +3520,18 @@ class TestPriceSelection:
         bot.config.price = "899元"
         bot.config.price_index = 5
 
-        with \
+        with (
             patch.object(
                 bot,
                 "get_visible_price_options",
                 return_value=[
                     {"index": 5, "text": "", "tag": "", "source": "ui"},
                 ],
-            ) as get_visible, \
+            ) as get_visible,
             patch.object(
                 bot, "_click_visible_price_option", return_value=True
-            ) as click_visible:
+            ) as click_visible,
+        ):
             result = bot._select_price_option_fast()
 
         assert result is True
@@ -3418,13 +3539,14 @@ class TestPriceSelection:
         click_visible.assert_called_once_with(5)
 
     def test_click_price_option_by_config_index_bursts_clicks_in_rush_mode(self, bot):
-        with \
+        with (
             patch.object(
                 bot,
                 "_get_price_option_coordinates_by_config_index",
                 return_value=(260, 1540),
-            ), \
-            patch.object(bot, "_burst_click_coordinates") as burst_click:
+            ),
+            patch.object(bot, "_burst_click_coordinates") as burst_click,
+        ):
             result = bot._click_price_option_by_config_index(burst=True)
 
         assert result is True
@@ -3438,12 +3560,13 @@ class TestPriceSelection:
         bot.config.price = "899元"
         bot.config.price_index = 5
 
-        with \
-            patch.object(bot, "get_visible_price_options", return_value=[]), \
+        with (
+            patch.object(bot, "get_visible_price_options", return_value=[]),
             patch.object(
                 bot, "_click_price_option_by_config_index", return_value=True
-            ) as click_index, \
-            patch.object(bot, "ultra_fast_click", return_value=False):
+            ) as click_index,
+            patch.object(bot, "ultra_fast_click", return_value=False),
+        ):
             result = bot._select_price_option_fast()
 
         assert result is True
@@ -3453,7 +3576,7 @@ class TestPriceSelection:
         bot.config.price = "899元"
         bot.config.price_index = 5
 
-        with \
+        with (
             patch.object(
                 bot,
                 "get_visible_price_options",
@@ -3461,11 +3584,12 @@ class TestPriceSelection:
                     {"index": 0, "text": "看台699元", "tag": "", "source": "ocr"},
                     {"index": 5, "text": "看台899元", "tag": "", "source": "ocr"},
                 ],
-            ), \
+            ),
             patch.object(
                 bot, "_click_visible_price_option", return_value=True
-            ) as click_visible, \
-            patch.object(bot, "ultra_fast_click") as fast_click:
+            ) as click_visible,
+            patch.object(bot, "ultra_fast_click") as fast_click,
+        ):
             result = bot._select_price_option()
 
         assert result is True
@@ -3476,7 +3600,7 @@ class TestPriceSelection:
         bot.config.price = "899元"
         bot.config.price_index = 5
 
-        with \
+        with (
             patch.object(
                 bot,
                 "get_visible_price_options",
@@ -3488,9 +3612,10 @@ class TestPriceSelection:
                         "source": "ocr",
                     },
                 ],
-            ), \
-            patch.object(bot, "_click_visible_price_option") as click_visible, \
-            patch.object(bot, "ultra_fast_click") as fast_click:
+            ),
+            patch.object(bot, "_click_visible_price_option") as click_visible,
+            patch.object(bot, "ultra_fast_click") as fast_click,
+        ):
             result = bot._select_price_option()
 
         assert result is False
@@ -3504,12 +3629,13 @@ class TestPriceSelection:
             (By.XPATH, '//*[contains(@text,"提交")]'),
         ]
 
-        with \
-            patch.object(bot, "ultra_fast_click", side_effect=[True, True]), \
-            patch.object(bot, "smart_wait_and_click", return_value=False), \
+        with (
+            patch.object(bot, "ultra_fast_click", side_effect=[True, True]),
+            patch.object(bot, "smart_wait_and_click", return_value=False),
             patch.object(
                 bot, "verify_order_result", side_effect=["timeout", "success"]
-            ) as verify_result:
+            ) as verify_result,
+        ):
             result = bot._submit_order_fast(submit_selectors)
 
         assert result == "success"
@@ -3522,12 +3648,13 @@ class TestPriceSelection:
             (By.XPATH, '//*[contains(@text,"提交")]'),
         ]
 
-        with \
-            patch.object(bot, "ultra_fast_click", side_effect=[True, False, False]), \
-            patch.object(bot, "smart_wait_and_click", return_value=False), \
+        with (
+            patch.object(bot, "ultra_fast_click", side_effect=[True, False, False]),
+            patch.object(bot, "smart_wait_and_click", return_value=False),
             patch.object(
                 bot, "verify_order_result", side_effect=["timeout", "existing_order"]
-            ) as verify_result:
+            ) as verify_result,
+        ):
             result = bot._submit_order_fast(submit_selectors)
 
         assert result == "existing_order"
@@ -3535,9 +3662,9 @@ class TestPriceSelection:
 
     def test_price_selection_text_match_success(self, bot):
         """Text-based price match works, index fallback not used."""
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
-            patch.object(bot, "check_session_valid", return_value=True), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
+            patch.object(bot, "check_session_valid", return_value=True),
             patch.object(
                 bot,
                 "probe_current_page",
@@ -3548,9 +3675,9 @@ class TestPriceSelection:
                     "quantity_picker": False,
                     "submit_button": False,
                 },
-            ), \
-            patch.object(bot, "wait_for_sale_start"), \
-            patch.object(bot, "select_performance_date"), \
+            ),
+            patch.object(bot, "wait_for_sale_start"),
+            patch.object(bot, "select_performance_date"),
             patch.object(
                 bot,
                 "_enter_purchase_flow_from_detail_page",
@@ -3559,13 +3686,14 @@ class TestPriceSelection:
                     "price_container": True,
                     "reservation_mode": False,
                 },
-            ), \
-            patch.object(bot, "_wait_for_submit_ready", return_value=True), \
-            patch.object(bot, "smart_wait_and_click", return_value=True), \
-            patch.object(bot, "ultra_fast_click", return_value=True) as ufc, \
-            patch.object(bot, "ultra_batch_click"), \
-            patch.object(bot, "_submit_order_fast", return_value="success"), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "_wait_for_submit_ready", return_value=True),
+            patch.object(bot, "smart_wait_and_click", return_value=True),
+            patch.object(bot, "ultra_fast_click", return_value=True) as ufc,
+            patch.object(bot, "ultra_batch_click"),
+            patch.object(bot, "_submit_order_fast", return_value="success"),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
             bot.driver.find_elements.return_value = []
 
@@ -3596,10 +3724,10 @@ class TestPriceSelection:
         _price_logger = _logging.getLogger("mobile.price_selector")
         _price_logger.propagate = True
         try:
-            with \
-                caplog.at_level("INFO"), \
-                patch.object(bot, "dismiss_startup_popups"), \
-                patch.object(bot, "check_session_valid", return_value=True), \
+            with (
+                caplog.at_level("INFO"),
+                patch.object(bot, "dismiss_startup_popups"),
+                patch.object(bot, "check_session_valid", return_value=True),
                 patch.object(
                     bot,
                     "probe_current_page",
@@ -3610,9 +3738,9 @@ class TestPriceSelection:
                         "quantity_picker": False,
                         "submit_button": False,
                     },
-                ), \
-                patch.object(bot, "wait_for_sale_start"), \
-                patch.object(bot, "select_performance_date"), \
+                ),
+                patch.object(bot, "wait_for_sale_start"),
+                patch.object(bot, "select_performance_date"),
                 patch.object(
                     bot,
                     "_enter_purchase_flow_from_detail_page",
@@ -3621,35 +3749,37 @@ class TestPriceSelection:
                         "price_container": True,
                         "reservation_mode": False,
                     },
-                ), \
-                patch.object(bot, "_wait_for_submit_ready", return_value=True), \
-                patch.object(bot, "smart_wait_and_click", return_value=True), \
+                ),
+                patch.object(bot, "_wait_for_submit_ready", return_value=True),
+                patch.object(bot, "smart_wait_and_click", return_value=True),
                 patch.object(
                     bot, "ultra_fast_click", side_effect=ultra_fast_click_side_effect
-                ), \
-                patch.object(bot, "ultra_batch_click"), \
-                patch.object(bot, "_submit_order_fast", return_value="success"), \
-                patch("mobile.damai_app.time") as mock_time:
+                ),
+                patch.object(bot, "ultra_batch_click"),
+                patch.object(bot, "_submit_order_fast", return_value="success"),
+                patch("mobile.damai_app.time") as mock_time,
+            ):
                 mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
                 # Mock price container for index-based fallback
                 mock_target = _make_mock_element()
-                with \
+                with (
                     patch.object(
                         bot._price_sel, "_click_price_card_element", return_value=False
-                    ), \
-                    patch.object(bot, "_find", return_value=Mock()), \
+                    ),
+                    patch.object(bot, "_find", return_value=Mock()),
                     patch.object(
                         bot,
                         "_container_find_elements",
                         return_value=[mock_target, mock_target],
-                    ), \
-                    patch.object(bot, "_is_clickable", return_value=True), \
-                    patch.object(bot, "_click_element_center"), \
+                    ),
+                    patch.object(bot, "_is_clickable", return_value=True),
+                    patch.object(bot, "_click_element_center"),
                     patch.object(
                         bot,
                         "_ensure_attendees_selected_on_confirm_page",
                         return_value=True,
-                    ):
+                    ),
+                ):
                     result = bot.run_ticket_grabbing()
         finally:
             _price_logger.propagate = False
@@ -3889,22 +4019,24 @@ class TestSmartWaitForElement:
 
 class TestWaitForPageState:
     def test_returns_last_probe_on_timeout(self, bot):
-        with \
+        with (
             patch.object(
                 bot, "probe_current_page", return_value={"state": "unknown_state"}
-            ), \
-            patch("mobile.damai_app.time.time", side_effect=[0.0, 10.0, 20.0]), \
-            patch("mobile.damai_app.time.sleep"):
+            ),
+            patch("mobile.damai_app.time.time", side_effect=[0.0, 10.0, 20.0]),
+            patch("mobile.damai_app.time.sleep"),
+        ):
             result = bot.wait_for_page_state({"order_confirm_page"}, timeout=5)
         assert result["state"] == "unknown_state"
 
     def test_returns_immediately_on_matching_state(self, bot):
-        with \
+        with (
             patch.object(
                 bot, "probe_current_page", return_value={"state": "detail_page"}
-            ), \
-            patch("mobile.damai_app.time.time", side_effect=[0.0, 1.0]), \
-            patch("mobile.damai_app.time.sleep"):
+            ),
+            patch("mobile.damai_app.time.time", side_effect=[0.0, 1.0]),
+            patch("mobile.damai_app.time.sleep"),
+        ):
             result = bot.wait_for_page_state({"detail_page"})
         assert result["state"] == "detail_page"
 
@@ -3959,18 +4091,19 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_wait_for_purchase_entry_result",
                 return_value={"state": "sku_page"},
-            ), \
-            patch.object(bot, "_click_price_option_by_config_index") as price_click, \
-            patch.object(bot, "_click_sku_buy_button_element") as buy_click, \
-            patch.object(bot, "_click_coordinates") as click_coords, \
+            ),
+            patch.object(bot, "_click_price_option_by_config_index") as price_click,
+            patch.object(bot, "_click_sku_buy_button_element") as buy_click,
+            patch.object(bot, "_click_coordinates") as click_coords,
             patch.object(
                 bot._pipeline, "_confirm_page_ready", side_effect=[False, True]
-            ):
+            ),
+        ):
             result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
 
         assert result is True
@@ -3981,7 +4114,9 @@ class TestWarmValidationPipeline:
         second_shell = mock_d.shell.call_args_list[1][0][0]
         assert "input tap 300 1200" in second_shell
         assert second_shell.count("input tap 540 2100") == 2
-        detail_calls = [c for c in click_coords.call_args_list if c[0][:2] == (540, 1800)]
+        detail_calls = [
+            c for c in click_coords.call_args_list if c[0][:2] == (540, 1800)
+        ]
         assert len(detail_calls) == 0
         buy_click.assert_not_called()
         price_click.assert_not_called()
@@ -4006,18 +4141,19 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_wait_for_purchase_entry_result",
                 return_value={"state": "sku_page"},
-            ), \
-            patch.object(bot, "_click_price_option_by_config_index") as price_click, \
-            patch.object(bot, "_click_sku_buy_button_element") as buy_click, \
-            patch.object(bot, "_click_coordinates"), \
+            ),
+            patch.object(bot, "_click_price_option_by_config_index") as price_click,
+            patch.object(bot, "_click_sku_buy_button_element") as buy_click,
+            patch.object(bot, "_click_coordinates"),
             patch.object(
                 bot._pipeline, "_confirm_page_ready", side_effect=[False, True]
-            ):
+            ),
+        ):
             result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
 
         assert result is True
@@ -4043,23 +4179,26 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_wait_for_purchase_entry_result",
                 return_value={"state": "sku_page"},
-            ), \
-            patch.object(bot, "_click_price_option_by_config_index", return_value=True), \
-            patch.object(bot, "_click_sku_buy_button_element", return_value=True), \
-            patch.object(bot._pipeline, "_confirm_page_ready", side_effect=False), \
-            patch("mobile.damai_app.time") as mock_time:
+            ),
+            patch.object(bot, "_click_price_option_by_config_index", return_value=True),
+            patch.object(bot, "_click_sku_buy_button_element", return_value=True),
+            patch.object(bot._pipeline, "_confirm_page_ready", side_effect=False),
+            patch("mobile.damai_app.time") as mock_time,
+        ):
             mock_time.time = Mock(side_effect=[100.0, 100.0, 109.0])
             mock_time.sleep = Mock()
             result = bot._run_warm_validation_pipeline(start_time=100.0)
 
         assert result is None
 
-    def test_pipeline_detail_and_buy_fallbacks_use_u2_when_shell_fast_path_misses(self, bot):
+    def test_pipeline_detail_and_buy_fallbacks_use_u2_when_shell_fast_path_misses(
+        self, bot
+    ):
         """Warm pipeline falls back to u2 detail/buy clicks when shell taps do not advance."""
         bot.config.rush_mode = True
         bot.config.if_commit_order = False
@@ -4074,27 +4213,30 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with \
+        with (
             patch.object(
                 bot,
                 "_wait_for_purchase_entry_result",
                 side_effect=[None, {"state": "sku_page"}],
-            ), \
+            ),
             patch.object(
                 bot._pipeline, "_shell_price_and_buy_until_confirm", return_value=False
-            ), \
-            patch.object(bot, "_click_price_option_by_config_index", return_value=True), \
+            ),
+            patch.object(bot, "_click_price_option_by_config_index", return_value=True),
             patch.object(
                 bot, "_click_sku_buy_button_element", return_value=True
-            ) as buy_click, \
-            patch.object(bot, "_click_coordinates") as click_coords, \
+            ) as buy_click,
+            patch.object(bot, "_click_coordinates") as click_coords,
             patch.object(
                 bot._pipeline, "_confirm_page_ready", side_effect=[False, True]
-            ):
+            ),
+        ):
             result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
 
         assert result is True
-        detail_calls = [c for c in click_coords.call_args_list if c[0][:2] == (540, 1800)]
+        detail_calls = [
+            c for c in click_coords.call_args_list if c[0][:2] == (540, 1800)
+        ]
         assert len(detail_calls) == 1, (
             f"Expected detail CTA u2 fallback, got: {click_coords.call_args_list}"
         )
@@ -4122,11 +4264,12 @@ class TestWarmValidationPipeline:
         # Don't populate coords
         initial_probe = {"state": "detail_page", "purchase_button": True}
 
-        with \
-            patch.object(bot, "_run_warm_validation_pipeline") as pipeline, \
+        with (
+            patch.object(bot, "_run_warm_validation_pipeline") as pipeline,
             patch.object(
                 bot, "_enter_purchase_flow_from_detail_page", return_value=None
-            ):
+            ),
+        ):
             result = bot.run_ticket_grabbing(initial_page_probe=initial_probe)
 
         pipeline.assert_not_called()  # _has_warm_pipeline_coords returned False
@@ -4154,14 +4297,15 @@ class TestRecoverToDetailPage:
         }
         # First probe_current_page call (after dismiss_startup_popups) returns order_confirm;
         # second call (in back-loop with fast=True) returns detail_page.
-        with \
-            patch.object(bot, "dismiss_startup_popups"), \
+        with (
+            patch.object(bot, "dismiss_startup_popups"),
             patch.object(
                 bot,
                 "probe_current_page",
                 side_effect=[{"state": "order_confirm_page"}, detail_result],
-            ) as probe_mock, \
-            patch.object(bot, "_press_keycode_safe", return_value=True):
+            ) as probe_mock,
+            patch.object(bot, "_press_keycode_safe", return_value=True),
+        ):
             result = bot._recover_to_detail_page_for_local_retry(initial_probe)
         assert result["state"] == "detail_page"
         # Second call should be fast=True (back-loop)
@@ -4221,11 +4365,12 @@ class TestRushPreSelectViaXml:
         bot.driver = mock_d
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
-        with \
-            patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False), \
+        with (
+            patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False),
             patch.object(
                 bot, "_dump_hierarchy_xml", return_value=ET.fromstring(self.DETAIL_XML)
-            ):
+            ),
+        ):
             result = bot._rush_preselect_and_buy_via_xml()
 
         assert result is True
@@ -4249,13 +4394,14 @@ class TestRushPreSelectViaXml:
 
         mock_d = Mock()
         bot.d = mock_d
-        with \
-            patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False), \
+        with (
+            patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False),
             patch.object(
                 bot,
                 "_dump_hierarchy_xml",
                 return_value=ET.fromstring(self.DETAIL_XML_NO_CITY),
-            ):
+            ),
+        ):
             result = bot._rush_preselect_and_buy_via_xml()
 
         assert result is True
@@ -4274,11 +4420,12 @@ class TestRushPreSelectViaXml:
 
         mock_d = Mock()
         bot.d = mock_d
-        with \
-            patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False), \
+        with (
+            patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False),
             patch.object(
                 bot, "_dump_hierarchy_xml", return_value=ET.fromstring(no_buy_xml)
-            ):
+            ),
+        ):
             result = bot._rush_preselect_and_buy_via_xml()
 
         assert result is False
@@ -4304,13 +4451,14 @@ class TestRushPreSelectViaXml:
             "price_container": True,
             "reservation_mode": False,
         }
-        with \
+        with (
             patch.object(
                 bot, "_rush_preselect_and_buy_via_xml", return_value=True
-            ) as xml_method, \
+            ) as xml_method,
             patch.object(
                 bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ):
+            ),
+        ):
             result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         assert result == next_probe
@@ -4326,12 +4474,13 @@ class TestRushPreSelectViaXml:
             "price_container": True,
             "reservation_mode": False,
         }
-        with \
-            patch.object(bot, "_rush_preselect_and_buy_via_xml") as xml_method, \
-            patch.object(bot, "_cached_tap", return_value=True), \
+        with (
+            patch.object(bot, "_rush_preselect_and_buy_via_xml") as xml_method,
+            patch.object(bot, "_cached_tap", return_value=True),
             patch.object(
                 bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ):
+            ),
+        ):
             result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         xml_method.assert_not_called()  # warm path, skip XML dump
@@ -4571,3 +4720,98 @@ class TestSelectorExistsAndWait:
         """No exists, no wait → False."""
         sel = Mock(spec=[])
         assert DamaiBot._selector_exists(sel) is False
+
+
+# ---------------------------------------------------------------------------
+# SALE_READY_TEXTS — issue #29 「立即预订」文案兼容性
+# ---------------------------------------------------------------------------
+
+
+class TestSaleReadyTexts:
+    """Verify wait_for_sale_start / _is_sale_ready handle every SALE_READY_TEXTS variant.
+
+    Damai shipped a UI string change ("立即预定" → "立即预订") in 2026-04 that broke
+    the previous hard-coded list. These tests pin every supported variant so a
+    future copy change cannot regress silently (issue #29).
+    """
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            "立即购票",
+            "立即预定",
+            "立即预订",
+            "立即抢票",
+            "Book Now",
+        ],
+    )
+    def test_book_now_text_variants_recognized(self, bot, variant):
+        """Each SALE_READY_TEXTS member must make _is_sale_ready return True."""
+        from mobile.damai_app import SALE_READY_TEXTS
+
+        assert variant in SALE_READY_TEXTS, (
+            f"{variant!r} dropped from SALE_READY_TEXTS — issue #29 regression"
+        )
+
+        def has_element(by, value):
+            return f'textContains("{variant}")' in str(value)
+
+        with patch.object(bot, "_has_element", side_effect=has_element):
+            assert bot._is_sale_ready() is True
+            assert getattr(bot, "_last_sale_ready_text", None) == variant
+
+    def test_wait_for_sale_start_polls_with_book_now(self, bot, monkeypatch):
+        """When the page surfaces 「立即预订」, wait_for_sale_start returns within 1s."""
+        _tz = timezone(timedelta(hours=8))
+        # Sale starts 1s in the future so we enter the polling branch (not the
+        # "开售时间已过，跳过等待" early-return branch). countdown_lead_ms=0 keeps the
+        # pre-roll sleep at zero.
+        sell_time = datetime(2026, 6, 1, 20, 0, 1, tzinfo=_tz)
+        now_base = datetime(2026, 6, 1, 20, 0, 0, tzinfo=_tz)
+        bot.config.sell_start_time = sell_time.isoformat()
+        bot.config.countdown_lead_ms = 0
+
+        # Stage datetime.now so we (a) pass the "已过" check, (b) deterministically
+        # enter the polling loop with deadline still in the future.
+        now_calls = [0]
+
+        def mock_now(tz=None):
+            now_calls[0] += 1
+            if now_calls[0] == 1:
+                # First call: "is sale already over?" → we are 1s before sell_time
+                return now_base
+            if now_calls[0] == 2:
+                # Second call: compute pre-roll sleep_seconds (sell_time - lead - now)
+                return now_base
+            # During polling: stay before deadline so the loop can run at least once
+            return now_base
+
+        # BuyButtonGuard NOT used in this test path
+        bot._guard = Mock()
+        bot._guard.wait_until_safe = Mock(return_value=False)
+
+        # _has_element returns True only for textContains("立即预订")
+        def has_element(by, value):
+            return 'textContains("立即预订")' in str(value)
+
+        # Skip real sleeps to keep the test fast
+        sleep_calls = []
+        monkeypatch.setattr(
+            "mobile.damai_app.time.sleep",
+            lambda s: sleep_calls.append(s),
+        )
+
+        wall_start = _time_module.perf_counter()
+        with (
+            patch("mobile.damai_app.datetime") as mock_dt,
+            patch.object(bot, "_has_element", side_effect=has_element),
+        ):
+            mock_dt.fromisoformat = datetime.fromisoformat
+            mock_dt.now = mock_now
+            bot.wait_for_sale_start()
+        wall_elapsed = _time_module.perf_counter() - wall_start
+
+        assert wall_elapsed < 1.0, (
+            f"wait_for_sale_start should detect 立即预订 quickly, took {wall_elapsed:.3f}s"
+        )
+        assert getattr(bot, "_last_sale_ready_text", None) == "立即预订"

--- a/tests/unit/test_mobile_damai_app.py
+++ b/tests/unit/test_mobile_damai_app.py
@@ -130,11 +130,9 @@ def bot():
         probe_only=False,
     )
 
-    with (
-        patch("mobile.damai_app.Config.load_config", return_value=mock_config),
-        patch("uiautomator2.connect", return_value=mock_driver),
-    ):
-        bot = DamaiBot()
+    with patch("mobile.damai_app.Config.load_config", return_value=mock_config):
+        with patch("uiautomator2.connect", return_value=mock_driver):
+            bot = DamaiBot()
     return bot
 
 
@@ -162,11 +160,9 @@ class TestInitialization:
             probe_only=True,
         )
 
-        with (
-            patch("uiautomator2.connect", return_value=mock_driver),
-            patch("mobile.damai_app.Config.load_config") as load_config,
-        ):
-            bot = DamaiBot(config=injected_config)
+        with patch("uiautomator2.connect", return_value=mock_driver):
+            with patch("mobile.damai_app.Config.load_config") as load_config:
+                bot = DamaiBot(config=injected_config)
 
         assert bot.config is injected_config
         load_config.assert_not_called()
@@ -296,11 +292,9 @@ class TestCachedTap:
     def test_cache_hit_clicks_coordinates_and_returns_true(self, bot):
         """Warm path: cached (x, y) → single _click_coordinates call, True."""
         bot._cached_hot_path_coords["city"] = (300, 500)
-        with (
-            patch.object(bot, "_click_coordinates") as click_coords,
-            patch.object(bot, "ultra_fast_click") as ufc,
-        ):
-            result = bot._cached_tap("city", By.ID, "some.id", timeout=0.3)
+        with patch.object(bot, "_click_coordinates") as click_coords:
+            with patch.object(bot, "ultra_fast_click") as ufc:
+                result = bot._cached_tap("city", By.ID, "some.id", timeout=0.3)
         assert result is True
         click_coords.assert_called_once_with(300, 500)
         ufc.assert_not_called()
@@ -312,16 +306,14 @@ class TestCachedTap:
         mock_selector.info = {
             "bounds": {"left": 100, "top": 200, "right": 300, "bottom": 260}
         }
-        with (
-            patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector),
-            patch.object(bot, "_click_coordinates") as click_coords,
-        ):
-            result = bot._cached_tap(
-                "city",
-                ANDROID_UIAUTOMATOR,
-                'new UiSelector().text("北京")',
-                timeout=0.2,
-            )
+        with patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector):
+            with patch.object(bot, "_click_coordinates") as click_coords:
+                result = bot._cached_tap(
+                    "city",
+                    ANDROID_UIAUTOMATOR,
+                    'new UiSelector().text("北京")',
+                    timeout=0.2,
+                )
         assert result is True
         assert bot._cached_hot_path_coords["city"] == (200, 230)
         click_coords.assert_called_once_with(200, 230)
@@ -346,11 +338,9 @@ class TestCachedTap:
         mock_selector.wait.return_value = True
         mock_selector.info = {"bounds": None}
         mock_selector.get.return_value = mock_el
-        with (
-            patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector),
-            patch.object(bot, "_click_element_center") as click_center,
-        ):
-            result = bot._cached_tap("k", By.ID, "id", timeout=0.1)
+        with patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector):
+            with patch.object(bot, "_click_element_center") as click_center:
+                result = bot._cached_tap("k", By.ID, "id", timeout=0.1)
         assert result is True
         click_center.assert_called_once_with(mock_el, duration=50)
         assert "k" not in bot._cached_hot_path_coords
@@ -372,12 +362,10 @@ class TestCachedTap:
         mock_selector.info = {
             "bounds": {"left": 50, "top": 100, "right": 150, "bottom": 140}
         }
-        with (
-            patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector),
-            patch.object(bot, "_click_coordinates") as click_coords,
-        ):
-            bot._cached_tap("btn", By.ID, "id", timeout=0.2)  # cold
-            bot._cached_tap("btn", By.ID, "id", timeout=0.2)  # warm
+        with patch.object(bot, "_appium_selector_to_u2", return_value=mock_selector):
+            with patch.object(bot, "_click_coordinates") as click_coords:
+                bot._cached_tap("btn", By.ID, "id", timeout=0.2)  # cold
+                bot._cached_tap("btn", By.ID, "id", timeout=0.2)  # warm
         assert click_coords.call_count == 2
         mock_selector.wait.assert_called_once()  # only called on cold run
 
@@ -391,11 +379,9 @@ class TestBatchClick:
     def test_batch_click_all_success(self, bot):
         """ultra_fast_click called for each element pair."""
         elements = [("by1", "v1"), ("by2", "v2"), ("by3", "v3")]
-        with (
-            patch.object(bot, "ultra_fast_click", return_value=True) as ufc,
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            bot.batch_click(elements, delay=0.1)
+        with patch.object(bot, "ultra_fast_click", return_value=True) as ufc:
+            with patch("mobile.damai_app.time") as mock_time:
+                bot.batch_click(elements, delay=0.1)
 
         assert ufc.call_count == 3
         ufc.assert_any_call("by1", "v1")
@@ -405,12 +391,10 @@ class TestBatchClick:
     def test_batch_click_some_fail(self, bot, caplog):
         """Failed clicks log a warning but processing continues."""
         elements = [("by1", "v1"), ("by2", "v2")]
-        with (
-            caplog.at_level("WARNING", logger="mobile.ui_primitives"),
-            patch.object(bot, "ultra_fast_click", side_effect=[False, True]) as ufc,
-            patch("mobile.ui_primitives.time"),
-        ):
-            bot.batch_click(elements, delay=0.1)
+        with caplog.at_level("WARNING", logger="mobile.ui_primitives"):
+            with patch.object(bot, "ultra_fast_click", side_effect=[False, True]) as ufc:
+                with patch("mobile.ui_primitives.time"):
+                    bot.batch_click(elements, delay=0.1)
 
         assert ufc.call_count == 2
         assert "点击失败: v1" in caplog.text
@@ -427,12 +411,10 @@ class TestUltraBatchClick:
         el1 = _make_mock_element(x=10, y=20, width=100, height=50)
         el2 = _make_mock_element(x=200, y=300, width=60, height=30)
 
-        with (
-            caplog.at_level("DEBUG", logger="mobile.ui_primitives"),
-            patch.object(bot, "_wait_for_element", side_effect=[el1, el2]),
-            patch("mobile.ui_primitives.time"),
-        ):
-            bot.ultra_batch_click([(By.ID, "v1"), (By.ID, "v2")], timeout=2)
+        with caplog.at_level("DEBUG", logger="mobile.ui_primitives"):
+            with patch.object(bot, "_wait_for_element", side_effect=[el1, el2]):
+                with patch("mobile.ui_primitives.time"):
+                    bot.ultra_batch_click([(By.ID, "v1"), (By.ID, "v2")], timeout=2)
 
         assert "成功找到 2 个用户" in caplog.text
 
@@ -440,14 +422,10 @@ class TestUltraBatchClick:
         """Timed-out elements are skipped; found ones are still clicked."""
         el1 = _make_mock_element(x=10, y=20, width=100, height=50)
 
-        with (
-            caplog.at_level("DEBUG", logger="mobile.ui_primitives"),
-            patch.object(
-                bot, "_wait_for_element", side_effect=[el1, TimeoutException("timeout")]
-            ),
-            patch("mobile.ui_primitives.time"),
-        ):
-            bot.ultra_batch_click([(By.ID, "v1"), (By.ID, "v2")], timeout=2)
+        with caplog.at_level("DEBUG", logger="mobile.ui_primitives"):
+            with patch.object( bot, "_wait_for_element", side_effect=[el1, TimeoutException("timeout")] ):
+                with patch("mobile.ui_primitives.time"):
+                    bot.ultra_batch_click([(By.ID, "v1"), (By.ID, "v2")], timeout=2)
 
         assert "超时未找到用户: v2" in caplog.text
         assert "成功找到 1 个用户" in caplog.text
@@ -539,21 +517,10 @@ class TestAutoNavigation:
             assert bot._current_page_matches_target({"state": "sku_page"}) is False
 
     def test_exit_non_target_event_context_backs_out_until_search_page(self, bot):
-        with (
-            patch.object(
-                bot, "_current_page_matches_target", side_effect=[False, False]
-            ),
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                side_effect=[
-                    {"state": "detail_page"},
-                    {"state": "search_page"},
-                ],
-            ),
-        ):
-            result = bot._exit_non_target_event_context({"state": "sku_page"})
+        with patch.object( bot, "_current_page_matches_target", side_effect=[False, False] ):
+            with patch.object(bot, "dismiss_startup_popups"):
+                with patch.object( bot, "probe_current_page", side_effect=[ {"state": "detail_page"}, {"state": "search_page"}, ], ):
+                    result = bot._exit_non_target_event_context({"state": "sku_page"})
 
         assert result["state"] == "search_page"
         assert bot.d.press.call_count == 2
@@ -561,69 +528,36 @@ class TestAutoNavigation:
     def test_discover_target_event_exits_wrong_sku_page_before_search(self, bot):
         bot.config.keyword = "余佳运 演唱会"
 
-        with (
-            patch.object(
-                bot, "_recover_to_navigation_start", return_value={"state": "sku_page"}
-            ),
-            patch.object(
-                bot, "_current_page_matches_target", side_effect=[False, False]
-            ),
-            patch.object(
-                bot,
-                "_exit_non_target_event_context",
-                return_value={"state": "search_page"},
-            ) as exit_context,
-            patch.object(
-                bot, "_submit_search_keyword", return_value=True
-            ) as submit_keyword,
-            patch.object(
-                bot,
-                "_open_target_from_search_results",
-                return_value={
-                    "opened": True,
-                    "search_results": [{"score": 80, "title": "余佳运演唱会"}],
-                },
-            ),
-            patch.object(
-                bot, "probe_current_page", return_value={"state": "detail_page"}
-            ),
-        ):
-            result = bot.discover_target_event(
-                ["余佳运 演唱会"], initial_probe={"state": "sku_page"}
-            )
+        with patch.object( bot, "_recover_to_navigation_start", return_value={"state": "sku_page"} ):
+            with patch.object( bot, "_current_page_matches_target", side_effect=[False, False] ):
+                with patch.object( bot, "_exit_non_target_event_context", return_value={"state": "search_page"}, ) as exit_context:
+                    with patch.object( bot, "_submit_search_keyword", return_value=True ) as submit_keyword:
+                        with patch.object( bot, "_open_target_from_search_results", return_value={ "opened": True, "search_results": [{"score": 80, "title": "余佳运演唱会"}], }, ):
+                            with patch.object( bot, "probe_current_page", return_value={"state": "detail_page"} ):
+                                result = bot.discover_target_event(
+                                    ["余佳运 演唱会"], initial_probe={"state": "sku_page"}
+                                )
 
         assert result is not None
         exit_context.assert_called_once()
         submit_keyword.assert_called_once()
 
     def test_navigate_to_target_event_from_search_page(self, bot):
-        with (
-            patch.object(
-                bot,
-                "_recover_to_navigation_start",
-                return_value={"state": "search_page"},
-            ),
-            patch.object(
-                bot, "_submit_search_keyword", return_value=True
-            ) as submit_keyword,
-            patch.object(
-                bot, "_open_target_from_search_results", return_value=True
-            ) as open_target,
-        ):
-            result = bot.navigate_to_target_event({"state": "unknown"})
+        with patch.object( bot, "_recover_to_navigation_start", return_value={"state": "search_page"}, ):
+            with patch.object( bot, "_submit_search_keyword", return_value=True ) as submit_keyword:
+                with patch.object( bot, "_open_target_from_search_results", return_value=True ) as open_target:
+                    result = bot.navigate_to_target_event({"state": "unknown"})
 
         assert result is True
         submit_keyword.assert_called_once()
         open_target.assert_called_once()
 
     def test_recover_to_navigation_start_handles_back_key_failure(self, bot):
-        with (
-            patch.object(bot, "_press_keycode_safe", return_value=False),
-            patch.object(bot, "probe_current_page", return_value={"state": "unknown"}),
-            patch.object(bot.d, "app_start") as app_start,
-            patch("mobile.damai_app.time.sleep"),
-        ):
-            result = bot._recover_to_navigation_start({"state": "unknown"})
+        with patch.object(bot, "_press_keycode_safe", return_value=False):
+            with patch.object(bot, "probe_current_page", return_value={"state": "unknown"}):
+                with patch.object(bot.d, "app_start") as app_start:
+                    with patch("mobile.damai_app.time.sleep"):
+                        result = bot._recover_to_navigation_start({"state": "unknown"})
 
         app_start.assert_called_once_with(bot.config.app_package, stop=False)
         assert result["state"] == "unknown"
@@ -631,34 +565,22 @@ class TestAutoNavigation:
     def test_fast_retry_does_not_submit_when_commit_disabled(self, bot):
         bot.config.if_commit_order = False
 
-        with (
-            patch.object(
-                bot, "probe_current_page", return_value={"state": "order_confirm_page"}
-            ),
-            patch.object(
-                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ),
-            patch.object(
-                bot, "smart_wait_for_element", return_value=True
-            ) as wait_for_element,
-            patch.object(bot, "smart_wait_and_click") as smart_click,
-        ):
-            result = bot._fast_retry_from_current_state()
+        with patch.object( bot, "probe_current_page", return_value={"state": "order_confirm_page"} ):
+            with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
+                with patch.object( bot, "smart_wait_for_element", return_value=True ) as wait_for_element:
+                    with patch.object(bot, "smart_wait_and_click") as smart_click:
+                        result = bot._fast_retry_from_current_state()
 
         assert result is True
         wait_for_element.assert_called_once()
         smart_click.assert_not_called()
 
     def test_run_with_retry_stops_on_terminal_failure(self, bot):
-        with (
-            patch("mobile.damai_app.time.sleep"),
-            patch.object(
-                bot, "run_ticket_grabbing", side_effect=self._mark_terminal_failure(bot)
-            ),
-            patch.object(bot, "_fast_retry_from_current_state") as fast_retry,
-            patch.object(bot, "_setup_driver") as setup_driver,
-        ):
-            result = bot.run_with_retry(max_retries=3)
+        with patch("mobile.damai_app.time.sleep"):
+            with patch.object( bot, "run_ticket_grabbing", side_effect=self._mark_terminal_failure(bot) ):
+                with patch.object(bot, "_fast_retry_from_current_state") as fast_retry:
+                    with patch.object(bot, "_setup_driver") as setup_driver:
+                        result = bot.run_with_retry(max_retries=3)
 
         assert result is False
         fast_retry.assert_not_called()
@@ -682,38 +604,13 @@ class TestRunTicketGrabbing:
     def test_run_ticket_grabbing_auto_navigates_from_homepage(self, bot):
         bot.config.probe_only = True
 
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(bot, "check_session_valid", return_value=True),
-            patch.object(
-                bot, "navigate_to_target_event", return_value=True
-            ) as navigate,
-            patch.object(
-                bot,
-                "probe_current_page",
-                side_effect=[
-                    {
-                        "state": "homepage",
-                        "purchase_button": False,
-                        "price_container": False,
-                        "quantity_picker": False,
-                        "submit_button": False,
-                        "reservation_mode": False,
-                    },
-                    {
-                        "state": "detail_page",
-                        "purchase_button": True,
-                        "price_container": True,
-                        "quantity_picker": False,
-                        "submit_button": False,
-                        "reservation_mode": False,
-                    },
-                ],
-            ),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.3)
-            result = bot.run_ticket_grabbing()
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object(bot, "check_session_valid", return_value=True):
+                with patch.object( bot, "navigate_to_target_event", return_value=True ) as navigate:
+                    with patch.object( bot, "probe_current_page", side_effect=[ { "state": "homepage", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, "reservation_mode": False, }, { "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, "reservation_mode": False, }, ], ):
+                        with patch("mobile.damai_app.time") as mock_time:
+                            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.3)
+                            result = bot.run_ticket_grabbing()
 
         assert result is True
         navigate.assert_called_once()
@@ -722,24 +619,12 @@ class TestRunTicketGrabbing:
         """Homepage or other non-detail states fail fast with a clear result."""
         bot.config.auto_navigate = False
 
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "homepage",
-                    "purchase_button": False,
-                    "price_container": False,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "smart_wait_and_click") as smart_click,
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.return_value = 0.0
-            result = bot.run_ticket_grabbing()
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "homepage", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "smart_wait_and_click") as smart_click:
+                    with patch("mobile.damai_app.time") as mock_time:
+                        mock_time.time.return_value = 0.0
+                        result = bot.run_ticket_grabbing()
 
         assert result is False
         smart_click.assert_not_called()
@@ -748,24 +633,12 @@ class TestRunTicketGrabbing:
         """probe_only stops before purchase when detail-page essentials are present."""
         bot.config.probe_only = True
 
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "smart_wait_and_click") as smart_click,
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
-            result = bot.run_ticket_grabbing()
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "smart_wait_and_click") as smart_click:
+                    with patch("mobile.damai_app.time") as mock_time:
+                        mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
+                        result = bot.run_ticket_grabbing()
 
         assert result is True
         smart_click.assert_not_called()
@@ -774,24 +647,12 @@ class TestRunTicketGrabbing:
         """The first runtime log should clearly state this is only a probe."""
         bot.config.probe_only = True
 
-        with (
-            caplog.at_level("INFO", logger="mobile.damai_app"),
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
-            result = bot.run_ticket_grabbing()
+        with caplog.at_level("INFO", logger="mobile.damai_app"):
+            with patch.object(bot, "dismiss_startup_popups"):
+                with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                    with patch("mobile.damai_app.time") as mock_time:
+                        mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
+                        result = bot.run_ticket_grabbing()
 
         assert result is True
         assert "开始执行安全探测" in caplog.text
@@ -803,23 +664,11 @@ class TestRunTicketGrabbing:
         """probe_only reports failure when detail-page essentials are missing."""
         bot.config.probe_only = True
 
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": False,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.return_value = 0.0
-            result = bot.run_ticket_grabbing()
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch("mobile.damai_app.time") as mock_time:
+                    mock_time.time.return_value = 0.0
+                    result = bot.run_ticket_grabbing()
 
         assert result is False
 
@@ -827,70 +676,38 @@ class TestRunTicketGrabbing:
         """probe_only succeeds when the ticket sku page is already open."""
         bot.config.probe_only = True
 
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "sku_page",
-                    "purchase_button": False,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "smart_wait_and_click") as smart_click,
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
-            result = bot.run_ticket_grabbing()
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "smart_wait_and_click") as smart_click:
+                    with patch("mobile.damai_app.time") as mock_time:
+                        mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
+                        result = bot.run_ticket_grabbing()
 
         assert result is True
         smart_click.assert_not_called()
 
     def test_run_ticket_grabbing_success(self, bot):
         """All phases succeed, returns True."""
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(
-                bot,
-                "_enter_purchase_flow_from_detail_page",
-                return_value={
-                    "state": "sku_page",
-                    "price_container": True,
-                    "reservation_mode": False,
-                },
-            ),
-            patch.object(bot, "_wait_for_submit_ready", return_value=True),
-            patch.object(bot, "smart_wait_and_click", return_value=True),
-            patch.object(bot, "ultra_fast_click", return_value=True),
-            patch.object(bot, "ultra_batch_click"),
-            patch.object(bot, "_submit_order_fast", return_value="success"),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            # Provide enough time.time() values for the confirm-retry loop
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
-            # Mock find_element for price container + target_price
-            mock_price_container = Mock()
-            mock_target = _make_mock_element()
-            mock_price_container.find_element.return_value = mock_target
-            bot.driver.find_element.return_value = mock_price_container
-            bot.driver.find_elements.return_value = []  # no quantity layout
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "wait_for_sale_start"):
+                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
+                        with patch.object(bot, "_wait_for_submit_ready", return_value=True):
+                            with patch.object(bot, "smart_wait_and_click", return_value=True):
+                                with patch.object(bot, "ultra_fast_click", return_value=True):
+                                    with patch.object(bot, "ultra_batch_click"):
+                                        with patch.object(bot, "_submit_order_fast", return_value="success"):
+                                            with patch("mobile.damai_app.time") as mock_time:
+                                                # Provide enough time.time() values for the confirm-retry loop
+                                                mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
+                                                # Mock find_element for price container + target_price
+                                                mock_price_container = Mock()
+                                                mock_target = _make_mock_element()
+                                                mock_price_container.find_element.return_value = mock_target
+                                                bot.driver.find_element.return_value = mock_price_container
+                                                bot.driver.find_elements.return_value = []  # no quantity layout
 
-            result = bot.run_ticket_grabbing()
+                                                result = bot.run_ticket_grabbing()
 
         assert result is True
 
@@ -900,51 +717,25 @@ class TestRunTicketGrabbing:
         bot.config.rush_mode = True
         bot.config.if_commit_order = False
 
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(
-                bot,
-                "_enter_purchase_flow_from_detail_page",
-                return_value={
-                    "state": "sku_page",
-                    "price_container": True,
-                    "reservation_mode": False,
-                    "price_coords": (240, 1560),
-                    "buy_button_coords": (320, 1880),
-                },
-            ) as enter_purchase_flow,
-            patch.object(
-                bot, "_select_price_option", return_value=True
-            ) as select_price,
-            patch.object(bot, "_wait_for_submit_ready", return_value=True),
-            patch.object(
-                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ),
-            patch.object(bot, "_burst_click_coordinates") as burst_click_coords,
-            patch.object(bot, "ultra_fast_click", return_value=True),
-            patch.object(bot, "ultra_batch_click"),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.9)
-            mock_price_container = Mock()
-            mock_target = _make_mock_element()
-            mock_price_container.find_element.return_value = mock_target
-            bot.driver.find_element.return_value = mock_price_container
-            bot.driver.find_elements.return_value = []
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "wait_for_sale_start"):
+                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, "price_coords": (240, 1560), "buy_button_coords": (320, 1880), }, ) as enter_purchase_flow:
+                        with patch.object( bot, "_select_price_option", return_value=True ) as select_price:
+                            with patch.object(bot, "_wait_for_submit_ready", return_value=True):
+                                with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
+                                    with patch.object(bot, "_burst_click_coordinates") as burst_click_coords:
+                                        with patch.object(bot, "ultra_fast_click", return_value=True):
+                                            with patch.object(bot, "ultra_batch_click"):
+                                                with patch("mobile.damai_app.time") as mock_time:
+                                                    mock_time.time.side_effect = _make_time_side_effect(0.0, 0.9)
+                                                    mock_price_container = Mock()
+                                                    mock_target = _make_mock_element()
+                                                    mock_price_container.find_element.return_value = mock_target
+                                                    bot.driver.find_element.return_value = mock_price_container
+                                                    bot.driver.find_elements.return_value = []
 
-            result = bot.run_ticket_grabbing()
+                                                    result = bot.run_ticket_grabbing()
 
         assert result is True
         enter_purchase_flow.assert_called_once_with(prepared=False)
@@ -957,48 +748,24 @@ class TestRunTicketGrabbing:
         """if_commit_order=False waits for confirm page but never clicks submit."""
         bot.config.if_commit_order = False
 
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(
-                bot,
-                "_enter_purchase_flow_from_detail_page",
-                return_value={
-                    "state": "sku_page",
-                    "price_container": True,
-                    "reservation_mode": False,
-                },
-            ),
-            patch.object(
-                bot, "_wait_for_submit_ready", return_value=True
-            ) as wait_submit_ready,
-            patch.object(
-                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ),
-            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click,
-            patch.object(bot, "ultra_fast_click", return_value=True),
-            patch.object(bot, "ultra_batch_click"),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 1.2)
-            mock_price_container = Mock()
-            mock_target = _make_mock_element()
-            mock_price_container.find_element.return_value = mock_target
-            bot.driver.find_element.return_value = mock_price_container
-            bot.driver.find_elements.return_value = []
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "wait_for_sale_start"):
+                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
+                        with patch.object( bot, "_wait_for_submit_ready", return_value=True ) as wait_submit_ready:
+                            with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
+                                with patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click:
+                                    with patch.object(bot, "ultra_fast_click", return_value=True):
+                                        with patch.object(bot, "ultra_batch_click"):
+                                            with patch("mobile.damai_app.time") as mock_time:
+                                                mock_time.time.side_effect = _make_time_side_effect(0.0, 1.2)
+                                                mock_price_container = Mock()
+                                                mock_target = _make_mock_element()
+                                                mock_price_container.find_element.return_value = mock_target
+                                                bot.driver.find_element.return_value = mock_price_container
+                                                bot.driver.find_elements.return_value = []
 
-            result = bot.run_ticket_grabbing()
+                                                result = bot.run_ticket_grabbing()
 
         assert result is True
         wait_submit_ready.assert_called_once()
@@ -1007,46 +774,24 @@ class TestRunTicketGrabbing:
         """Commit-disabled runs should be labeled as developer validation in logs."""
         bot.config.if_commit_order = False
 
-        with (
-            caplog.at_level("INFO", logger="mobile.damai_app"),
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(
-                bot,
-                "_enter_purchase_flow_from_detail_page",
-                return_value={
-                    "state": "sku_page",
-                    "price_container": True,
-                    "reservation_mode": False,
-                },
-            ),
-            patch.object(bot, "_wait_for_submit_ready", return_value=True),
-            patch.object(
-                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ),
-            patch.object(bot, "ultra_fast_click", return_value=True),
-            patch.object(bot, "ultra_batch_click"),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
-            mock_price_container = Mock()
-            mock_target = _make_mock_element()
-            mock_price_container.find_element.return_value = mock_target
-            bot.driver.find_element.return_value = mock_price_container
-            bot.driver.find_elements.return_value = []
+        with caplog.at_level("INFO", logger="mobile.damai_app"):
+            with patch.object(bot, "dismiss_startup_popups"):
+                with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                    with patch.object(bot, "wait_for_sale_start"):
+                        with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
+                            with patch.object(bot, "_wait_for_submit_ready", return_value=True):
+                                with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
+                                    with patch.object(bot, "ultra_fast_click", return_value=True):
+                                        with patch.object(bot, "ultra_batch_click"):
+                                            with patch("mobile.damai_app.time") as mock_time:
+                                                mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
+                                                mock_price_container = Mock()
+                                                mock_target = _make_mock_element()
+                                                mock_price_container.find_element.return_value = mock_target
+                                                bot.driver.find_element.return_value = mock_price_container
+                                                bot.driver.find_elements.return_value = []
 
-            result = bot.run_ticket_grabbing()
+                                                result = bot.run_ticket_grabbing()
 
         assert result is True
         assert "开始执行开发验证" in caplog.text
@@ -1058,39 +803,23 @@ class TestRunTicketGrabbing:
         """sku_page can continue directly to confirm page without returning to detail."""
         bot.config.if_commit_order = False
 
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "sku_page",
-                    "purchase_button": False,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(
-                bot, "_wait_for_submit_ready", return_value=True
-            ) as wait_submit_ready,
-            patch.object(
-                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ),
-            patch.object(bot, "smart_wait_and_click") as smart_click,
-            patch.object(bot, "ultra_fast_click", return_value=True),
-            patch.object(bot, "ultra_batch_click"),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
-            mock_price_container = Mock()
-            mock_target = _make_mock_element()
-            mock_price_container.find_element.return_value = mock_target
-            bot.driver.find_element.return_value = mock_price_container
-            bot.driver.find_elements.return_value = []
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "wait_for_sale_start"):
+                    with patch.object( bot, "_wait_for_submit_ready", return_value=True ) as wait_submit_ready:
+                        with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
+                            with patch.object(bot, "smart_wait_and_click") as smart_click:
+                                with patch.object(bot, "ultra_fast_click", return_value=True):
+                                    with patch.object(bot, "ultra_batch_click"):
+                                        with patch("mobile.damai_app.time") as mock_time:
+                                            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
+                                            mock_price_container = Mock()
+                                            mock_target = _make_mock_element()
+                                            mock_price_container.find_element.return_value = mock_target
+                                            bot.driver.find_element.return_value = mock_price_container
+                                            bot.driver.find_elements.return_value = []
 
-            result = bot.run_ticket_grabbing()
+                                            result = bot.run_ticket_grabbing()
 
         assert result is True
         smart_click.assert_not_called()
@@ -1102,46 +831,15 @@ class TestRunTicketGrabbing:
         """Reservation-only sku pages stop safely before tapping the bottom action."""
         bot.config.if_commit_order = False
 
-        with (
-            caplog.at_level("WARNING", logger="mobile.damai_app"),
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                side_effect=[
-                    {
-                        "state": "sku_page",
-                        "purchase_button": False,
-                        "price_container": True,
-                        "quantity_picker": False,
-                        "submit_button": False,
-                        "reservation_mode": True,
-                    },
-                    {
-                        "state": "sku_page",
-                        "purchase_button": False,
-                        "price_container": True,
-                        "quantity_picker": False,
-                        "submit_button": False,
-                        "reservation_mode": True,
-                    },
-                    {
-                        "state": "sku_page",
-                        "purchase_button": False,
-                        "price_container": True,
-                        "quantity_picker": False,
-                        "submit_button": False,
-                        "reservation_mode": True,
-                    },
-                ],
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(bot, "ultra_fast_click") as fast_click,
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.return_value = 0.0
+        with caplog.at_level("WARNING", logger="mobile.damai_app"):
+            with patch.object(bot, "dismiss_startup_popups"):
+                with patch.object( bot, "probe_current_page", side_effect=[ { "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, "reservation_mode": True, }, { "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, "reservation_mode": True, }, { "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, "reservation_mode": True, }, ], ):
+                    with patch.object(bot, "wait_for_sale_start"):
+                        with patch.object(bot, "ultra_fast_click") as fast_click:
+                            with patch("mobile.damai_app.time") as mock_time:
+                                mock_time.time.return_value = 0.0
 
-            result = bot.run_ticket_grabbing()
+                                result = bot.run_ticket_grabbing()
 
         assert result is False
         assert fast_click.call_count == 1
@@ -1158,120 +856,62 @@ class TestRunTicketGrabbing:
         """Commit-disabled mode fails safely if the confirm page never becomes ready."""
         bot.config.if_commit_order = False
 
-        with (
-            caplog.at_level("WARNING", logger="mobile.damai_app"),
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(
-                bot,
-                "_enter_purchase_flow_from_detail_page",
-                return_value={
-                    "state": "sku_page",
-                    "price_container": True,
-                    "reservation_mode": False,
-                },
-            ),
-            patch.object(bot, "_wait_for_submit_ready", return_value=False),
-            patch.object(bot, "smart_wait_and_click", return_value=True),
-            patch.object(bot, "ultra_fast_click", return_value=True),
-            patch.object(bot, "ultra_batch_click", return_value=0),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_monotonic(0.0, 2.0)
-            mock_price_container = Mock()
-            mock_target = _make_mock_element()
-            mock_price_container.find_element.return_value = mock_target
-            bot.driver.find_element.return_value = mock_price_container
-            bot.driver.find_elements.return_value = []
+        with caplog.at_level("WARNING", logger="mobile.damai_app"):
+            with patch.object(bot, "dismiss_startup_popups"):
+                with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                    with patch.object(bot, "wait_for_sale_start"):
+                        with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
+                            with patch.object(bot, "_wait_for_submit_ready", return_value=False):
+                                with patch.object(bot, "smart_wait_and_click", return_value=True):
+                                    with patch.object(bot, "ultra_fast_click", return_value=True):
+                                        with patch.object(bot, "ultra_batch_click", return_value=0):
+                                            with patch("mobile.damai_app.time") as mock_time:
+                                                mock_time.time.side_effect = _make_time_monotonic(0.0, 2.0)
+                                                mock_price_container = Mock()
+                                                mock_target = _make_mock_element()
+                                                mock_price_container.find_element.return_value = mock_target
+                                                bot.driver.find_element.return_value = mock_price_container
+                                                bot.driver.find_elements.return_value = []
 
-            result = bot.run_ticket_grabbing()
+                                                result = bot.run_ticket_grabbing()
 
         assert result is False
         assert "未进入订单确认页" in caplog.text
 
     def test_run_ticket_grabbing_city_fail(self, bot):
         """City selection fails, returns False immediately."""
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(bot, "_select_city_from_detail_page", return_value=False),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.return_value = 0.0
-            result = bot.run_ticket_grabbing()
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "wait_for_sale_start"):
+                    with patch.object(bot, "_select_city_from_detail_page", return_value=False):
+                        with patch("mobile.damai_app.time") as mock_time:
+                            mock_time.time.return_value = 0.0
+                            result = bot.run_ticket_grabbing()
 
         assert result is False
 
     def test_run_ticket_grabbing_book_fail(self, bot):
         """Booking button fails, returns False."""
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(
-                bot, "_enter_purchase_flow_from_detail_page", return_value=None
-            ),
-            patch.object(bot, "ultra_batch_click"),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.return_value = 0.0
-            result = bot.run_ticket_grabbing()
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "wait_for_sale_start"):
+                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value=None ):
+                        with patch.object(bot, "ultra_batch_click"):
+                            with patch("mobile.damai_app.time") as mock_time:
+                                mock_time.time.return_value = 0.0
+                                result = bot.run_ticket_grabbing()
 
         assert result is False
 
     def test_run_ticket_grabbing_exception_returns_false(self, bot):
         """Unexpected exception in flow returns False."""
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(bot, "smart_wait_and_click", side_effect=RuntimeError("boom")),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.return_value = 0.0
-            result = bot.run_ticket_grabbing()
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "wait_for_sale_start"):
+                    with patch.object(bot, "smart_wait_and_click", side_effect=RuntimeError("boom")):
+                        with patch("mobile.damai_app.time") as mock_time:
+                            mock_time.time.return_value = 0.0
+                            result = bot.run_ticket_grabbing()
 
         assert result is False
 
@@ -1279,46 +919,24 @@ class TestRunTicketGrabbing:
         self, bot
     ):
         """Submit timeout should fail closed to avoid false success and duplicate submit."""
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(
-                bot,
-                "_enter_purchase_flow_from_detail_page",
-                return_value={
-                    "state": "sku_page",
-                    "price_container": True,
-                    "reservation_mode": False,
-                },
-            ),
-            patch.object(bot, "_wait_for_submit_ready", return_value=True),
-            patch.object(bot, "smart_wait_and_click", return_value=True),
-            patch.object(bot, "ultra_fast_click", return_value=True),
-            patch.object(bot, "ultra_batch_click"),
-            patch.object(
-                bot, "_submit_order_fast", return_value="timeout"
-            ) as submit_fast,
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
-            mock_price_container = Mock()
-            mock_target = _make_mock_element()
-            mock_price_container.find_element.return_value = mock_target
-            bot.driver.find_element.return_value = mock_price_container
-            bot.driver.find_elements.return_value = []
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "wait_for_sale_start"):
+                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
+                        with patch.object(bot, "_wait_for_submit_ready", return_value=True):
+                            with patch.object(bot, "smart_wait_and_click", return_value=True):
+                                with patch.object(bot, "ultra_fast_click", return_value=True):
+                                    with patch.object(bot, "ultra_batch_click"):
+                                        with patch.object( bot, "_submit_order_fast", return_value="timeout" ) as submit_fast:
+                                            with patch("mobile.damai_app.time") as mock_time:
+                                                mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
+                                                mock_price_container = Mock()
+                                                mock_target = _make_mock_element()
+                                                mock_price_container.find_element.return_value = mock_target
+                                                bot.driver.find_element.return_value = mock_price_container
+                                                bot.driver.find_elements.return_value = []
 
-            result = bot.run_ticket_grabbing()
+                                                result = bot.run_ticket_grabbing()
 
         assert result is False
         assert bot._terminal_failure_reason == "submit_unverified"
@@ -1328,47 +946,25 @@ class TestRunTicketGrabbing:
         self, bot
     ):
         """Existing unpaid order means submit flow already succeeded and only payment is pending."""
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(
-                bot,
-                "_enter_purchase_flow_from_detail_page",
-                return_value={
-                    "state": "sku_page",
-                    "price_container": True,
-                    "reservation_mode": False,
-                },
-            ),
-            patch.object(bot, "_wait_for_submit_ready", return_value=True),
-            patch.object(
-                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ),
-            patch.object(bot, "smart_wait_and_click", return_value=True),
-            patch.object(bot, "ultra_fast_click", return_value=True),
-            patch.object(bot, "ultra_batch_click"),
-            patch.object(bot, "_submit_order_fast", return_value="existing_order"),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
-            mock_price_container = Mock()
-            mock_target = _make_mock_element()
-            mock_price_container.find_element.return_value = mock_target
-            bot.driver.find_element.return_value = mock_price_container
-            bot.driver.find_elements.return_value = []
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "wait_for_sale_start"):
+                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
+                        with patch.object(bot, "_wait_for_submit_ready", return_value=True):
+                            with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
+                                with patch.object(bot, "smart_wait_and_click", return_value=True):
+                                    with patch.object(bot, "ultra_fast_click", return_value=True):
+                                        with patch.object(bot, "ultra_batch_click"):
+                                            with patch.object(bot, "_submit_order_fast", return_value="existing_order"):
+                                                with patch("mobile.damai_app.time") as mock_time:
+                                                    mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
+                                                    mock_price_container = Mock()
+                                                    mock_target = _make_mock_element()
+                                                    mock_price_container.find_element.return_value = mock_target
+                                                    bot.driver.find_element.return_value = mock_price_container
+                                                    bot.driver.find_elements.return_value = []
 
-            result = bot.run_ticket_grabbing()
+                                                    result = bot.run_ticket_grabbing()
 
         assert result is True
         assert bot._last_run_outcome == "order_pending_payment"
@@ -1377,24 +973,10 @@ class TestRunTicketGrabbing:
     def test_run_ticket_grabbing_returns_success_when_pending_order_dialog_detected_early(
         self, bot
     ):
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(bot, "check_session_valid", return_value=True),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "pending_order_dialog",
-                    "purchase_button": False,
-                    "price_container": False,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                    "reservation_mode": False,
-                    "pending_order_dialog": True,
-                },
-            ),
-        ):
-            result = bot.run_ticket_grabbing()
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object(bot, "check_session_valid", return_value=True):
+                with patch.object( bot, "probe_current_page", return_value={ "state": "pending_order_dialog", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, "reservation_mode": False, "pending_order_dialog": True, }, ):
+                    result = bot.run_ticket_grabbing()
 
         assert result is True
         assert bot._last_run_outcome == "order_pending_payment"
@@ -1415,37 +997,23 @@ class TestRunTicketGrabbing:
             "reservation_mode": False,
         }
 
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(bot, "check_session_valid", return_value=True),
-            patch.object(
-                bot, "probe_current_page", return_value=detail_probe
-            ) as probe_page,
-            patch.object(bot, "_prepare_detail_page_hot_path") as prepare_detail,
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(
-                bot,
-                "_enter_purchase_flow_from_detail_page",
-                return_value={
-                    "state": "sku_page",
-                    "price_container": True,
-                    "reservation_mode": False,
-                },
-            ),
-            patch.object(bot, "_select_price_option", return_value=True),
-            patch.object(bot, "_wait_for_submit_ready", return_value=True),
-            patch.object(
-                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ),
-            patch.object(bot, "_submit_order_fast", return_value="success"),
-            patch.object(bot, "ultra_fast_click", return_value=True),
-            patch.object(bot, "ultra_batch_click"),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
-            bot.driver.find_elements.return_value = []
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object(bot, "check_session_valid", return_value=True):
+                with patch.object( bot, "probe_current_page", return_value=detail_probe ) as probe_page:
+                    with patch.object(bot, "_prepare_detail_page_hot_path") as prepare_detail:
+                        with patch.object(bot, "wait_for_sale_start"):
+                            with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
+                                with patch.object(bot, "_select_price_option", return_value=True):
+                                    with patch.object(bot, "_wait_for_submit_ready", return_value=True):
+                                        with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
+                                            with patch.object(bot, "_submit_order_fast", return_value="success"):
+                                                with patch.object(bot, "ultra_fast_click", return_value=True):
+                                                    with patch.object(bot, "ultra_batch_click"):
+                                                        with patch("mobile.damai_app.time") as mock_time:
+                                                            mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
+                                                            bot.driver.find_elements.return_value = []
 
-            result = bot.run_ticket_grabbing()
+                                                            result = bot.run_ticket_grabbing()
 
         assert result is True
         assert bot._last_run_outcome == "order_submitted"
@@ -1454,25 +1022,13 @@ class TestRunTicketGrabbing:
 
     def test_run_ticket_grabbing_no_driver_quit_in_finally(self, bot):
         """Verify driver.quit is NOT called inside run_ticket_grabbing's finally block."""
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(bot, "smart_wait_and_click", return_value=False),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.return_value = 0.0
-            bot.run_ticket_grabbing()
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "wait_for_sale_start"):
+                    with patch.object(bot, "smart_wait_and_click", return_value=False):
+                        with patch("mobile.damai_app.time") as mock_time:
+                            mock_time.time.return_value = 0.0
+                            bot.run_ticket_grabbing()
 
         bot.driver.quit.assert_not_called()
 
@@ -1482,36 +1038,22 @@ class TestRunTicketGrabbing:
         """Direct jump to order confirm page should skip manual user selection."""
         bot.config.if_commit_order = False
 
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "sku_page",
-                    "purchase_button": False,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(bot, "_wait_for_submit_ready", return_value=True),
-            patch.object(
-                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ),
-            patch.object(bot, "ultra_fast_click", return_value=True),
-            patch.object(bot, "ultra_batch_click") as batch_click,
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
-            mock_price_container = Mock()
-            mock_target = _make_mock_element()
-            mock_price_container.find_element.return_value = mock_target
-            bot.driver.find_element.return_value = mock_price_container
-            bot.driver.find_elements.return_value = []
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", return_value={ "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(bot, "wait_for_sale_start"):
+                    with patch.object(bot, "_wait_for_submit_ready", return_value=True):
+                        with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
+                            with patch.object(bot, "ultra_fast_click", return_value=True):
+                                with patch.object(bot, "ultra_batch_click") as batch_click:
+                                    with patch("mobile.damai_app.time") as mock_time:
+                                        mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
+                                        mock_price_container = Mock()
+                                        mock_target = _make_mock_element()
+                                        mock_price_container.find_element.return_value = mock_target
+                                        bot.driver.find_element.return_value = mock_price_container
+                                        bot.driver.find_elements.return_value = []
 
-            result = bot.run_ticket_grabbing()
+                                        result = bot.run_ticket_grabbing()
 
         assert result is True
         batch_click.assert_not_called()
@@ -1537,13 +1079,9 @@ class TestPageStateHelpers:
 
         bot.config.keyword = "张杰 演唱会"
 
-        with (
-            patch.object(bot, "_find_all", return_value=[card]),
-            patch.object(
-                bot, "_container_find_elements", side_effect=fake_container_find
-            ),
-        ):
-            results = bot.collect_search_results()
+        with patch.object(bot, "_find_all", return_value=[card]):
+            with patch.object( bot, "_container_find_elements", side_effect=fake_container_find ):
+                results = bot.collect_search_results()
 
         assert results == [
             {
@@ -1558,11 +1096,9 @@ class TestPageStateHelpers:
         assert results[0]["score"] >= 60
 
     def test_wait_for_purchase_entry_result_detects_sku_without_full_probe(self, bot):
-        with (
-            patch.object(bot, "_has_any_element", side_effect=[False, True]),
-            patch.object(bot, "is_reservation_sku_mode", return_value=False),
-        ):
-            result = bot._wait_for_purchase_entry_result(timeout=0.2, poll_interval=0)
+        with patch.object(bot, "_has_any_element", side_effect=[False, True]):
+            with patch.object(bot, "is_reservation_sku_mode", return_value=False):
+                result = bot._wait_for_purchase_entry_result(timeout=0.2, poll_interval=0)
 
         assert result["state"] == "sku_page"
         assert result["reservation_mode"] is False
@@ -1570,15 +1106,13 @@ class TestPageStateHelpers:
     def test_wait_for_purchase_entry_result_returns_none_without_fallback_probe(
         self, bot
     ):
-        with (
-            patch.object(bot, "_has_any_element", return_value=False),
-            patch.object(bot, "probe_current_page") as probe,
-        ):
-            result = bot._wait_for_purchase_entry_result(
-                timeout=0.01,
-                poll_interval=0,
-                fallback_probe_on_timeout=False,
-            )
+        with patch.object(bot, "_has_any_element", return_value=False):
+            with patch.object(bot, "probe_current_page") as probe:
+                result = bot._wait_for_purchase_entry_result(
+                    timeout=0.01,
+                    poll_interval=0,
+                    fallback_probe_on_timeout=False,
+                )
 
         assert result is None
         probe.assert_not_called()
@@ -1617,23 +1151,15 @@ class TestPageStateHelpers:
             "buy_button_coords": (540, 2100),
         }
 
-        with (
-            patch.object(bot, "_select_price_option", return_value=True),
-            patch.object(bot, "_has_element", return_value=False),
-            patch.object(
-                bot, "_wait_for_submit_ready", side_effect=[False, True]
-            ) as wait_ready,
-            patch.object(
-                bot, "_click_sku_buy_button_element", return_value=True
-            ) as element_click,
-            patch.object(bot, "_burst_click_coordinates") as burst_click,
-            patch.object(
-                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ),
-            patch("mobile.damai_app.time.sleep"),
-            patch("mobile.damai_app.time.time", side_effect=_make_time_monotonic()),
-        ):
-            assert bot.run_ticket_grabbing(initial_page_probe=initial_probe) is True
+        with patch.object(bot, "_select_price_option", return_value=True):
+            with patch.object(bot, "_has_element", return_value=False):
+                with patch.object( bot, "_wait_for_submit_ready", side_effect=[False, True] ) as wait_ready:
+                    with patch.object( bot, "_click_sku_buy_button_element", return_value=True ) as element_click:
+                        with patch.object(bot, "_burst_click_coordinates") as burst_click:
+                            with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
+                                with patch("mobile.damai_app.time.sleep"):
+                                    with patch("mobile.damai_app.time.time", side_effect=_make_time_monotonic()):
+                                        assert bot.run_ticket_grabbing(initial_page_probe=initial_probe) is True
 
         assert wait_ready.call_count == 2
         burst_click.assert_called_once_with(
@@ -1652,23 +1178,11 @@ class TestPageStateHelpers:
             checked_state["value"] = "true"
             return True
 
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: 'textContains("实名观演人")' in value,
-            ),
-            patch.object(bot, "_attendee_checkbox_elements", return_value=[checkbox]),
-            patch.object(
-                bot, "_attendee_required_count_on_confirm_page", return_value=1
-            ),
-            patch.object(
-                bot,
-                "_select_attendee_checkbox_by_name",
-                side_effect=_select_side_effect,
-            ),
-        ):
-            assert bot._ensure_attendees_selected_on_confirm_page() is True
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: 'textContains("实名观演人")' in value, ):
+            with patch.object(bot, "_attendee_checkbox_elements", return_value=[checkbox]):
+                with patch.object( bot, "_attendee_required_count_on_confirm_page", return_value=1 ):
+                    with patch.object( bot, "_select_attendee_checkbox_by_name", side_effect=_select_side_effect, ):
+                        assert bot._ensure_attendees_selected_on_confirm_page() is True
 
     def test_attendee_selected_count_falls_back_to_page_source(self, bot):
         checkbox = Mock(spec=[])
@@ -1688,15 +1202,11 @@ class TestPageStateHelpers:
         checkbox = Mock()
         checkbox.click = Mock()
 
-        with (
-            patch.object(
-                bot, "_click_element_center", side_effect=Exception("center failed")
-            ),
-            patch.object(bot, "_burst_click_element_center", return_value=None),
-            patch.object(bot, "_is_checkbox_selected", return_value=False),
-            patch.object(bot, "_attendee_selected_count", side_effect=[0, 1]),
-        ):
-            assert bot._click_attendee_checkbox(checkbox) is True
+        with patch.object( bot, "_click_element_center", side_effect=Exception("center failed") ):
+            with patch.object(bot, "_burst_click_element_center", return_value=None):
+                with patch.object(bot, "_is_checkbox_selected", return_value=False):
+                    with patch.object(bot, "_attendee_selected_count", side_effect=[0, 1]):
+                        assert bot._click_attendee_checkbox(checkbox) is True
 
         checkbox.click.assert_called_once()
 
@@ -1712,14 +1222,10 @@ class TestPageStateHelpers:
                 return [checkbox]
             return []
 
-        with (
-            patch.object(bot, "_find_all", side_effect=_find_all_side_effect),
-            patch.object(bot, "_is_checkbox_selected", return_value=False),
-            patch.object(
-                bot, "_click_attendee_checkbox", return_value=True
-            ) as click_checkbox,
-        ):
-            assert bot._select_attendee_checkbox_by_name("张志涛") is True
+        with patch.object(bot, "_find_all", side_effect=_find_all_side_effect):
+            with patch.object(bot, "_is_checkbox_selected", return_value=False):
+                with patch.object( bot, "_click_attendee_checkbox", return_value=True ) as click_checkbox:
+                    assert bot._select_attendee_checkbox_by_name("张志涛") is True
 
         assert any("contains(normalize-space(@text)" in xpath for xpath in seen_xpaths)
         click_checkbox.assert_called_once_with(checkbox)
@@ -1727,15 +1233,9 @@ class TestPageStateHelpers:
     def test_ensure_attendees_selected_fails_when_section_visible_but_no_checkbox(
         self, bot
     ):
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: 'textContains("实名观演人")' in value,
-            ),
-            patch.object(bot, "_attendee_checkbox_elements", return_value=[]),
-        ):
-            assert bot._ensure_attendees_selected_on_confirm_page() is False
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: 'textContains("实名观演人")' in value, ):
+            with patch.object(bot, "_attendee_checkbox_elements", return_value=[]):
+                assert bot._ensure_attendees_selected_on_confirm_page() is False
 
     def test_ensure_attendees_polls_for_checkbox_in_rush_dev_mode(self, bot):
         """When rush_mode + dev validation, poll for checkbox elements instead of failing immediately."""
@@ -1757,19 +1257,15 @@ class TestPageStateHelpers:
                 return []
             return [checkbox1, checkbox2]
 
-        with (
-            patch.object(
-                bot, "_attendee_checkbox_elements", side_effect=_delayed_checkbox
-            ),
-            patch.object(bot, "_attendee_selected_count", return_value=0),
-            patch.object(bot, "_click_attendee_checkbox_fast", return_value=True),
-        ):
-            assert (
-                bot._ensure_attendees_selected_on_confirm_page(
-                    require_attendee_section=True
-                )
-                is True
-            )
+        with patch.object( bot, "_attendee_checkbox_elements", side_effect=_delayed_checkbox ):
+            with patch.object(bot, "_attendee_selected_count", return_value=0):
+                with patch.object(bot, "_click_attendee_checkbox_fast", return_value=True):
+                    assert (
+                        bot._ensure_attendees_selected_on_confirm_page(
+                            require_attendee_section=True
+                        )
+                        is True
+                    )
         assert call_count["n"] >= 3
 
     def test_get_buy_button_coordinates_returns_first_match_center(self, bot):
@@ -1807,23 +1303,11 @@ class TestPageStateHelpers:
                 return [card_a, card_b]
             return []
 
-        with (
-            patch.object(bot, "_find", return_value=price_container),
-            patch.object(
-                bot, "_container_find_elements", side_effect=fake_container_find
-            ),
-            patch.object(bot, "_is_clickable", return_value=True),
-            patch.object(
-                bot,
-                "_collect_descendant_texts",
-                side_effect=lambda c, **kw: (
-                    ["内场", "1280", "可预约"]
-                    if c is card_a
-                    else ["看台", "380", "无票"]
-                ),
-            ),
-        ):
-            options = bot.get_visible_price_options()
+        with patch.object(bot, "_find", return_value=price_container):
+            with patch.object( bot, "_container_find_elements", side_effect=fake_container_find ):
+                with patch.object(bot, "_is_clickable", return_value=True):
+                    with patch.object( bot, "_collect_descendant_texts", side_effect=lambda c, **kw: ( ["内场", "1280", "可预约"] if c is card_a else ["看台", "380", "无票"] ), ):
+                        options = bot.get_visible_price_options()
 
         assert options == [
             {
@@ -1844,17 +1328,13 @@ class TestPageStateHelpers:
 
     def test_purchase_bar_text_ready_distinguishes_reservation_from_purchase(self, bot):
         purchase_bar = Mock()
-        with (
-            patch.object(bot.driver, "find_element", return_value=purchase_bar),
-            patch.object(bot, "_collect_descendant_texts", return_value=["立即购买"]),
-        ):
-            assert bot._purchase_bar_text_ready() is True
+        with patch.object(bot.driver, "find_element", return_value=purchase_bar):
+            with patch.object(bot, "_collect_descendant_texts", return_value=["立即购买"]):
+                assert bot._purchase_bar_text_ready() is True
 
-        with (
-            patch.object(bot.driver, "find_element", return_value=purchase_bar),
-            patch.object(bot, "_collect_descendant_texts", return_value=["抢票预约"]),
-        ):
-            assert bot._purchase_bar_text_ready() is False
+        with patch.object(bot.driver, "find_element", return_value=purchase_bar):
+            with patch.object(bot, "_collect_descendant_texts", return_value=["抢票预约"]):
+                assert bot._purchase_bar_text_ready() is False
 
     def test_normalize_ocr_price_text(self, bot):
         assert bot._normalize_ocr_price_text("38075 Fam ©") == "380元"
@@ -1903,12 +1383,10 @@ class TestPageStateHelpers:
                 return Mock(stdout=b"13803\n", stderr=b"", returncode=0)
             raise AssertionError(cmd)
 
-        with (
-            patch("mobile.price_selector._MAGICK_BIN", "magick"),
-            patch("mobile.price_selector._TESSERACT_BIN", "tesseract"),
-            patch("mobile.price_selector.subprocess.run", side_effect=fake_run) as run,
-        ):
-            result = bot._ocr_price_text_from_card("/tmp/sku.png", rect)
+        with patch("mobile.price_selector._MAGICK_BIN", "magick"):
+            with patch("mobile.price_selector._TESSERACT_BIN", "tesseract"):
+                with patch("mobile.price_selector.subprocess.run", side_effect=fake_run) as run:
+                    result = bot._ocr_price_text_from_card("/tmp/sku.png", rect)
 
         assert result == "1380元"
         first_magick_cmd = run.call_args_list[0][0][0]
@@ -1918,45 +1396,27 @@ class TestPageStateHelpers:
         assert first_tesseract_cmd[first_tesseract_cmd.index("--psm") + 1] == "13"
 
     def test_probe_current_page_detects_homepage(self, bot):
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: (
-                    (by, value) == (By.ID, "cn.damai:id/homepage_header_search")
-                ),
-            ),
-            patch.object(bot, "_get_current_activity", return_value=""),
-        ):
-            result = bot._probe_current_page_element_based()
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: ( (by, value) == (By.ID, "cn.damai:id/homepage_header_search") ), ):
+            with patch.object(bot, "_get_current_activity", return_value=""):
+                result = bot._probe_current_page_element_based()
 
-            assert result["state"] == "homepage"
-            assert result["purchase_button"] is False
+                assert result["state"] == "homepage"
+                assert result["purchase_button"] is False
 
     def test_probe_current_page_detects_homepage_by_activity(self, bot):
-        with (
-            patch.object(bot, "_has_element", return_value=False),
-            patch.object(
-                bot, "_get_current_activity", return_value=".homepage.MainActivity"
-            ),
-        ):
-            result = bot._probe_current_page_element_based()
+        with patch.object(bot, "_has_element", return_value=False):
+            with patch.object( bot, "_get_current_activity", return_value=".homepage.MainActivity" ):
+                result = bot._probe_current_page_element_based()
 
-            assert result["state"] == "homepage"
+                assert result["state"] == "homepage"
 
     def test_probe_current_page_detects_search_activity(self, bot):
-        with (
-            patch.object(bot, "_has_element", return_value=False),
-            patch.object(
-                bot,
-                "_get_current_activity",
-                return_value="com.alibaba.pictures.bricks.search.v2.SearchActivity",
-            ),
-        ):
-            result = bot._probe_current_page_element_based()
+        with patch.object(bot, "_has_element", return_value=False):
+            with patch.object( bot, "_get_current_activity", return_value="com.alibaba.pictures.bricks.search.v2.SearchActivity", ):
+                result = bot._probe_current_page_element_based()
 
-            assert result["state"] == "search_page"
-            assert result["purchase_button"] is False
+                assert result["state"] == "search_page"
+                assert result["purchase_button"] is False
 
     def test_probe_current_page_detects_detail_page_by_activity_and_summary_price(
         self, bot
@@ -1965,23 +1425,13 @@ class TestPageStateHelpers:
             (By.ID, "cn.damai:id/project_detail_price_layout"),
         }
 
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: (by, value) in present,
-            ),
-            patch.object(
-                bot,
-                "_get_current_activity",
-                return_value=".trade.newtradeorder.ui.projectdetail.ui.activity.ProjectDetailActivity",
-            ),
-        ):
-            result = bot._probe_current_page_element_based()
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+            with patch.object( bot, "_get_current_activity", return_value=".trade.newtradeorder.ui.projectdetail.ui.activity.ProjectDetailActivity", ):
+                result = bot._probe_current_page_element_based()
 
-            assert result["state"] == "detail_page"
-            assert result["purchase_button"] is False
-            assert result["price_container"] is True
+                assert result["state"] == "detail_page"
+                assert result["purchase_button"] is False
+                assert result["price_container"] is True
 
     def test_probe_current_page_detects_sku_page(self, bot):
         present = {
@@ -1989,23 +1439,13 @@ class TestPageStateHelpers:
             (By.ID, "cn.damai:id/layout_sku"),
         }
 
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: (by, value) in present,
-            ),
-            patch.object(
-                bot,
-                "_get_current_activity",
-                return_value=".commonbusiness.seatbiz.sku.qilin.ui.NcovSkuActivity",
-            ),
-        ):
-            result = bot._probe_current_page_element_based()
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+            with patch.object( bot, "_get_current_activity", return_value=".commonbusiness.seatbiz.sku.qilin.ui.NcovSkuActivity", ):
+                result = bot._probe_current_page_element_based()
 
-            assert result["state"] == "sku_page"
-            assert result["price_container"] is True
-            assert result["reservation_mode"] is False
+                assert result["state"] == "sku_page"
+                assert result["price_container"] is True
+                assert result["reservation_mode"] is False
 
     def test_probe_current_page_marks_reservation_mode_for_reservation_sku(self, bot):
         present = {
@@ -2014,37 +1454,21 @@ class TestPageStateHelpers:
             (ANDROID_UIAUTOMATOR, 'new UiSelector().text("预约想看场次")'),
         }
 
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: (by, value) in present,
-            ),
-            patch.object(
-                bot,
-                "_get_current_activity",
-                return_value=".commonbusiness.seatbiz.sku.qilin.ui.NcovSkuActivity",
-            ),
-        ):
-            result = bot._probe_current_page_element_based()
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+            with patch.object( bot, "_get_current_activity", return_value=".commonbusiness.seatbiz.sku.qilin.ui.NcovSkuActivity", ):
+                result = bot._probe_current_page_element_based()
 
-            assert result["state"] == "sku_page"
-            assert result["reservation_mode"] is True
+                assert result["state"] == "sku_page"
+                assert result["reservation_mode"] is True
 
     def test_probe_current_page_detects_pending_order_dialog(self, bot):
         present = {
             (By.ID, "cn.damai:id/damai_theme_dialog_confirm_btn"),
         }
 
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: (by, value) in present,
-            ),
-            patch.object(bot, "_get_current_activity", return_value=""),
-        ):
-            result = bot._probe_current_page_element_based()
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+            with patch.object(bot, "_get_current_activity", return_value=""):
+                result = bot._probe_current_page_element_based()
 
         assert result["state"] == "pending_order_dialog"
         assert result["pending_order_dialog"] is True
@@ -2060,21 +1484,15 @@ class TestPageStateHelpers:
             (By.ID, "cn.damai:id/checkbox"),
         }
 
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: (by, value) in present,
-            ),
-            patch.object(bot, "_get_current_activity", return_value=""),
-        ):
-            result = bot._probe_current_page_element_based()
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+            with patch.object(bot, "_get_current_activity", return_value=""):
+                result = bot._probe_current_page_element_based()
 
-            assert result["state"] == "order_confirm_page"
-            assert result["purchase_button"] is True
-            assert result["price_container"] is True
-            assert result["quantity_picker"] is True
-            assert result["submit_button"] is True
+                assert result["state"] == "order_confirm_page"
+                assert result["purchase_button"] is True
+                assert result["price_container"] is True
+                assert result["quantity_picker"] is True
+                assert result["submit_button"] is True
 
     def test_dismiss_startup_popups_clicks_known_popups(self, bot):
         present = {
@@ -2086,32 +1504,26 @@ class TestPageStateHelpers:
             (ANDROID_UIAUTOMATOR, 'new UiSelector().text("下次再说")'),
         }
 
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: (by, value) in present,
-            ),
-            patch.object(bot, "ultra_fast_click", return_value=True) as fast_click,
-            patch("mobile.damai_app.time.sleep"),
-        ):
-            result = bot.dismiss_startup_popups()
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+            with patch.object(bot, "ultra_fast_click", return_value=True) as fast_click:
+                with patch("mobile.damai_app.time.sleep"):
+                    result = bot.dismiss_startup_popups()
 
-            assert result is True
-            fast_click.assert_any_call(By.ID, "android:id/ok")
-            fast_click.assert_any_call(By.ID, "cn.damai:id/id_boot_action_agree")
-            fast_click.assert_any_call(
-                By.ID, "cn.damai:id/damai_theme_dialog_cancel_btn"
-            )
-            fast_click.assert_any_call(
-                By.ID, "cn.damai:id/damai_theme_dialog_close_layout"
-            )
-            fast_click.assert_any_call(
-                ANDROID_UIAUTOMATOR, 'new UiSelector().text("Cancel")'
-            )
-            fast_click.assert_any_call(
-                ANDROID_UIAUTOMATOR, 'new UiSelector().text("下次再说")'
-            )
+                    assert result is True
+                    fast_click.assert_any_call(By.ID, "android:id/ok")
+                    fast_click.assert_any_call(By.ID, "cn.damai:id/id_boot_action_agree")
+                    fast_click.assert_any_call(
+                        By.ID, "cn.damai:id/damai_theme_dialog_cancel_btn"
+                    )
+                    fast_click.assert_any_call(
+                        By.ID, "cn.damai:id/damai_theme_dialog_close_layout"
+                    )
+                    fast_click.assert_any_call(
+                        ANDROID_UIAUTOMATOR, 'new UiSelector().text("Cancel")'
+                    )
+                    fast_click.assert_any_call(
+                        ANDROID_UIAUTOMATOR, 'new UiSelector().text("下次再说")'
+                    )
 
     def test_dismiss_fast_blocking_dialogs_handles_realname_tip(self, bot):
         present = {
@@ -2119,16 +1531,10 @@ class TestPageStateHelpers:
             (ANDROID_UIAUTOMATOR, 'new UiSelector().text("知道了")'),
         }
 
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: (by, value) in present,
-            ),
-            patch.object(bot, "ultra_fast_click", return_value=True) as fast_click,
-            patch("mobile.damai_app.time.sleep"),
-        ):
-            assert bot._dismiss_fast_blocking_dialogs() is True
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+            with patch.object(bot, "ultra_fast_click", return_value=True) as fast_click:
+                with patch("mobile.damai_app.time.sleep"):
+                    assert bot._dismiss_fast_blocking_dialogs() is True
 
         fast_click.assert_any_call(
             By.ID, "cn.damai:id/damai_theme_dialog_cancel_btn", timeout=0.15
@@ -2148,48 +1554,40 @@ class TestPageStateHelpers:
 class TestRunWithRetry:
     def test_run_with_retry_success_first_attempt(self, bot):
         """Succeeds on first attempt, returns True immediately."""
-        with (
-            patch.object(bot, "run_ticket_grabbing", return_value=True),
-            patch("mobile.damai_app.time"),
-        ):
-            result = bot.run_with_retry(max_retries=3)
+        with patch.object(bot, "run_ticket_grabbing", return_value=True):
+            with patch("mobile.damai_app.time"):
+                result = bot.run_with_retry(max_retries=3)
 
         assert result is True
 
     def test_run_with_retry_success_second_attempt(self, bot):
         """Fails once, sets up driver again, succeeds second time."""
-        with (
-            patch.object(bot, "run_ticket_grabbing", side_effect=[False, True]),
-            patch.object(bot, "_fast_retry_from_current_state", return_value=False),
-            patch.object(bot, "_setup_driver") as mock_setup,
-            patch("mobile.damai_app.time"),
-        ):
-            result = bot.run_with_retry(max_retries=3)
+        with patch.object(bot, "run_ticket_grabbing", side_effect=[False, True]):
+            with patch.object(bot, "_fast_retry_from_current_state", return_value=False):
+                with patch.object(bot, "_setup_driver") as mock_setup:
+                    with patch("mobile.damai_app.time"):
+                        result = bot.run_with_retry(max_retries=3)
 
         assert result is True
         mock_setup.assert_called_once()
 
     def test_run_with_retry_all_fail(self, bot):
         """All retries fail, returns False."""
-        with (
-            patch.object(bot, "run_ticket_grabbing", return_value=False),
-            patch.object(bot, "_fast_retry_from_current_state", return_value=False),
-            patch.object(bot, "_setup_driver"),
-            patch("mobile.damai_app.time"),
-        ):
-            result = bot.run_with_retry(max_retries=3)
+        with patch.object(bot, "run_ticket_grabbing", return_value=False):
+            with patch.object(bot, "_fast_retry_from_current_state", return_value=False):
+                with patch.object(bot, "_setup_driver"):
+                    with patch("mobile.damai_app.time"):
+                        result = bot.run_with_retry(max_retries=3)
 
         assert result is False
 
     def test_run_with_retry_driver_quit_between_retries(self, bot):
         """Between retries, driver.quit and _setup_driver are called."""
-        with (
-            patch.object(bot, "run_ticket_grabbing", side_effect=[False, False, True]),
-            patch.object(bot, "_fast_retry_from_current_state", return_value=False),
-            patch.object(bot, "_setup_driver") as mock_setup,
-            patch("mobile.damai_app.time"),
-        ):
-            bot.run_with_retry(max_retries=3)
+        with patch.object(bot, "run_ticket_grabbing", side_effect=[False, False, True]):
+            with patch.object(bot, "_fast_retry_from_current_state", return_value=False):
+                with patch.object(bot, "_setup_driver") as mock_setup:
+                    with patch("mobile.damai_app.time"):
+                        bot.run_with_retry(max_retries=3)
 
         # quit called before each retry (2 failures, but last one succeeds so only 2 quit calls)
         assert bot.driver.quit.call_count == 2
@@ -2199,43 +1597,33 @@ class TestRunWithRetry:
         """driver.quit raises an exception, handled by except block."""
         bot.driver.quit.side_effect = Exception("quit failed")
 
-        with (
-            patch.object(bot, "run_ticket_grabbing", side_effect=[False, True]),
-            patch.object(bot, "_setup_driver") as mock_setup,
-            patch.object(bot, "_fast_retry_from_current_state", return_value=False),
-            patch("mobile.damai_app.time"),
-        ):
-            result = bot.run_with_retry(max_retries=3)
+        with patch.object(bot, "run_ticket_grabbing", side_effect=[False, True]):
+            with patch.object(bot, "_setup_driver") as mock_setup:
+                with patch.object(bot, "_fast_retry_from_current_state", return_value=False):
+                    with patch("mobile.damai_app.time"):
+                        result = bot.run_with_retry(max_retries=3)
 
         # Despite quit failure, retry continued and succeeded
         assert result is True
 
     def test_run_with_retry_uses_fast_retry(self, bot):
         """Verify fast retry is attempted before driver recreation."""
-        with (
-            patch.object(bot, "run_ticket_grabbing", side_effect=[False, False]),
-            patch.object(
-                bot, "_fast_retry_from_current_state", return_value=False
-            ) as fast_retry,
-            patch.object(bot, "_setup_driver"),
-            patch("mobile.damai_app.time"),
-        ):
-            bot.run_with_retry(max_retries=2)
+        with patch.object(bot, "run_ticket_grabbing", side_effect=[False, False]):
+            with patch.object( bot, "_fast_retry_from_current_state", return_value=False ) as fast_retry:
+                with patch.object(bot, "_setup_driver"):
+                    with patch("mobile.damai_app.time"):
+                        bot.run_with_retry(max_retries=2)
 
         # fast_retry called fast_retry_count times per failed attempt
         assert fast_retry.call_count == bot.config.fast_retry_count * 2
 
     def test_run_with_retry_first_fast_retry_has_no_extra_sleep(self, bot):
         """The first fast retry should execute immediately after a failed attempt."""
-        with (
-            patch.object(bot, "run_ticket_grabbing", return_value=False),
-            patch.object(
-                bot, "_fast_retry_from_current_state", side_effect=[False, True]
-            ),
-            patch.object(bot, "_setup_driver"),
-            patch("mobile.damai_app.time.sleep") as mock_sleep,
-        ):
-            result = bot.run_with_retry(max_retries=1)
+        with patch.object(bot, "run_ticket_grabbing", return_value=False):
+            with patch.object( bot, "_fast_retry_from_current_state", side_effect=[False, True] ):
+                with patch.object(bot, "_setup_driver"):
+                    with patch("mobile.damai_app.time.sleep") as mock_sleep:
+                        result = bot.run_with_retry(max_retries=1)
 
         assert result is True
         mock_sleep.assert_called_once_with(bot.config.fast_retry_interval_ms / 1000)
@@ -2244,13 +1632,11 @@ class TestRunWithRetry:
         """Manual-start mode keeps the driver session instead of rebuilding it."""
         bot.config.auto_navigate = False
 
-        with (
-            patch.object(bot, "run_ticket_grabbing", side_effect=[False, False]),
-            patch.object(bot, "_fast_retry_from_current_state", return_value=False),
-            patch.object(bot, "_setup_driver") as mock_setup,
-            patch("mobile.damai_app.time"),
-        ):
-            result = bot.run_with_retry(max_retries=2)
+        with patch.object(bot, "run_ticket_grabbing", side_effect=[False, False]):
+            with patch.object(bot, "_fast_retry_from_current_state", return_value=False):
+                with patch.object(bot, "_setup_driver") as mock_setup:
+                    with patch("mobile.damai_app.time"):
+                        result = bot.run_with_retry(max_retries=2)
 
         assert result is False
         bot.driver.quit.assert_not_called()
@@ -2261,12 +1647,10 @@ class TestRunWithRetry:
         bot.config.probe_only = True
         bot._last_run_outcome = "probe_ready"
 
-        with (
-            caplog.at_level("INFO", logger="mobile.damai_app"),
-            patch.object(bot, "run_ticket_grabbing", return_value=True),
-            patch("mobile.damai_app.time"),
-        ):
-            result = bot.run_with_retry(max_retries=1)
+        with caplog.at_level("INFO", logger="mobile.damai_app"):
+            with patch.object(bot, "run_ticket_grabbing", return_value=True):
+                with patch("mobile.damai_app.time"):
+                    result = bot.run_with_retry(max_retries=1)
 
         assert result is True
         assert "探测成功" in caplog.text
@@ -2277,12 +1661,10 @@ class TestRunWithRetry:
         bot.config.if_commit_order = False
         bot._last_run_outcome = "validation_ready"
 
-        with (
-            caplog.at_level("INFO", logger="mobile.damai_app"),
-            patch.object(bot, "run_ticket_grabbing", return_value=True),
-            patch("mobile.damai_app.time"),
-        ):
-            result = bot.run_with_retry(max_retries=1)
+        with caplog.at_level("INFO", logger="mobile.damai_app"):
+            with patch.object(bot, "run_ticket_grabbing", return_value=True):
+                with patch("mobile.damai_app.time"):
+                    result = bot.run_with_retry(max_retries=1)
 
         assert result is True
         assert "开发验证成功：已到订单确认页，未提交订单" in caplog.text
@@ -2291,12 +1673,10 @@ class TestRunWithRetry:
         """Actual order submission keeps the purchase-success wording."""
         bot._last_run_outcome = "order_submitted"
 
-        with (
-            caplog.at_level("INFO", logger="mobile.damai_app"),
-            patch.object(bot, "run_ticket_grabbing", return_value=True),
-            patch("mobile.damai_app.time"),
-        ):
-            result = bot.run_with_retry(max_retries=1)
+        with caplog.at_level("INFO", logger="mobile.damai_app"):
+            with patch.object(bot, "run_ticket_grabbing", return_value=True):
+                with patch("mobile.damai_app.time"):
+                    result = bot.run_with_retry(max_retries=1)
 
         assert result is True
         assert "抢票成功：已提交订单" in caplog.text
@@ -2344,14 +1724,12 @@ class TestWaitForSaleStart:
             # During polling, return past the sale time
             return future_time + timedelta(seconds=1)
 
-        with (
-            patch("mobile.damai_app.datetime") as mock_dt,
-            patch("mobile.damai_app.time.sleep") as mock_sleep,
-            patch.object(bot, "_has_element", return_value=True),
-        ):
-            mock_dt.fromisoformat = datetime.fromisoformat
-            mock_dt.now = mock_now
-            bot.wait_for_sale_start()
+        with patch("mobile.damai_app.datetime") as mock_dt:
+            with patch("mobile.damai_app.time.sleep") as mock_sleep:
+                with patch.object(bot, "_has_element", return_value=True):
+                    mock_dt.fromisoformat = datetime.fromisoformat
+                    mock_dt.now = mock_now
+                    bot.wait_for_sale_start()
 
         # Should have slept for the wait period (10s - 3s lead = 7s)
         assert mock_sleep.call_count >= 1
@@ -2363,12 +1741,10 @@ class TestWaitForSaleStart:
         bot.config.sell_start_time = None
         bot.config.wait_cta_ready_timeout_ms = 5000
 
-        with (
-            patch("mobile.damai_app.logger") as mock_logger,
-            patch("mobile.damai_app.time.sleep") as mock_sleep,
-            patch.object(bot, "_is_sale_ready") as is_ready,
-        ):
-            bot.wait_for_sale_start()
+        with patch("mobile.damai_app.logger") as mock_logger:
+            with patch("mobile.damai_app.time.sleep") as mock_sleep:
+                with patch.object(bot, "_is_sale_ready") as is_ready:
+                    bot.wait_for_sale_start()
 
         is_ready.assert_not_called()
         mock_sleep.assert_not_called()
@@ -2382,47 +1758,29 @@ class TestWaitForSaleStart:
         bot.config.sell_start_time = None
         bot.config.wait_cta_ready_timeout_ms = 100
 
-        with (
-            patch("mobile.damai_app.logger"),
-            patch("mobile.damai_app.time.sleep") as mock_sleep,
-            patch.object(bot, "_is_sale_ready") as is_ready,
-        ):
-            bot.wait_for_sale_start()
+        with patch("mobile.damai_app.logger"):
+            with patch("mobile.damai_app.time.sleep") as mock_sleep:
+                with patch.object(bot, "_is_sale_ready") as is_ready:
+                    bot.wait_for_sale_start()
 
         is_ready.assert_not_called()
         mock_sleep.assert_not_called()
 
     def test_prepare_detail_page_hot_path_preselects_date_and_city(self, bot):
-        with (
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "select_performance_date") as select_date,
-            patch.object(
-                bot, "_select_city_from_detail_page", return_value=True
-            ) as select_city,
-        ):
-            result = bot._prepare_detail_page_hot_path()
+        with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(bot, "select_performance_date") as select_date:
+                with patch.object( bot, "_select_city_from_detail_page", return_value=True ) as select_city:
+                    result = bot._prepare_detail_page_hot_path()
 
         assert result is True
         select_date.assert_called_once()
         select_city.assert_called_once_with(timeout=0.6)
 
     def test_prepare_detail_page_hot_path_returns_false_outside_detail_page(self, bot):
-        with (
-            patch.object(bot, "probe_current_page", return_value={"state": "homepage"}),
-            patch.object(bot, "select_performance_date") as select_date,
-            patch.object(bot, "_select_city_from_detail_page") as select_city,
-        ):
-            result = bot._prepare_detail_page_hot_path()
+        with patch.object(bot, "probe_current_page", return_value={"state": "homepage"}):
+            with patch.object(bot, "select_performance_date") as select_date:
+                with patch.object(bot, "_select_city_from_detail_page") as select_city:
+                    result = bot._prepare_detail_page_hot_path()
 
         assert result is False
         select_date.assert_not_called()
@@ -2448,13 +1806,9 @@ class TestDetailPagePurchaseEntry:
         )
 
     def test_enter_purchase_flow_returns_none_when_city_selection_fails(self, bot):
-        with (
-            patch.object(bot, "select_performance_date") as select_date,
-            patch.object(
-                bot, "_select_city_from_detail_page", return_value=False
-            ) as select_city,
-        ):
-            result = bot._enter_purchase_flow_from_detail_page(prepared=False)
+        with patch.object(bot, "select_performance_date") as select_date:
+            with patch.object( bot, "_select_city_from_detail_page", return_value=False ) as select_city:
+                result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         assert result is None
         select_date.assert_called_once()
@@ -2466,14 +1820,10 @@ class TestDetailPagePurchaseEntry:
         bot.config.rush_mode = True
         next_probe = {"state": "sku_page", "reservation_mode": False}
 
-        with (
-            patch.object(bot, "_cached_tap", return_value=False),
-            patch.object(bot, "smart_wait_and_click", return_value=True),
-            patch.object(
-                bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ),
-        ):
-            result = bot._enter_purchase_flow_from_detail_page(prepared=False)
+        with patch.object(bot, "_cached_tap", return_value=False):
+            with patch.object(bot, "smart_wait_and_click", return_value=True):
+                with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ):
+                    result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         assert result == next_probe
 
@@ -2481,13 +1831,9 @@ class TestDetailPagePurchaseEntry:
         bot.config.rush_mode = True
         next_probe = {"state": "sku_page", "reservation_mode": False}
 
-        with (
-            patch.object(bot, "_cached_tap", return_value=True) as cached_tap,
-            patch.object(
-                bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ) as wait_result,
-        ):
-            result = bot._enter_purchase_flow_from_detail_page(prepared=True)
+        with patch.object(bot, "_cached_tap", return_value=True) as cached_tap:
+            with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ) as wait_result:
+                result = bot._enter_purchase_flow_from_detail_page(prepared=True)
 
         assert result == next_probe
         cached_tap.assert_called()
@@ -2496,25 +1842,19 @@ class TestDetailPagePurchaseEntry:
     def test_enter_purchase_flow_falls_back_to_book_selectors(self, bot):
         next_probe = {"state": "order_confirm_page", "submit_button": True}
 
-        with (
-            patch.object(bot, "ultra_fast_click", return_value=False),
-            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click,
-            patch.object(
-                bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ) as wait_result,
-        ):
-            result = bot._enter_purchase_flow_from_detail_page(prepared=True)
+        with patch.object(bot, "ultra_fast_click", return_value=False):
+            with patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click:
+                with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ) as wait_result:
+                    result = bot._enter_purchase_flow_from_detail_page(prepared=True)
 
         assert result == next_probe
         smart_click.assert_called_once()
         wait_result.assert_called_once_with(timeout=5, poll_interval=0.08)
 
     def test_enter_purchase_flow_returns_none_when_all_clicks_fail(self, bot):
-        with (
-            patch.object(bot, "ultra_fast_click", return_value=False),
-            patch.object(bot, "smart_wait_and_click", return_value=False),
-        ):
-            result = bot._enter_purchase_flow_from_detail_page(prepared=True)
+        with patch.object(bot, "ultra_fast_click", return_value=False):
+            with patch.object(bot, "smart_wait_and_click", return_value=False):
+                result = bot._enter_purchase_flow_from_detail_page(prepared=True)
 
         assert result is None
 
@@ -2528,11 +1868,9 @@ class TestSaleReadiness:
         self, bot
     ):
         purchase_bar = Mock()
-        with (
-            patch.object(bot.driver, "find_element", return_value=purchase_bar),
-            patch.object(bot, "_collect_descendant_texts", return_value=["", "   "]),
-        ):
-            assert bot._purchase_bar_text_ready() is False
+        with patch.object(bot.driver, "find_element", return_value=purchase_bar):
+            with patch.object(bot, "_collect_descendant_texts", return_value=["", "   "]):
+                assert bot._purchase_bar_text_ready() is False
 
     def test_is_sale_ready_detects_ready_selector(self, bot):
         with patch.object(
@@ -2547,40 +1885,22 @@ class TestSaleReadiness:
     def test_is_sale_ready_uses_sku_mode_to_block_reservation(self, bot):
         present = {(By.ID, "cn.damai:id/project_detail_perform_price_flowlayout")}
 
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: (by, value) in present,
-            ),
-            patch.object(bot, "is_reservation_sku_mode", return_value=True),
-        ):
-            assert bot._is_sale_ready() is False
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+            with patch.object(bot, "is_reservation_sku_mode", return_value=True):
+                assert bot._is_sale_ready() is False
 
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: (by, value) in present,
-            ),
-            patch.object(bot, "is_reservation_sku_mode", return_value=False),
-        ):
-            assert bot._is_sale_ready() is True
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+            with patch.object(bot, "is_reservation_sku_mode", return_value=False):
+                assert bot._is_sale_ready() is True
 
     def test_is_sale_ready_uses_purchase_bar_text_when_detail_cta_present(self, bot):
         present = {
             (By.ID, "cn.damai:id/trade_project_detail_purchase_status_bar_container_fl")
         }
 
-        with (
-            patch.object(
-                bot,
-                "_has_element",
-                side_effect=lambda by, value: (by, value) in present,
-            ),
-            patch.object(bot, "_purchase_bar_text_ready", return_value=True),
-        ):
-            assert bot._is_sale_ready() is True
+        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+            with patch.object(bot, "_purchase_bar_text_ready", return_value=True):
+                assert bot._is_sale_ready() is True
 
     def test_is_sale_ready_returns_false_without_any_signal(self, bot):
         with patch.object(bot, "_has_element", return_value=False):
@@ -2611,58 +1931,30 @@ class TestFastRetry:
         }
         # First call from dismiss_startup_popups fallback returns unknown;
         # second call (in back-loop with fast=True) returns detail_page.
-        with (
-            patch.object(
-                bot, "probe_current_page", side_effect=[unknown_probe, detail_probe]
-            ),
-            patch.object(bot, "dismiss_startup_popups"),
-            patch("mobile.damai_app.time.sleep"),
-        ):
-            result = bot._recover_to_detail_page_for_local_retry(
-                initial_probe=unknown_probe
-            )
+        with patch.object( bot, "probe_current_page", side_effect=[unknown_probe, detail_probe] ):
+            with patch.object(bot, "dismiss_startup_popups"):
+                with patch("mobile.damai_app.time.sleep"):
+                    result = bot._recover_to_detail_page_for_local_retry(
+                        initial_probe=unknown_probe
+                    )
 
         bot.d.press.assert_called_once_with("back")
         assert result["state"] == "detail_page"
 
     def test_fast_retry_from_detail_page(self, bot):
         """probe returns detail_page, re-runs full flow."""
-        with (
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg,
-        ):
-            result = bot._fast_retry_from_current_state()
+        with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg:
+                result = bot._fast_retry_from_current_state()
 
         assert result is True
         run_tg.assert_called_once()
 
     def test_fast_retry_from_order_confirm_page(self, bot):
         """probe returns order_confirm_page, re-attempts submit only."""
-        with (
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "order_confirm_page",
-                    "purchase_button": False,
-                    "price_container": False,
-                    "quantity_picker": False,
-                    "submit_button": True,
-                },
-            ),
-            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click,
-        ):
-            result = bot._fast_retry_from_current_state()
+        with patch.object( bot, "probe_current_page", return_value={ "state": "order_confirm_page", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": True, }, ):
+            with patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click:
+                result = bot._fast_retry_from_current_state()
 
         assert result is True
         smart_click.assert_called_once()
@@ -2672,26 +1964,10 @@ class TestFastRetry:
     ):
         bot.config.if_commit_order = False
 
-        with (
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "order_confirm_page",
-                    "purchase_button": False,
-                    "price_container": False,
-                    "quantity_picker": False,
-                    "submit_button": True,
-                },
-            ),
-            patch.object(
-                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
-            ) as ensure_attendees,
-            patch.object(
-                bot, "smart_wait_for_element", return_value=True
-            ) as wait_element,
-        ):
-            result = bot._fast_retry_from_current_state()
+        with patch.object( bot, "probe_current_page", return_value={ "state": "order_confirm_page", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": True, }, ):
+            with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ) as ensure_attendees:
+                with patch.object( bot, "smart_wait_for_element", return_value=True ) as wait_element:
+                    result = bot._fast_retry_from_current_state()
 
         assert result is True
         ensure_attendees.assert_called_once()
@@ -2718,25 +1994,11 @@ class TestFastRetry:
         bot.item_detail = _make_item_detail()
         bot.config.auto_navigate = True
 
-        with (
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "_current_page_matches_target", return_value=False),
-            patch.object(
-                bot, "navigate_to_target_event", return_value=True
-            ) as navigate,
-            patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg,
-        ):
-            result = bot._fast_retry_from_current_state()
+        with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(bot, "_current_page_matches_target", return_value=False):
+                with patch.object( bot, "navigate_to_target_event", return_value=True ) as navigate:
+                    with patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg:
+                        result = bot._fast_retry_from_current_state()
 
         assert result is True
         navigate.assert_called_once()
@@ -2746,23 +2008,11 @@ class TestFastRetry:
         bot.item_detail = _make_item_detail()
         bot.config.auto_navigate = False
 
-        with (
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "_current_page_matches_target", return_value=False),
-            patch.object(bot, "navigate_to_target_event") as navigate,
-            patch.object(bot, "run_ticket_grabbing") as run_tg,
-        ):
-            result = bot._fast_retry_from_current_state()
+        with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(bot, "_current_page_matches_target", return_value=False):
+                with patch.object(bot, "navigate_to_target_event") as navigate:
+                    with patch.object(bot, "run_ticket_grabbing") as run_tg:
+                        result = bot._fast_retry_from_current_state()
 
         assert result is False
         navigate.assert_not_called()
@@ -2772,33 +2022,11 @@ class TestFastRetry:
         """Manual-start retry recovers locally before re-running the flow."""
         bot.config.auto_navigate = False
 
-        with (
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "unknown",
-                    "purchase_button": False,
-                    "price_container": False,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(
-                bot,
-                "_recover_to_detail_page_for_local_retry",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ) as recover_local,
-            patch.object(bot, "run_ticket_grabbing", return_value=False) as run_tg,
-            patch("mobile.damai_app.time.sleep"),
-        ):
-            result = bot._fast_retry_from_current_state()
+        with patch.object( bot, "probe_current_page", return_value={ "state": "unknown", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object( bot, "_recover_to_detail_page_for_local_retry", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ) as recover_local:
+                with patch.object(bot, "run_ticket_grabbing", return_value=False) as run_tg:
+                    with patch("mobile.damai_app.time.sleep"):
+                        result = bot._fast_retry_from_current_state()
 
         recover_local.assert_called_once()
         run_tg.assert_called_once()
@@ -2808,32 +2036,10 @@ class TestFastRetry:
         """Manual-start retry stops if it cannot recover to a detail/sku page."""
         bot.config.auto_navigate = False
 
-        with (
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "unknown",
-                    "purchase_button": False,
-                    "price_container": False,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(
-                bot,
-                "_recover_to_detail_page_for_local_retry",
-                return_value={
-                    "state": "homepage",
-                    "purchase_button": False,
-                    "price_container": False,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ) as recover_local,
-            patch.object(bot, "run_ticket_grabbing") as run_tg,
-        ):
-            result = bot._fast_retry_from_current_state()
+        with patch.object( bot, "probe_current_page", return_value={ "state": "unknown", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object( bot, "_recover_to_detail_page_for_local_retry", return_value={ "state": "homepage", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, }, ) as recover_local:
+                with patch.object(bot, "run_ticket_grabbing") as run_tg:
+                    result = bot._fast_retry_from_current_state()
 
         recover_local.assert_called_once()
         run_tg.assert_not_called()
@@ -2842,24 +2048,10 @@ class TestFastRetry:
     def test_fast_retry_from_unknown_uses_auto_navigation_when_enabled(self, bot):
         bot.config.auto_navigate = True
 
-        with (
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "unknown",
-                    "purchase_button": False,
-                    "price_container": False,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(
-                bot, "navigate_to_target_event", return_value=True
-            ) as navigate,
-            patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg,
-        ):
-            result = bot._fast_retry_from_current_state()
+        with patch.object( bot, "probe_current_page", return_value={ "state": "unknown", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object( bot, "navigate_to_target_event", return_value=True ) as navigate:
+                with patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg:
+                    result = bot._fast_retry_from_current_state()
 
         assert result is True
         navigate.assert_called_once()
@@ -2874,16 +2066,10 @@ class TestFastRetry:
 class TestVerifyOrderResult:
     def test_verify_order_success_payment_activity(self, bot):
         """Activity contains 'Pay', returns 'success'."""
-        with (
-            patch.object(
-                bot,
-                "_get_current_activity",
-                return_value="com.alipay.android.app.PayActivity",
-            ),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
-            result = bot.verify_order_result(timeout=5)
+        with patch.object( bot, "_get_current_activity", return_value="com.alipay.android.app.PayActivity", ):
+            with patch("mobile.damai_app.time") as mock_time:
+                mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
+                result = bot.verify_order_result(timeout=5)
 
         assert result == "success"
 
@@ -2893,13 +2079,11 @@ class TestVerifyOrderResult:
         def has_element_side_effect(by, value):
             return "立即支付" in value
 
-        with (
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
-            result = bot.verify_order_result(timeout=5)
+        with patch.object(bot, "_get_current_activity", return_value="SomeActivity"):
+            with patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+                with patch("mobile.damai_app.time") as mock_time:
+                    mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
+                    result = bot.verify_order_result(timeout=5)
 
         assert result == "success"
 
@@ -2911,13 +2095,11 @@ class TestVerifyOrderResult:
             # Simulate a page containing generic "支付" wording but no payment CTA.
             return 'textContains("支付")' in value and "未支付" not in value
 
-        with (
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
-            patch("mobile.damai_app.time.time", side_effect=time_values),
-            patch("mobile.damai_app.time.sleep"),
-        ):
-            result = bot.verify_order_result(timeout=1)
+        with patch.object(bot, "_get_current_activity", return_value="SomeActivity"):
+            with patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+                with patch("mobile.damai_app.time.time", side_effect=time_values):
+                    with patch("mobile.damai_app.time.sleep"):
+                        result = bot.verify_order_result(timeout=1)
 
         assert result == "timeout"
 
@@ -2946,13 +2128,11 @@ class TestVerifyOrderResult:
                 return True
             return False
 
-        with (
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
-            patch("mobile.damai_app.time.time", side_effect=time_values),
-            patch("mobile.damai_app.time.sleep"),
-        ):
-            result = bot.verify_order_result(timeout=1)
+        with patch.object(bot, "_get_current_activity", return_value="SomeActivity"):
+            with patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+                with patch("mobile.damai_app.time.time", side_effect=time_values):
+                    with patch("mobile.damai_app.time.sleep"):
+                        result = bot.verify_order_result(timeout=1)
 
         assert result == "timeout"
 
@@ -2962,13 +2142,11 @@ class TestVerifyOrderResult:
         def has_element_side_effect(by, value):
             return "已售罄" in value
 
-        with (
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
-            result = bot.verify_order_result(timeout=5)
+        with patch.object(bot, "_get_current_activity", return_value="SomeActivity"):
+            with patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+                with patch("mobile.damai_app.time") as mock_time:
+                    mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
+                    result = bot.verify_order_result(timeout=5)
 
         assert result == "sold_out"
 
@@ -2981,14 +2159,12 @@ class TestVerifyOrderResult:
             # Return increasing time so we exceed timeout quickly
             return call_count[0] * 3.0
 
-        with (
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
-            patch.object(bot, "_has_element", return_value=False),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time = mock_time_func
-            mock_time.sleep = Mock()
-            result = bot.verify_order_result(timeout=5)
+        with patch.object(bot, "_get_current_activity", return_value="SomeActivity"):
+            with patch.object(bot, "_has_element", return_value=False):
+                with patch("mobile.damai_app.time") as mock_time:
+                    mock_time.time = mock_time_func
+                    mock_time.sleep = Mock()
+                    result = bot.verify_order_result(timeout=5)
 
         assert result == "timeout"
 
@@ -3005,13 +2181,11 @@ class TestVerifyOrderResult:
                 return True
             return False
 
-        with (
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
-            result = bot.verify_order_result(timeout=5)
+        with patch.object(bot, "_get_current_activity", return_value="SomeActivity"):
+            with patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+                with patch("mobile.damai_app.time") as mock_time:
+                    mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
+                    result = bot.verify_order_result(timeout=5)
 
         assert result == "captcha"
 
@@ -3029,13 +2203,11 @@ class TestVerifyOrderResult:
                 return True
             return False
 
-        with (
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
-            result = bot.verify_order_result(timeout=5)
+        with patch.object(bot, "_get_current_activity", return_value="SomeActivity"):
+            with patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+                with patch("mobile.damai_app.time") as mock_time:
+                    mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
+                    result = bot.verify_order_result(timeout=5)
 
         assert result == "existing_order"
 
@@ -3048,11 +2220,9 @@ class TestVerifyOrderResult:
 class TestSelectPerformanceDate:
     def test_select_performance_date_found(self, bot, caplog):
         """Date text found and clicked successfully."""
-        with (
-            caplog.at_level("INFO", logger="mobile.damai_app"),
-            patch.object(bot, "ultra_fast_click", return_value=True) as ufc,
-        ):
-            bot.select_performance_date()
+        with caplog.at_level("INFO", logger="mobile.damai_app"):
+            with patch.object(bot, "ultra_fast_click", return_value=True) as ufc:
+                bot.select_performance_date()
 
         ufc.assert_called_once_with(
             ANDROID_UIAUTOMATOR,
@@ -3063,11 +2233,9 @@ class TestSelectPerformanceDate:
 
     def test_select_performance_date_not_found(self, bot, caplog):
         """Date not found, continues gracefully without error."""
-        with (
-            caplog.at_level("DEBUG", logger="mobile.damai_app"),
-            patch.object(bot, "ultra_fast_click", return_value=False) as ufc,
-        ):
-            bot.select_performance_date()
+        with caplog.at_level("DEBUG", logger="mobile.damai_app"):
+            with patch.object(bot, "ultra_fast_click", return_value=False) as ufc:
+                bot.select_performance_date()
 
         ufc.assert_called_once()
         assert "未找到日期" in caplog.text
@@ -3089,40 +2257,26 @@ class TestSelectPerformanceDate:
 class TestCheckSessionValid:
     def test_check_session_valid_logged_in(self, bot):
         """No login indicators, returns True."""
-        with (
-            patch.object(
-                bot, "_get_current_activity", return_value="ProjectDetailActivity"
-            ),
-            patch.object(bot, "_has_element", return_value=False),
-        ):
-            result = bot.check_session_valid()
+        with patch.object( bot, "_get_current_activity", return_value="ProjectDetailActivity" ):
+            with patch.object(bot, "_has_element", return_value=False):
+                result = bot.check_session_valid()
 
         assert result is True
 
     def test_check_session_valid_login_activity(self, bot, caplog):
         """LoginActivity detected, returns False."""
-        with (
-            caplog.at_level("ERROR", logger="mobile.damai_app"),
-            patch.object(
-                bot,
-                "_get_current_activity",
-                return_value="com.taobao.login.LoginActivity",
-            ),
-        ):
-            result = bot.check_session_valid()
+        with caplog.at_level("ERROR", logger="mobile.damai_app"):
+            with patch.object( bot, "_get_current_activity", return_value="com.taobao.login.LoginActivity", ):
+                result = bot.check_session_valid()
 
         assert result is False
         assert "登录已过期" in caplog.text
 
     def test_check_session_valid_sign_activity(self, bot, caplog):
         """SignActivity detected, returns False."""
-        with (
-            caplog.at_level("ERROR", logger="mobile.damai_app"),
-            patch.object(
-                bot, "_get_current_activity", return_value="com.taobao.SignActivity"
-            ),
-        ):
-            result = bot.check_session_valid()
+        with caplog.at_level("ERROR", logger="mobile.damai_app"):
+            with patch.object( bot, "_get_current_activity", return_value="com.taobao.SignActivity" ):
+                result = bot.check_session_valid()
 
         assert result is False
         assert "登录已过期" in caplog.text
@@ -3133,12 +2287,10 @@ class TestCheckSessionValid:
         def has_element_side_effect(by, value):
             return "请先登录" in value
 
-        with (
-            caplog.at_level("ERROR", logger="mobile.damai_app"),
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
-        ):
-            result = bot.check_session_valid()
+        with caplog.at_level("ERROR", logger="mobile.damai_app"):
+            with patch.object(bot, "_get_current_activity", return_value="SomeActivity"):
+                with patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+                    result = bot.check_session_valid()
 
         assert result is False
         assert "登录提示" in caplog.text
@@ -3146,11 +2298,9 @@ class TestCheckSessionValid:
 
 class TestSkuInspectionHelpers:
     def test_dismiss_startup_popups_returns_false_when_nothing_is_clickable(self, bot):
-        with (
-            patch.object(bot, "_has_element", return_value=False),
-            patch.object(bot, "ultra_fast_click") as fast_click,
-        ):
-            assert bot.dismiss_startup_popups() is False
+        with patch.object(bot, "_has_element", return_value=False):
+            with patch.object(bot, "ultra_fast_click") as fast_click:
+                assert bot.dismiss_startup_popups() is False
 
         fast_click.assert_not_called()
 
@@ -3204,26 +2354,18 @@ class TestSkuInspectionHelpers:
     def test_ensure_sku_page_for_inspection_enters_sku_from_detail_page(self, bot):
         next_probe = {"state": "sku_page", "reservation_mode": False}
 
-        with (
-            patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click,
-            patch.object(
-                bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ) as wait_entry,
-        ):
-            result = bot.ensure_sku_page_for_inspection({"state": "detail_page"})
+        with patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click:
+            with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ) as wait_entry:
+                result = bot.ensure_sku_page_for_inspection({"state": "detail_page"})
 
         assert result == next_probe
         assert smart_click.call_count == 1
         wait_entry.assert_called_once_with(timeout=5, poll_interval=0.04)
 
     def test_ensure_sku_page_for_inspection_returns_probe_when_click_fails(self, bot):
-        with (
-            patch.object(bot, "smart_wait_and_click", return_value=False),
-            patch.object(
-                bot, "probe_current_page", return_value={"state": "detail_page"}
-            ) as probe,
-        ):
-            result = bot.ensure_sku_page_for_inspection({"state": "detail_page"})
+        with patch.object(bot, "smart_wait_and_click", return_value=False):
+            with patch.object( bot, "probe_current_page", return_value={"state": "detail_page"} ) as probe:
+                result = bot.ensure_sku_page_for_inspection({"state": "detail_page"})
 
         assert result == {"state": "detail_page"}
         probe.assert_called_once()
@@ -3232,24 +2374,14 @@ class TestSkuInspectionHelpers:
         sku_probe = {"state": "sku_page", "reservation_mode": True}
         prices = [{"index": 5, "text": "看台 899元", "tag": "可选", "source": "ui"}]
 
-        with (
-            patch.object(bot, "smart_wait_and_click", return_value=True),
-            patch.object(bot, "_dump_hierarchy_xml", return_value=None),
-            patch.object(
-                bot, "_wait_for_purchase_entry_result", return_value=sku_probe
-            ),
-            patch.object(
-                bot, "_get_detail_title_text", side_effect=["", "马思唯上海站"]
-            ),
-            patch.object(
-                bot,
-                "_get_detail_venue_text",
-                side_effect=["", "上海市 · 浦发银行东方体育中心"],
-            ),
-            patch.object(bot, "get_visible_date_options", return_value=["04.04"]),
-            patch.object(bot, "get_visible_price_options", return_value=prices),
-        ):
-            summary = bot.inspect_current_target_event({"state": "detail_page"})
+        with patch.object(bot, "smart_wait_and_click", return_value=True):
+            with patch.object(bot, "_dump_hierarchy_xml", return_value=None):
+                with patch.object( bot, "_wait_for_purchase_entry_result", return_value=sku_probe ):
+                    with patch.object( bot, "_get_detail_title_text", side_effect=["", "马思唯上海站"] ):
+                        with patch.object( bot, "_get_detail_venue_text", side_effect=["", "上海市 · 浦发银行东方体育中心"], ):
+                            with patch.object(bot, "get_visible_date_options", return_value=["04.04"]):
+                                with patch.object(bot, "get_visible_price_options", return_value=prices):
+                                    summary = bot.inspect_current_target_event({"state": "detail_page"})
 
         assert summary == {
             "state": "sku_page",
@@ -3261,22 +2393,14 @@ class TestSkuInspectionHelpers:
         }
 
     def test_inspect_current_target_event_skips_price_reads_outside_sku_page(self, bot):
-        with (
-            patch.object(bot, "smart_wait_and_click", return_value=True),
-            patch.object(bot, "_dump_hierarchy_xml", return_value=None),
-            patch.object(
-                bot,
-                "_wait_for_purchase_entry_result",
-                return_value={"state": "detail_page"},
-            ),
-            patch.object(bot, "_get_detail_title_text", return_value="马思唯上海站"),
-            patch.object(
-                bot, "_get_detail_venue_text", return_value="浦发银行东方体育中心"
-            ),
-            patch.object(bot, "get_visible_date_options") as get_dates,
-            patch.object(bot, "get_visible_price_options") as get_prices,
-        ):
-            summary = bot.inspect_current_target_event({"state": "detail_page"})
+        with patch.object(bot, "smart_wait_and_click", return_value=True):
+            with patch.object(bot, "_dump_hierarchy_xml", return_value=None):
+                with patch.object( bot, "_wait_for_purchase_entry_result", return_value={"state": "detail_page"}, ):
+                    with patch.object(bot, "_get_detail_title_text", return_value="马思唯上海站"):
+                        with patch.object( bot, "_get_detail_venue_text", return_value="浦发银行东方体育中心" ):
+                            with patch.object(bot, "get_visible_date_options") as get_dates:
+                                with patch.object(bot, "get_visible_price_options") as get_prices:
+                                    summary = bot.inspect_current_target_event({"state": "detail_page"})
 
         assert summary["state"] == "detail_page"
         assert summary["dates"] == []
@@ -3290,12 +2414,10 @@ class TestSkuInspectionHelpers:
         def has_element_side_effect(by, value):
             return "登录/注册" in value
 
-        with (
-            caplog.at_level("ERROR", logger="mobile.damai_app"),
-            patch.object(bot, "_get_current_activity", return_value="SomeActivity"),
-            patch.object(bot, "_has_element", side_effect=has_element_side_effect),
-        ):
-            result = bot.check_session_valid()
+        with caplog.at_level("ERROR", logger="mobile.damai_app"):
+            with patch.object(bot, "_get_current_activity", return_value="SomeActivity"):
+                with patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+                    result = bot.check_session_valid()
 
         assert result is False
         assert "登录提示" in caplog.text
@@ -3463,15 +2585,13 @@ class TestXmlHierarchyHelpers:
         bot.d.dump_hierarchy = Mock(return_value="<hierarchy><node/></hierarchy>")
         sku_probe = {"state": "sku_page", "reservation_mode": False}
 
-        with (
-            patch.object(bot, "probe_current_page", return_value=sku_probe),
-            patch.object(bot, "ensure_sku_page_for_inspection", return_value=sku_probe),
-            patch.object(bot, "_get_detail_title_text", return_value="演唱会"),
-            patch.object(bot, "_get_detail_venue_text", return_value="场馆"),
-            patch.object(bot, "get_visible_date_options", return_value=["04.06"]),
-            patch.object(bot, "get_visible_price_options", return_value=[]),
-        ):
-            bot.inspect_current_target_event()
+        with patch.object(bot, "probe_current_page", return_value=sku_probe):
+            with patch.object(bot, "ensure_sku_page_for_inspection", return_value=sku_probe):
+                with patch.object(bot, "_get_detail_title_text", return_value="演唱会"):
+                    with patch.object(bot, "_get_detail_venue_text", return_value="场馆"):
+                        with patch.object(bot, "get_visible_date_options", return_value=["04.06"]):
+                            with patch.object(bot, "get_visible_price_options", return_value=[]):
+                                bot.inspect_current_target_event()
 
         # Hierarchy should only be dumped once (no re-dump since page didn't navigate).
         bot.d.dump_hierarchy.assert_called_once()
@@ -3489,13 +2609,9 @@ class TestPriceSelection:
         bot.config.rush_mode = True
         bot.config.price_index = 5
 
-        with (
-            patch.object(
-                bot, "_click_price_option_by_config_index", return_value=True
-            ) as click_index,
-            patch.object(bot, "get_visible_price_options") as get_visible,
-        ):
-            result = bot._select_price_option_fast()
+        with patch.object( bot, "_click_price_option_by_config_index", return_value=True ) as click_index:
+            with patch.object(bot, "get_visible_price_options") as get_visible:
+                result = bot._select_price_option_fast()
 
         assert result is True
         click_index.assert_called_once_with(burst=True, coords=None)
@@ -3504,13 +2620,9 @@ class TestPriceSelection:
     def test_select_price_option_fast_rush_mode_uses_cached_coordinates(self, bot):
         bot.config.rush_mode = True
 
-        with (
-            patch.object(
-                bot, "_click_price_option_by_config_index", return_value=True
-            ) as click_index,
-            patch.object(bot, "get_visible_price_options") as get_visible,
-        ):
-            result = bot._select_price_option_fast(cached_coords=(240, 1560))
+        with patch.object( bot, "_click_price_option_by_config_index", return_value=True ) as click_index:
+            with patch.object(bot, "get_visible_price_options") as get_visible:
+                result = bot._select_price_option_fast(cached_coords=(240, 1560))
 
         assert result is True
         click_index.assert_called_once_with(burst=True, coords=(240, 1560))
@@ -3520,34 +2632,18 @@ class TestPriceSelection:
         bot.config.price = "899元"
         bot.config.price_index = 5
 
-        with (
-            patch.object(
-                bot,
-                "get_visible_price_options",
-                return_value=[
-                    {"index": 5, "text": "", "tag": "", "source": "ui"},
-                ],
-            ) as get_visible,
-            patch.object(
-                bot, "_click_visible_price_option", return_value=True
-            ) as click_visible,
-        ):
-            result = bot._select_price_option_fast()
+        with patch.object( bot, "get_visible_price_options", return_value=[ {"index": 5, "text": "", "tag": "", "source": "ui"}, ], ) as get_visible:
+            with patch.object( bot, "_click_visible_price_option", return_value=True ) as click_visible:
+                result = bot._select_price_option_fast()
 
         assert result is True
         get_visible.assert_called_once_with(allow_ocr=False)
         click_visible.assert_called_once_with(5)
 
     def test_click_price_option_by_config_index_bursts_clicks_in_rush_mode(self, bot):
-        with (
-            patch.object(
-                bot,
-                "_get_price_option_coordinates_by_config_index",
-                return_value=(260, 1540),
-            ),
-            patch.object(bot, "_burst_click_coordinates") as burst_click,
-        ):
-            result = bot._click_price_option_by_config_index(burst=True)
+        with patch.object( bot, "_get_price_option_coordinates_by_config_index", return_value=(260, 1540), ):
+            with patch.object(bot, "_burst_click_coordinates") as burst_click:
+                result = bot._click_price_option_by_config_index(burst=True)
 
         assert result is True
         burst_click.assert_called_once_with(
@@ -3560,14 +2656,10 @@ class TestPriceSelection:
         bot.config.price = "899元"
         bot.config.price_index = 5
 
-        with (
-            patch.object(bot, "get_visible_price_options", return_value=[]),
-            patch.object(
-                bot, "_click_price_option_by_config_index", return_value=True
-            ) as click_index,
-            patch.object(bot, "ultra_fast_click", return_value=False),
-        ):
-            result = bot._select_price_option_fast()
+        with patch.object(bot, "get_visible_price_options", return_value=[]):
+            with patch.object( bot, "_click_price_option_by_config_index", return_value=True ) as click_index:
+                with patch.object(bot, "ultra_fast_click", return_value=False):
+                    result = bot._select_price_option_fast()
 
         assert result is True
         click_index.assert_called_once_with()
@@ -3576,21 +2668,10 @@ class TestPriceSelection:
         bot.config.price = "899元"
         bot.config.price_index = 5
 
-        with (
-            patch.object(
-                bot,
-                "get_visible_price_options",
-                return_value=[
-                    {"index": 0, "text": "看台699元", "tag": "", "source": "ocr"},
-                    {"index": 5, "text": "看台899元", "tag": "", "source": "ocr"},
-                ],
-            ),
-            patch.object(
-                bot, "_click_visible_price_option", return_value=True
-            ) as click_visible,
-            patch.object(bot, "ultra_fast_click") as fast_click,
-        ):
-            result = bot._select_price_option()
+        with patch.object( bot, "get_visible_price_options", return_value=[ {"index": 0, "text": "看台699元", "tag": "", "source": "ocr"}, {"index": 5, "text": "看台899元", "tag": "", "source": "ocr"}, ], ):
+            with patch.object( bot, "_click_visible_price_option", return_value=True ) as click_visible:
+                with patch.object(bot, "ultra_fast_click") as fast_click:
+                    result = bot._select_price_option()
 
         assert result is True
         click_visible.assert_called_once_with(5)
@@ -3600,23 +2681,10 @@ class TestPriceSelection:
         bot.config.price = "899元"
         bot.config.price_index = 5
 
-        with (
-            patch.object(
-                bot,
-                "get_visible_price_options",
-                return_value=[
-                    {
-                        "index": 5,
-                        "text": "看台899元",
-                        "tag": "缺货登记",
-                        "source": "ocr",
-                    },
-                ],
-            ),
-            patch.object(bot, "_click_visible_price_option") as click_visible,
-            patch.object(bot, "ultra_fast_click") as fast_click,
-        ):
-            result = bot._select_price_option()
+        with patch.object( bot, "get_visible_price_options", return_value=[ { "index": 5, "text": "看台899元", "tag": "缺货登记", "source": "ocr", }, ], ):
+            with patch.object(bot, "_click_visible_price_option") as click_visible:
+                with patch.object(bot, "ultra_fast_click") as fast_click:
+                    result = bot._select_price_option()
 
         assert result is False
         click_visible.assert_not_called()
@@ -3629,14 +2697,10 @@ class TestPriceSelection:
             (By.XPATH, '//*[contains(@text,"提交")]'),
         ]
 
-        with (
-            patch.object(bot, "ultra_fast_click", side_effect=[True, True]),
-            patch.object(bot, "smart_wait_and_click", return_value=False),
-            patch.object(
-                bot, "verify_order_result", side_effect=["timeout", "success"]
-            ) as verify_result,
-        ):
-            result = bot._submit_order_fast(submit_selectors)
+        with patch.object(bot, "ultra_fast_click", side_effect=[True, True]):
+            with patch.object(bot, "smart_wait_and_click", return_value=False):
+                with patch.object( bot, "verify_order_result", side_effect=["timeout", "success"] ) as verify_result:
+                    result = bot._submit_order_fast(submit_selectors)
 
         assert result == "success"
         assert verify_result.call_args_list == [call(timeout=1.2), call(timeout=1.2)]
@@ -3648,56 +2712,32 @@ class TestPriceSelection:
             (By.XPATH, '//*[contains(@text,"提交")]'),
         ]
 
-        with (
-            patch.object(bot, "ultra_fast_click", side_effect=[True, False, False]),
-            patch.object(bot, "smart_wait_and_click", return_value=False),
-            patch.object(
-                bot, "verify_order_result", side_effect=["timeout", "existing_order"]
-            ) as verify_result,
-        ):
-            result = bot._submit_order_fast(submit_selectors)
+        with patch.object(bot, "ultra_fast_click", side_effect=[True, False, False]):
+            with patch.object(bot, "smart_wait_and_click", return_value=False):
+                with patch.object( bot, "verify_order_result", side_effect=["timeout", "existing_order"] ) as verify_result:
+                    result = bot._submit_order_fast(submit_selectors)
 
         assert result == "existing_order"
         assert verify_result.call_args_list == [call(timeout=1.2), call(timeout=2)]
 
     def test_price_selection_text_match_success(self, bot):
         """Text-based price match works, index fallback not used."""
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(bot, "check_session_valid", return_value=True),
-            patch.object(
-                bot,
-                "probe_current_page",
-                return_value={
-                    "state": "detail_page",
-                    "purchase_button": True,
-                    "price_container": True,
-                    "quantity_picker": False,
-                    "submit_button": False,
-                },
-            ),
-            patch.object(bot, "wait_for_sale_start"),
-            patch.object(bot, "select_performance_date"),
-            patch.object(
-                bot,
-                "_enter_purchase_flow_from_detail_page",
-                return_value={
-                    "state": "sku_page",
-                    "price_container": True,
-                    "reservation_mode": False,
-                },
-            ),
-            patch.object(bot, "_wait_for_submit_ready", return_value=True),
-            patch.object(bot, "smart_wait_and_click", return_value=True),
-            patch.object(bot, "ultra_fast_click", return_value=True) as ufc,
-            patch.object(bot, "ultra_batch_click"),
-            patch.object(bot, "_submit_order_fast", return_value="success"),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
-            bot.driver.find_elements.return_value = []
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object(bot, "check_session_valid", return_value=True):
+                with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                    with patch.object(bot, "wait_for_sale_start"):
+                        with patch.object(bot, "select_performance_date"):
+                            with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
+                                with patch.object(bot, "_wait_for_submit_ready", return_value=True):
+                                    with patch.object(bot, "smart_wait_and_click", return_value=True):
+                                        with patch.object(bot, "ultra_fast_click", return_value=True) as ufc:
+                                            with patch.object(bot, "ultra_batch_click"):
+                                                with patch.object(bot, "_submit_order_fast", return_value="success"):
+                                                    with patch("mobile.damai_app.time") as mock_time:
+                                                        mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
+                                                        bot.driver.find_elements.return_value = []
 
-            result = bot.run_ticket_grabbing()
+                                                        result = bot.run_ticket_grabbing()
 
         assert result is True
         # ultra_fast_click should have been called with the price text selector
@@ -3724,63 +2764,29 @@ class TestPriceSelection:
         _price_logger = _logging.getLogger("mobile.price_selector")
         _price_logger.propagate = True
         try:
-            with (
-                caplog.at_level("INFO"),
-                patch.object(bot, "dismiss_startup_popups"),
-                patch.object(bot, "check_session_valid", return_value=True),
-                patch.object(
-                    bot,
-                    "probe_current_page",
-                    return_value={
-                        "state": "detail_page",
-                        "purchase_button": True,
-                        "price_container": True,
-                        "quantity_picker": False,
-                        "submit_button": False,
-                    },
-                ),
-                patch.object(bot, "wait_for_sale_start"),
-                patch.object(bot, "select_performance_date"),
-                patch.object(
-                    bot,
-                    "_enter_purchase_flow_from_detail_page",
-                    return_value={
-                        "state": "sku_page",
-                        "price_container": True,
-                        "reservation_mode": False,
-                    },
-                ),
-                patch.object(bot, "_wait_for_submit_ready", return_value=True),
-                patch.object(bot, "smart_wait_and_click", return_value=True),
-                patch.object(
-                    bot, "ultra_fast_click", side_effect=ultra_fast_click_side_effect
-                ),
-                patch.object(bot, "ultra_batch_click"),
-                patch.object(bot, "_submit_order_fast", return_value="success"),
-                patch("mobile.damai_app.time") as mock_time,
-            ):
-                mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
-                # Mock price container for index-based fallback
-                mock_target = _make_mock_element()
-                with (
-                    patch.object(
-                        bot._price_sel, "_click_price_card_element", return_value=False
-                    ),
-                    patch.object(bot, "_find", return_value=Mock()),
-                    patch.object(
-                        bot,
-                        "_container_find_elements",
-                        return_value=[mock_target, mock_target],
-                    ),
-                    patch.object(bot, "_is_clickable", return_value=True),
-                    patch.object(bot, "_click_element_center"),
-                    patch.object(
-                        bot,
-                        "_ensure_attendees_selected_on_confirm_page",
-                        return_value=True,
-                    ),
-                ):
-                    result = bot.run_ticket_grabbing()
+            with caplog.at_level("INFO"):
+                with patch.object(bot, "dismiss_startup_popups"):
+                    with patch.object(bot, "check_session_valid", return_value=True):
+                        with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                            with patch.object(bot, "wait_for_sale_start"):
+                                with patch.object(bot, "select_performance_date"):
+                                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
+                                        with patch.object(bot, "_wait_for_submit_ready", return_value=True):
+                                            with patch.object(bot, "smart_wait_and_click", return_value=True):
+                                                with patch.object( bot, "ultra_fast_click", side_effect=ultra_fast_click_side_effect ):
+                                                    with patch.object(bot, "ultra_batch_click"):
+                                                        with patch.object(bot, "_submit_order_fast", return_value="success"):
+                                                            with patch("mobile.damai_app.time") as mock_time:
+                                                                mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
+                                                                # Mock price container for index-based fallback
+                                                                mock_target = _make_mock_element()
+                                                                with patch.object( bot._price_sel, "_click_price_card_element", return_value=False ):
+                                                                    with patch.object(bot, "_find", return_value=Mock()):
+                                                                        with patch.object( bot, "_container_find_elements", return_value=[mock_target, mock_target], ):
+                                                                            with patch.object(bot, "_is_clickable", return_value=True):
+                                                                                with patch.object(bot, "_click_element_center"):
+                                                                                    with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True, ):
+                                                                                        result = bot.run_ticket_grabbing()
         finally:
             _price_logger.propagate = False
 
@@ -4019,25 +3025,17 @@ class TestSmartWaitForElement:
 
 class TestWaitForPageState:
     def test_returns_last_probe_on_timeout(self, bot):
-        with (
-            patch.object(
-                bot, "probe_current_page", return_value={"state": "unknown_state"}
-            ),
-            patch("mobile.damai_app.time.time", side_effect=[0.0, 10.0, 20.0]),
-            patch("mobile.damai_app.time.sleep"),
-        ):
-            result = bot.wait_for_page_state({"order_confirm_page"}, timeout=5)
+        with patch.object( bot, "probe_current_page", return_value={"state": "unknown_state"} ):
+            with patch("mobile.damai_app.time.time", side_effect=[0.0, 10.0, 20.0]):
+                with patch("mobile.damai_app.time.sleep"):
+                    result = bot.wait_for_page_state({"order_confirm_page"}, timeout=5)
         assert result["state"] == "unknown_state"
 
     def test_returns_immediately_on_matching_state(self, bot):
-        with (
-            patch.object(
-                bot, "probe_current_page", return_value={"state": "detail_page"}
-            ),
-            patch("mobile.damai_app.time.time", side_effect=[0.0, 1.0]),
-            patch("mobile.damai_app.time.sleep"),
-        ):
-            result = bot.wait_for_page_state({"detail_page"})
+        with patch.object( bot, "probe_current_page", return_value={"state": "detail_page"} ):
+            with patch("mobile.damai_app.time.time", side_effect=[0.0, 1.0]):
+                with patch("mobile.damai_app.time.sleep"):
+                    result = bot.wait_for_page_state({"detail_page"})
         assert result["state"] == "detail_page"
 
 
@@ -4091,20 +3089,12 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with (
-            patch.object(
-                bot,
-                "_wait_for_purchase_entry_result",
-                return_value={"state": "sku_page"},
-            ),
-            patch.object(bot, "_click_price_option_by_config_index") as price_click,
-            patch.object(bot, "_click_sku_buy_button_element") as buy_click,
-            patch.object(bot, "_click_coordinates") as click_coords,
-            patch.object(
-                bot._pipeline, "_confirm_page_ready", side_effect=[False, True]
-            ),
-        ):
-            result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
+        with patch.object( bot, "_wait_for_purchase_entry_result", return_value={"state": "sku_page"}, ):
+            with patch.object(bot, "_click_price_option_by_config_index") as price_click:
+                with patch.object(bot, "_click_sku_buy_button_element") as buy_click:
+                    with patch.object(bot, "_click_coordinates") as click_coords:
+                        with patch.object( bot._pipeline, "_confirm_page_ready", side_effect=[False, True] ):
+                            result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
 
         assert result is True
         assert mock_d.shell.call_count >= 2
@@ -4141,20 +3131,12 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with (
-            patch.object(
-                bot,
-                "_wait_for_purchase_entry_result",
-                return_value={"state": "sku_page"},
-            ),
-            patch.object(bot, "_click_price_option_by_config_index") as price_click,
-            patch.object(bot, "_click_sku_buy_button_element") as buy_click,
-            patch.object(bot, "_click_coordinates"),
-            patch.object(
-                bot._pipeline, "_confirm_page_ready", side_effect=[False, True]
-            ),
-        ):
-            result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
+        with patch.object( bot, "_wait_for_purchase_entry_result", return_value={"state": "sku_page"}, ):
+            with patch.object(bot, "_click_price_option_by_config_index") as price_click:
+                with patch.object(bot, "_click_sku_buy_button_element") as buy_click:
+                    with patch.object(bot, "_click_coordinates"):
+                        with patch.object( bot._pipeline, "_confirm_page_ready", side_effect=[False, True] ):
+                            result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
 
         assert result is True
         assert mock_d.shell.call_count >= 2
@@ -4179,20 +3161,14 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with (
-            patch.object(
-                bot,
-                "_wait_for_purchase_entry_result",
-                return_value={"state": "sku_page"},
-            ),
-            patch.object(bot, "_click_price_option_by_config_index", return_value=True),
-            patch.object(bot, "_click_sku_buy_button_element", return_value=True),
-            patch.object(bot._pipeline, "_confirm_page_ready", side_effect=False),
-            patch("mobile.damai_app.time") as mock_time,
-        ):
-            mock_time.time = Mock(side_effect=[100.0, 100.0, 109.0])
-            mock_time.sleep = Mock()
-            result = bot._run_warm_validation_pipeline(start_time=100.0)
+        with patch.object( bot, "_wait_for_purchase_entry_result", return_value={"state": "sku_page"}, ):
+            with patch.object(bot, "_click_price_option_by_config_index", return_value=True):
+                with patch.object(bot, "_click_sku_buy_button_element", return_value=True):
+                    with patch.object(bot._pipeline, "_confirm_page_ready", side_effect=False):
+                        with patch("mobile.damai_app.time") as mock_time:
+                            mock_time.time = Mock(side_effect=[100.0, 100.0, 109.0])
+                            mock_time.sleep = Mock()
+                            result = bot._run_warm_validation_pipeline(start_time=100.0)
 
         assert result is None
 
@@ -4213,25 +3189,13 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with (
-            patch.object(
-                bot,
-                "_wait_for_purchase_entry_result",
-                side_effect=[None, {"state": "sku_page"}],
-            ),
-            patch.object(
-                bot._pipeline, "_shell_price_and_buy_until_confirm", return_value=False
-            ),
-            patch.object(bot, "_click_price_option_by_config_index", return_value=True),
-            patch.object(
-                bot, "_click_sku_buy_button_element", return_value=True
-            ) as buy_click,
-            patch.object(bot, "_click_coordinates") as click_coords,
-            patch.object(
-                bot._pipeline, "_confirm_page_ready", side_effect=[False, True]
-            ),
-        ):
-            result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
+        with patch.object( bot, "_wait_for_purchase_entry_result", side_effect=[None, {"state": "sku_page"}], ):
+            with patch.object( bot._pipeline, "_shell_price_and_buy_until_confirm", return_value=False ):
+                with patch.object(bot, "_click_price_option_by_config_index", return_value=True):
+                    with patch.object( bot, "_click_sku_buy_button_element", return_value=True ) as buy_click:
+                        with patch.object(bot, "_click_coordinates") as click_coords:
+                            with patch.object( bot._pipeline, "_confirm_page_ready", side_effect=[False, True] ):
+                                result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
 
         assert result is True
         detail_calls = [
@@ -4264,13 +3228,9 @@ class TestWarmValidationPipeline:
         # Don't populate coords
         initial_probe = {"state": "detail_page", "purchase_button": True}
 
-        with (
-            patch.object(bot, "_run_warm_validation_pipeline") as pipeline,
-            patch.object(
-                bot, "_enter_purchase_flow_from_detail_page", return_value=None
-            ),
-        ):
-            result = bot.run_ticket_grabbing(initial_page_probe=initial_probe)
+        with patch.object(bot, "_run_warm_validation_pipeline") as pipeline:
+            with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value=None ):
+                result = bot.run_ticket_grabbing(initial_page_probe=initial_probe)
 
         pipeline.assert_not_called()  # _has_warm_pipeline_coords returned False
 
@@ -4297,16 +3257,10 @@ class TestRecoverToDetailPage:
         }
         # First probe_current_page call (after dismiss_startup_popups) returns order_confirm;
         # second call (in back-loop with fast=True) returns detail_page.
-        with (
-            patch.object(bot, "dismiss_startup_popups"),
-            patch.object(
-                bot,
-                "probe_current_page",
-                side_effect=[{"state": "order_confirm_page"}, detail_result],
-            ) as probe_mock,
-            patch.object(bot, "_press_keycode_safe", return_value=True),
-        ):
-            result = bot._recover_to_detail_page_for_local_retry(initial_probe)
+        with patch.object(bot, "dismiss_startup_popups"):
+            with patch.object( bot, "probe_current_page", side_effect=[{"state": "order_confirm_page"}, detail_result], ) as probe_mock:
+                with patch.object(bot, "_press_keycode_safe", return_value=True):
+                    result = bot._recover_to_detail_page_for_local_retry(initial_probe)
         assert result["state"] == "detail_page"
         # Second call should be fast=True (back-loop)
         assert probe_mock.call_count == 2
@@ -4365,13 +3319,9 @@ class TestRushPreSelectViaXml:
         bot.driver = mock_d
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
-        with (
-            patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False),
-            patch.object(
-                bot, "_dump_hierarchy_xml", return_value=ET.fromstring(self.DETAIL_XML)
-            ),
-        ):
-            result = bot._rush_preselect_and_buy_via_xml()
+        with patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False):
+            with patch.object( bot, "_dump_hierarchy_xml", return_value=ET.fromstring(self.DETAIL_XML) ):
+                result = bot._rush_preselect_and_buy_via_xml()
 
         assert result is True
         assert bot._cached_hot_path_coords["city"] == (150, 525)
@@ -4394,15 +3344,9 @@ class TestRushPreSelectViaXml:
 
         mock_d = Mock()
         bot.d = mock_d
-        with (
-            patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False),
-            patch.object(
-                bot,
-                "_dump_hierarchy_xml",
-                return_value=ET.fromstring(self.DETAIL_XML_NO_CITY),
-            ),
-        ):
-            result = bot._rush_preselect_and_buy_via_xml()
+        with patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False):
+            with patch.object( bot, "_dump_hierarchy_xml", return_value=ET.fromstring(self.DETAIL_XML_NO_CITY), ):
+                result = bot._rush_preselect_and_buy_via_xml()
 
         assert result is True
         assert "city" in bot._cached_hot_path_no_match
@@ -4420,13 +3364,9 @@ class TestRushPreSelectViaXml:
 
         mock_d = Mock()
         bot.d = mock_d
-        with (
-            patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False),
-            patch.object(
-                bot, "_dump_hierarchy_xml", return_value=ET.fromstring(no_buy_xml)
-            ),
-        ):
-            result = bot._rush_preselect_and_buy_via_xml()
+        with patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False):
+            with patch.object( bot, "_dump_hierarchy_xml", return_value=ET.fromstring(no_buy_xml) ):
+                result = bot._rush_preselect_and_buy_via_xml()
 
         assert result is False
 
@@ -4451,15 +3391,9 @@ class TestRushPreSelectViaXml:
             "price_container": True,
             "reservation_mode": False,
         }
-        with (
-            patch.object(
-                bot, "_rush_preselect_and_buy_via_xml", return_value=True
-            ) as xml_method,
-            patch.object(
-                bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ),
-        ):
-            result = bot._enter_purchase_flow_from_detail_page(prepared=False)
+        with patch.object( bot, "_rush_preselect_and_buy_via_xml", return_value=True ) as xml_method:
+            with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ):
+                result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         assert result == next_probe
         xml_method.assert_called_once()
@@ -4474,14 +3408,10 @@ class TestRushPreSelectViaXml:
             "price_container": True,
             "reservation_mode": False,
         }
-        with (
-            patch.object(bot, "_rush_preselect_and_buy_via_xml") as xml_method,
-            patch.object(bot, "_cached_tap", return_value=True),
-            patch.object(
-                bot, "_wait_for_purchase_entry_result", return_value=next_probe
-            ),
-        ):
-            result = bot._enter_purchase_flow_from_detail_page(prepared=False)
+        with patch.object(bot, "_rush_preselect_and_buy_via_xml") as xml_method:
+            with patch.object(bot, "_cached_tap", return_value=True):
+                with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ):
+                    result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         xml_method.assert_not_called()  # warm path, skip XML dump
 
@@ -4802,13 +3732,11 @@ class TestSaleReadyTexts:
         )
 
         wall_start = _time_module.perf_counter()
-        with (
-            patch("mobile.damai_app.datetime") as mock_dt,
-            patch.object(bot, "_has_element", side_effect=has_element),
-        ):
-            mock_dt.fromisoformat = datetime.fromisoformat
-            mock_dt.now = mock_now
-            bot.wait_for_sale_start()
+        with patch("mobile.damai_app.datetime") as mock_dt:
+            with patch.object(bot, "_has_element", side_effect=has_element):
+                mock_dt.fromisoformat = datetime.fromisoformat
+                mock_dt.now = mock_now
+                bot.wait_for_sale_start()
         wall_elapsed = _time_module.perf_counter() - wall_start
 
         assert wall_elapsed < 1.0, (


### PR DESCRIPTION
## Summary
- **#32**：给 `mobile/damai_app.py` 顶部 selenium import 加 try/except 守门，缺失时 `raise SystemExit` 含 `poetry install` 友好提示；`mobile/scripts/start_ticket_grabbing.sh` 启动时预检 poetry 与三大依赖（selenium / uiautomator2 / adbutils），缺失时自动 `poetry install`
- **#29**：新增模块常量 `SALE_READY_TEXTS`（覆盖「立即购票 / 立即预定 / **立即预订** / 立即抢票 / Book Now」），`_is_sale_ready` / `_enter_purchase_flow_from_detail_page` 全部经此常量派生 textContains/textMatches；`buy_button_guard.SAFE_TEXTS` 同步追加；`hot_path_benchmark.StepTimelineRecorder` 追加 `cta_text_seen` / `polls_before_match` 字段并自动解析 `CTA_MATCH` 日志行

## Test plan
- [x] `poetry run test` 全绿（889 passed）
- [x] 覆盖率 ≥80%（实测 81.23%）
- [ ] 在缺少 selenium 的虚拟环境直接 `python mobile/damai_app.py`，应抛 SystemExit 提示 poetry install
- [ ] 真机 probe 模式识别「立即预订」文案（W1-Wed QA 真机回归）
- [ ] CI（test.yml）在 PR 上跑绿

## 关联
- Closes #32
- Refs #29（仅 Step 1-2 已完成；Step 3 默认参数调优 `countdown_lead_ms / fast_retry_interval_ms / wait_cta_ready_timeout_ms` 留给 W1-Wed 单独 PR，需配套 benchmark 对比数据）

## 待办（不在本 PR 处理，记录给后续 sprint）
- `mobile/damai_app.py` 中另两处 inline `textMatches(".*预约.*|.*购买.*|.*立即.*")`（`inspect_current_target_event` / 另一 `book_selectors`）未改为 `SALE_READY_TEXTS` 派生 — 因 user prompt 明确仅限 `wait_for_sale_start` 与 `_enter_purchase_flow_from_detail_page`
- `damai_app.py` 已 ~1900+ 行，超出 800 行 hook 上限警告（W4-01 拆分计划已立项）
- `tests/unit/test_environment_check.py` 选择 subprocess 隔离方案而非 in-process `importlib` reload，避免 `mobile.damai_app` 模块 reload 导致同测试文件中其它 `patch("mobile.damai_app.logger")` 引用错位（已经在本 PR 早期发现并修复该 cross-test 污染）

🤖 Generated with [Claude Code](https://claude.ai/code)