### PR TITLE
chore(ops): GitHub issue 模板 + scripts/release_check.sh

### DIFF
--- a/.github/ISSUE_REPLY_TEMPLATES.md
+++ b/.github/ISSUE_REPLY_TEMPLATES.md
@@ -1,0 +1,161 @@
+# GitHub Issue 评论回复模板
+
+> **用途**：ops 在 GitHub 上分诊 / 跟进 issue 时复制粘贴使用。GitHub 原生不支持评论模板，本文件作为 ops 团队的「快捷回复库」。
+>
+> **来源**：从 [`reference/08-ops-runbook.md`](../reference/08-ops-runbook.md) §3「用户支持 SOP」抽取（reference/ 目录 gitignored，本文件在仓库内可见，供新加入 ops 快速上手）。
+>
+> **使用约定**：
+> 1. 复制对应小节的代码块内容到 GitHub 评论
+> 2. 把 `<占位符>` 替换为实际值
+> 3. 隐去用户上报中的敏感个人信息（姓名、手机号、身份证号）后再贴日志/dump
+> 4. 回复后立即在 issue 加上对应优先级标签（`priority/p0` / `priority/p1` / `priority/p2` / `needs-info` / `wontfix`）
+
+## 1. 首次回复模板（2h SLA 内）
+
+收到任何新 issue，先用此模板补环境信息：
+
+```markdown
+你好，已收到反馈，感谢报告 🙇
+
+为加快定位，请补充以下信息：
+
+- 设备型号：
+- Android 版本：
+- 大麦 App 版本（设置 → 关于）：
+- HaTickets 版本 / commit：
+- Python 版本（`poetry run python --version`）：
+- `mobile/config.jsonc` 内容（**请隐去观演人姓名、手机号**）：
+- 完整错误日志（请使用代码块粘贴 traceback）：
+
+收到信息后我们会在 24 小时内（P0/P1）或 1 周内（P2）给出反馈。
+```
+
+并执行：
+
+- [ ] 加 `triage` 标签
+- [ ] 通知 dev lead（疑似 P0/P1）
+
+## 2. 环境问题模板（#32 类 — Poetry 虚拟环境未激活 / 依赖缺失）
+
+```markdown
+看起来是 Poetry 虚拟环境未激活，导致 `mobile/` 模块无法 import 已安装的依赖。
+
+请按以下顺序排查：
+
+1. 在仓库根目录运行：
+   ```bash
+   poetry install
+   ```
+2. **不要直接 `python mobile/damai_app.py`**。请通过封装脚本启动：
+   ```bash
+   mobile/scripts/start_ticket_grabbing.sh --probe --yes
+   ```
+3. 如仍报错，请贴出 `poetry env info` 输出。
+
+详见 [`docs/quick-start.md`](../blob/master/docs/quick-start.md) 的「常见错误排查」一节。
+```
+
+并执行：
+
+- [ ] 加 `priority/p0` 或 `priority/p2` 标签
+- [ ] 标 `needs-info` 等 1 周后未回复则关闭
+
+## 3. UI 变更模板（#29 / #31 类 — 大麦 App 升级导致文案/坐标变更）
+
+```markdown
+疑似大麦 App UI 变更（文案 / 资源 ID / 坐标 / 价格选项布局之一）。
+
+我们已加入维护流程，预计 **<X> 天内**发布修复版本。
+
+**临时方案**（在等待修复期间）：
+
+- 在 `mobile/config.jsonc` 中尝试设置：
+  ```jsonc
+  {
+    "rush_mode": true,
+    "price_index": 0
+  }
+  ```
+- 或运行 `mobile/scripts/start_ticket_grabbing.sh --probe --yes` 抓取当前 UI dump，附加到本 issue 帮助加速定位。
+
+**进度跟踪**：内部维护流程已登记，后续修复 commit 会在本 issue 下回复关联。
+
+感谢理解 🙇
+```
+
+并执行：
+
+- [ ] 加 `priority/p0` 或 `priority/p1` 标签
+- [ ] 通知 dev lead 触发 [`reference/.maintenance-checklist.md`](../reference/.maintenance-checklist.md) 6 步流程
+- [ ] 在 `reference/10-changelog.md` 追加变更条目
+
+## 4. 多场次模板（#25 类 — 多场次活动跳过场次选择）
+
+```markdown
+多场次（音乐节 / 巡演）活动需要在 `mobile/config.jsonc` 中明确指定 `city` 与 `date` 字段：
+
+```jsonc
+{
+  "city": "<城市，如「上海」>",
+  "date": "<MM.dd 格式，如「07.20」>",
+  "rush_mode": true   // 当前版本兜底，后续版本会优化场次选择状态机
+}
+```
+
+完整修复（自动选择指定场次）将随 v0.4.0 发布（预计 **W3** 上线）。
+
+如有具体场次的 dump 截图（`d.dump_hierarchy()` 输出）愿意附上，可帮助加速场次选择状态机的覆盖率提升。
+```
+
+并执行：
+
+- [ ] 加 `priority/p1` 标签
+- [ ] 关联到 issue #25 主线讨论
+
+## 5. 关闭模板
+
+### 5.1 已修复
+
+```markdown
+此问题已在 commit <SHA> / PR #<NN> 修复，将随 **v0.X.Y** 发布。
+
+请在新版本发布后再次验证，如仍有问题欢迎重开。
+
+感谢报告 🙇
+```
+
+### 5.2 wontfix（设计决策）
+
+```markdown
+经 PM 评估，此场景**暂不在维护范围内**：
+
+> <具体原因，例：选座功能涉及大麦风控强匹配，当前版本不支持，详见 reference/04-issues-matrix.md #27>
+
+如有强需求，欢迎在 [`docs/`](../blob/master/docs/) 之外的 discussions 区继续讨论。
+```
+
+### 5.3 needs-info 超时
+
+```markdown
+由于已超过 1 周未收到补充信息，本 issue 暂时关闭。
+
+如问题仍存在，欢迎在新评论中补充环境与日志，我们会重新打开。
+```
+
+## 优先级标签速查（来自 [reference/08-ops-runbook.md §3](../reference/08-ops-runbook.md)）
+
+| 标签 | 含义 | SLA |
+| --- | --- | --- |
+| `priority/p0` | 阻塞新用户启动 | 24 h 反馈，3 天内修复 |
+| `priority/p1` | 影响成功率 | 48 h 反馈，1 周内修复 |
+| `priority/p2` | 改进或边缘场景 | 1 周反馈，下个 sprint 评估 |
+| `needs-info` | 等用户补充 | 1 周无回复关闭 |
+| `wontfix` | 不修复（合规 / 设计决策） | PM 决定后立即关闭 |
+
+## 隐私处理
+
+收到含真实姓名 / 手机号 / 身份证号的 issue 时：
+
+1. **立即在评论中编辑**（GitHub「edit」原评论）替换为 `<HIDDEN>`
+2. 在评论下补一句：「已隐去敏感信息，下次提交建议预先处理。」
+3. 不在 dev / qa 群转发原始内容

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,70 @@
+---
+name: 🐛 Bug 报告 / Bug report
+about: 抢票脚本运行异常、报错、文案/坐标不匹配等问题
+title: "[BUG] "
+labels: ["bug", "triage"]
+assignees: []
+---
+
+> **隐私提示**：请在粘贴 `mobile/config.jsonc` 与日志前，**隐去观演人姓名、手机号、身份证号**。如不慎泄露，ops 收到后会在评论中编辑替换，但仍建议自查后再提交。
+
+## 环境信息（必填）
+
+> 运维分类需要这一节才能定位优先级，请勿删除。
+
+- 设备型号（例：Pixel 6 / Xiaomi 13）：
+- Android 版本（设置 → 关于手机）：
+- 大麦 App 版本（大麦 → 我的 → 设置 → 关于）：
+- HaTickets 版本 / commit SHA：
+- Python 版本（`poetry run python --version`）：
+- 操作系统（macOS 14 / Ubuntu 22.04 / Windows 11）：
+
+## 复现步骤
+
+1.
+2.
+3.
+
+## 期望行为
+
+<!-- 例：脚本应在开售后 3s 内进入下单确认页 -->
+
+## 实际行为
+
+<!-- 例：脚本卡在「立即预订」轮询超时 -->
+
+## 完整日志（必填）
+
+> 完整 traceback 比截图更有助于定位。请使用代码块。
+
+```
+<粘贴 poetry run 输出 / start_ticket_grabbing.sh 输出 / tmp/failures/*.log>
+```
+
+## 配置（隐去敏感字段）
+
+```jsonc
+{
+  "serial": "<DEVICE_SERIAL>",
+  "keyword": "<演出关键词>",
+  "users": ["<HIDDEN>"],
+  "city": "<城市>",
+  "date": "<MM.dd>",
+  // ... 其他字段
+}
+```
+
+## 相关截图 / dump（可选）
+
+<!-- 拖拽上传或附 tmp/failures/ 中文件 -->
+
+## 自查清单
+
+- [ ] 已运行 `poetry install`，且通过 `mobile/scripts/start_ticket_grabbing.sh --probe --yes` 启动（未直接 `python xxx.py`）
+- [ ] 已阅读 `docs/quick-start.md` 的「常见错误排查」一节
+- [ ] 已搜索现有 issues 确认无重复
+- [ ] 已隐去敏感个人信息
+
+---
+
+> **SLA**：ops 在 2 小时内分诊（添加优先级标签）。P0/P1 见 [reference/08-ops-runbook.md §3](https://github.com/currycan/HaTickets/blob/master/reference/08-ops-runbook.md)。

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,48 @@
+---
+name: ✨ 功能请求 / Feature request
+about: 新功能、改进建议、新场景支持（如新 UI 流程、新场次类型）
+title: "[FEATURE] "
+labels: ["enhancement", "triage"]
+assignees: []
+---
+
+## 想解决的问题
+
+<!-- 描述你遇到的实际场景或痛点。避免「我想要 X」式的解决方案先行；先讲问题。 -->
+
+## 期望的行为
+
+<!-- 你希望脚本怎么处理？请尽量具体。 -->
+
+## 当前的 workaround（如有）
+
+<!-- 例：手动在 config.jsonc 里设置 rush_mode=true；或人工选场次后再启动脚本 -->
+
+## 替代方案
+
+<!-- 你考虑过的其他做法？为什么不采纳？ -->
+
+## 影响范围（请勾选）
+
+- [ ] 仅自己的使用场景
+- [ ] 影响 NLP 自动配置流程（`prompt_runner.py`）
+- [ ] 影响热路径（开售后 3 秒内）
+- [ ] 涉及多场次 / 选座 / 抢购排队等新场景
+- [ ] 需新增对外可见的 CLI 参数 / config 字段
+- [ ] 需修改文档（`docs/`）
+
+## 优先级建议
+
+> 最终由 PM 评定。详见 [reference/04-issues-matrix.md 优先级总览](https://github.com/currycan/HaTickets/blob/master/reference/04-issues-matrix.md)。
+
+- [ ] P0 — 阻塞核心抢票流程
+- [ ] P1 — 影响成功率或体验
+- [ ] P2 — 改进或边缘场景
+
+## 相关 issue / PR
+
+<!-- 关联已有讨论。 -->
+
+---
+
+> **回复 SLA**：1 周内 PM 给出立项 / backlog / wontfix 决定。已立项的 feature 会进入下一轮 sprint 评估（参见 `reference/07-roadmap-4w.md`，团队内可见）。

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# scripts/release_check.sh — 发布前自动检查
+#
+# 来源：reference/08-ops-runbook.md §4「发布 checklist」脚本化
+#
+# 检查项（任一不通过 → exit 1，绿全 → exit 0 提示人工 git tag）：
+#   C1. 当前分支必须是 master
+#   C2. master 工作区必须 clean（无未提交、无 untracked）
+#   C3. `poetry run test` 通过（覆盖率 ≥80% 由 pyproject.toml 强制）
+#   C4. `bash mobile/scripts/benchmark_hot_path.sh --runs 3` 跑通并打印平均耗时
+#   C5. reference/10-changelog.md 含本次发布条目（与 --tag 比对，或要求 7 天内有更新）
+#
+# 用法：
+#   scripts/release_check.sh                # 通用检查
+#   scripts/release_check.sh --tag v0.3.5   # 指定版本号，强校验 changelog
+#   scripts/release_check.sh --skip-bench   # 离机环境跳过 benchmark（仅供 CI 调试）
+#
+# 退出码：
+#   0 = 全部通过，可人工 `git tag -a vX.Y.Z -m "..." && git push origin vX.Y.Z`
+#   1 = 任一检查失败
+#
+
+set -uo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+# ── 颜色 ──────────────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+    readonly RED=$'\033[0;31m'
+    readonly GRN=$'\033[0;32m'
+    readonly YLW=$'\033[1;33m'
+    readonly BLU=$'\033[0;34m'
+    readonly RST=$'\033[0m'
+else
+    readonly RED=''
+    readonly GRN=''
+    readonly YLW=''
+    readonly BLU=''
+    readonly RST=''
+fi
+
+ok()    { printf '%s✓%s %s\n' "$GRN" "$RST" "$1"; }
+fail()  { printf '%s✗%s %s\n' "$RED" "$RST" "$1"; }
+warn()  { printf '%s!%s %s\n' "$YLW" "$RST" "$1"; }
+info()  { printf '%s•%s %s\n' "$BLU" "$RST" "$1"; }
+header(){ printf '\n%s── %s ──%s\n' "$BLU" "$1" "$RST"; }
+
+# ── 参数解析 ──────────────────────────────────────────────────────────────
+TAG=""
+SKIP_BENCH=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag)
+            shift
+            [[ $# -gt 0 ]] || { fail "--tag 需要版本号参数（如 v0.3.5）"; exit 1; }
+            TAG="$1"
+            ;;
+        --tag=*)
+            TAG="${1#*=}"
+            ;;
+        --skip-bench)
+            SKIP_BENCH=true
+            ;;
+        -h|--help)
+            sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            fail "未知参数：$1（用 --help 查看用法）"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+FAILED=0
+record_fail() { FAILED=$((FAILED + 1)); }
+
+# ── C1：分支检查 ──────────────────────────────────────────────────────────
+header "C1. 分支检查"
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+if [[ "$CURRENT_BRANCH" == "master" ]]; then
+    ok "当前分支为 master"
+else
+    fail "当前分支为 '$CURRENT_BRANCH'，需切到 master：git checkout master && git pull --ff-only origin master"
+    record_fail
+fi
+
+# ── C2：工作区 clean 检查 ─────────────────────────────────────────────────
+header "C2. 工作区 clean"
+DIRTY_OUTPUT="$(git status --porcelain)"
+if [[ -z "$DIRTY_OUTPUT" ]]; then
+    ok "工作区无未提交修改与 untracked 文件"
+else
+    fail "工作区不 clean，下面是 git status --porcelain 输出："
+    printf '%s\n' "$DIRTY_OUTPUT" | sed 's/^/    /'
+    record_fail
+fi
+
+# ── C3：测试套件 ──────────────────────────────────────────────────────────
+header "C3. poetry run test"
+if ! command -v poetry >/dev/null 2>&1; then
+    fail "未找到 poetry 命令；请先安装 Poetry（https://python-poetry.org/）"
+    record_fail
+else
+    info "执行 poetry run test（覆盖率 ≥80% 由 pyproject.toml 强制）..."
+    if poetry run test; then
+        ok "测试套件通过"
+    else
+        fail "测试套件失败 —— 修实现而不是放宽阈值"
+        record_fail
+    fi
+fi
+
+# ── C4：热路径 benchmark ──────────────────────────────────────────────────
+header "C4. benchmark_hot_path.sh --runs 3"
+if [[ "$SKIP_BENCH" == "true" ]]; then
+    warn "已传 --skip-bench，跳过基准测试（仅供 CI 调试，正式发布不允许）"
+elif ! command -v adb >/dev/null 2>&1; then
+    fail "未找到 adb 命令；benchmark 需要 Android 真机连接，请在带真机的 ops 工作站重跑"
+    record_fail
+else
+    DEVICE_COUNT="$(adb devices 2>/dev/null | awk 'NR>1 && $2=="device" {n++} END{print n+0}')"
+    if [[ "$DEVICE_COUNT" -lt 1 ]]; then
+        fail "adb 未检测到已授权设备（需至少 1 台 device 状态）"
+        record_fail
+    else
+        info "检测到 $DEVICE_COUNT 台 adb 设备，开始跑 3 次基准..."
+        BENCH_LOG="$(mktemp -t hatickets-bench.XXXXXX.log)"
+        if bash mobile/scripts/benchmark_hot_path.sh --runs 3 2>&1 | tee "$BENCH_LOG"; then
+            # 提取平均耗时（脚本输出格式可能演进，宽松匹配「平均」「average」「耗时」相关行）
+            AVG_LINE="$(grep -iE '平均|average|avg' "$BENCH_LOG" | tail -1 || true)"
+            if [[ -n "$AVG_LINE" ]]; then
+                ok "基准跑通：$AVG_LINE"
+            else
+                ok "基准跑通（未解析到平均耗时行，请人工查看上方输出）"
+            fi
+            info "基准日志保留在：$BENCH_LOG"
+        else
+            fail "benchmark_hot_path.sh 执行失败，请检查真机状态与配置"
+            record_fail
+        fi
+    fi
+fi
+
+# ── C5：changelog 校验 ────────────────────────────────────────────────────
+header "C5. reference/10-changelog.md 含本次发布条目"
+CHANGELOG="reference/10-changelog.md"
+if [[ ! -f "$CHANGELOG" ]]; then
+    fail "未找到 $CHANGELOG（reference/ 目录是 gitignored，请先 clone 或同步团队战情室）"
+    record_fail
+elif [[ -n "$TAG" ]]; then
+    if grep -qE "^## .*${TAG}\b" "$CHANGELOG"; then
+        ok "changelog 含 $TAG 标题条目"
+    else
+        fail "changelog 未找到 '## … $TAG' 标题条目，请先在 $CHANGELOG 顶部追加发布条目"
+        record_fail
+    fi
+else
+    # 未传 --tag：要求最近 7 天内至少有一条新条目
+    TODAY="$(date +%Y-%m-%d)"
+    SEVEN_DAYS_AGO="$(date -v-7d +%Y-%m-%d 2>/dev/null || date -d '7 days ago' +%Y-%m-%d 2>/dev/null || echo "")"
+    if [[ -z "$SEVEN_DAYS_AGO" ]]; then
+        warn "无法计算 7 天前日期（date 命令兼容性问题）；改为手动确认"
+        warn "请目视检查 $CHANGELOG 顶部是否含本次发布条目"
+    else
+        RECENT_HIT="$(awk -v from="$SEVEN_DAYS_AGO" -v to="$TODAY" '
+            /^## [0-9]{4}-[0-9]{2}-[0-9]{2}/ {
+                d=$2; gsub(/[^0-9-]/,"",d)
+                if (d >= from && d <= to) { print; exit }
+            }
+        ' "$CHANGELOG" || true)"
+        if [[ -n "$RECENT_HIT" ]]; then
+            ok "changelog 近 7 天有更新：$RECENT_HIT"
+        else
+            fail "changelog 近 7 天无更新条目；发布前请追加本次变更说明"
+            record_fail
+        fi
+    fi
+fi
+
+# ── 汇总 ──────────────────────────────────────────────────────────────────
+header "结果"
+if [[ $FAILED -eq 0 ]]; then
+    ok "全部检查通过 —— 可执行人工发布步骤："
+    if [[ -n "$TAG" ]]; then
+        printf '\n    git tag -a %s -m "release notes here"\n    git push origin %s\n\n' "$TAG" "$TAG"
+    else
+        printf '\n    git tag -a vX.Y.Z -m "release notes here"\n    git push origin vX.Y.Z\n\n'
+    fi
+    printf '注意：本脚本不会自动 tag，避免误操作。\n'
+    exit 0
+else
+    fail "$FAILED 项检查未通过 —— 修复后重跑 $0"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- 新增 `.github/ISSUE_TEMPLATE/bug_report.md`（环境字段 + 隐私提示 + 自查清单）
- 新增 `.github/ISSUE_TEMPLATE/feature_request.md`（场景痛点 + 影响面 + PM 决议 SLA）
- 新增 `.github/ISSUE_REPLY_TEMPLATES.md`（5 套 ops 评论模板：首回 / 环境问题 / UI 变更 / 多场次 / 关闭三档）
- 新增 `scripts/release_check.sh`：发布前自动检查
  - C1 当前必须在 master
  - C2 工作区必须 clean
  - C3 `poetry run test` 通过（覆盖率门槛由 pyproject 强制）
  - C4 `mobile/scripts/benchmark_hot_path.sh --runs 3` 跑通并打印平均耗时
  - C5 `reference/10-changelog.md` 含本次发布条目（与 `--tag vX.Y.Z` 比对，或近 7 天有更新）
  - C6 任一失败 exit 1，绿全才允许人工 `git tag`

## Test plan

- [ ] `bash scripts/release_check.sh` 在 clean master 上 exit 0（含真机 + changelog 条目时）
- [x] `bash scripts/release_check.sh` 在 dirty / 非 master 状态下 exit 1 — 已本地实测：当前 ops 分支 + dirty 状态下 C1+C2 失败、FAILED=2、exit=1
- [x] `bash scripts/release_check.sh --skip-bench` 在测试通过、changelog 7 天内有条目时仅因 C1/C2 失败而 exit 1 — 已本地实测
- [x] `bash scripts/release_check.sh --help` 输出用法说明
- [x] 模板格式符合 [GitHub issue templates 规范](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests)（YAML frontmatter `name/about/title/labels/assignees`）

## 验证记录（本地）

```text
── C1. 分支检查 ──
✗ 当前分支为 'ops/w1-emergency-flow'，需切到 master
── C2. 工作区 clean ──
✗ 工作区不 clean
── C3. poetry run test ──
✓ 测试套件通过（889 passed, coverage 80.82%）
── C4. benchmark_hot_path.sh --runs 3 ──
! 已传 --skip-bench，跳过基准测试
── C5. reference/10-changelog.md 含本次发布条目 ──
✓ changelog 近 7 天有更新
── 结果 ──
✗ 2 项检查未通过
exit=1
```

## 关联

- 实施 `reference/.maintenance-checklist.md` 与 `reference/08-ops-runbook.md` 第 3-4 节
- 演练记录与 `_template-ui-change.md` 已沉淀到团队战情室（`reference/` gitignored，不入本 PR）
- 不涉及 `mobile/` / `desktop/` / `docs/` 任何源代码