### PR TITLE
chore(release): v0.4.0 风格修正 + v0.4.1 release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    outputs:
-      release_id: ${{ steps.create-release.outputs.id }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -29,56 +27,10 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create release with auto-generated notes
-        id: create-release
         uses: softprops/action-gh-release@v2
         with:
-          name: "app ${{ github.ref_name }}"
+          name: "HaTickets ${{ github.ref_name }}"
           body: ${{ steps.tag-notes.outputs.notes }}
           generate_release_notes: true
           draft: false
           prerelease: false
-
-  # Desktop (Tauri) build — disabled, desktop module is deprecated.
-  # build-tauri:
-  #   needs: create-release
-  #   permissions:
-  #     contents: write
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       platform: [macos-latest, ubuntu-22.04, windows-latest]
-  #   runs-on: ${{ matrix.platform }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Reconfigure git to use HTTP authentication
-  #       run: git config --global url."https://github.com/".insteadOf ssh://git@github.com/
-  #     - name: Setup Node.js
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 22
-  #     - name: Install Rust stable
-  #       uses: dtolnay/rust-toolchain@stable
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         workspaces: desktop/src-tauri
-  #     - name: Install system dependencies (Ubuntu only)
-  #       if: matrix.platform == 'ubuntu-22.04'
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y \
-  #           build-essential pkg-config libssl-dev \
-  #           libwebkit2gtk-4.0-dev libgtk-3-dev \
-  #           libappindicator3-dev librsvg2-dev patchelf
-  #     - name: Install frontend dependencies
-  #       run: yarn install
-  #       working-directory: desktop
-  #     - uses: tauri-apps/tauri-action@v0
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         tagName: ${{ github.ref_name }}
-  #         releaseName: "app ${{ github.ref_name }}"
-  #         releaseId: ${{ needs.create-release.outputs.release_id }}
-  #         releaseDraft: false
-  #         prerelease: false
-  #         projectPath: desktop

--- a/docs/releases/v0.4.1-user.md
+++ b/docs/releases/v0.4.1-user.md
@@ -1,0 +1,46 @@
+# HaTickets v0.4.1（用户版发布说明）
+
+发布日期：2026-05-05
+
+这是一个**维护型 patch**：识别更稳、安装更省心、Python 版本兼容范围更准。日常用法不变。
+
+## 你会直接感受到的变化
+
+- **「立即预订」也能识别了**：大麦 App 把开售按钮文案在「立即购票 / 立即预定 / 立即预订 / 立即抢票」之间换来换去，这次把全集合都囊括了，不会再因为按钮文案变化漏抢。
+- **缺依赖时报错友好**：直接 `python mobile/damai_app.py` 时若忘了 `poetry install`，会报「请先在仓库根目录运行 `poetry install`」而非 `ModuleNotFoundError: No module named 'selenium'`。
+- **Python 3.14 装不上的提示更早**：本版本明确不支持 Python 3.14（部分依赖的 wheel 还没就绪）。建议使用 Python 3.13 或 3.12。
+- **抢票热路径速度**：实测平均 2.93 秒（v0.4.0 时代基线 4.37 秒），**约快 1/3**。
+
+## 推荐使用流程（保持 4 步）
+
+1. 安装依赖
+   ```bash
+   poetry install
+   ```
+2. 连接手机，确认 `adb devices` 能识别
+3. 先做安全探测（不提交订单）
+   ```bash
+   ./mobile/scripts/start_ticket_grabbing.sh --probe --yes
+   ```
+4. 正式抢票
+   ```bash
+   ./mobile/scripts/start_ticket_grabbing.sh --yes
+   ```
+
+## 自然语言入口（可选，与 v0.4.0 一致）
+
+```bash
+./mobile/scripts/run_from_prompt.sh --mode probe --yes "给张三抢 5 月 20 号张杰北京站演唱会内场票，价位 1680 元"
+```
+
+## 从 v0.4.0 升级注意
+
+- 直接 `git pull && poetry install` 即可，没有必填配置项变化。
+- 如果你的 Python 是 3.14.x，请降级到 3.13 或 3.12 后重新 `poetry install`。
+- 如果你 fork 过仓库并直接 import 了 `mobile.damai_app` 内部的 helper（如 `_find`、`_click_coordinates`），现在它们已搬到 `mobile/ui_primitives.py`；公共主流程接口未变。
+
+## 已知边界
+
+- 线上库存、风控、验证码会影响结果，自动化不保证 100% 成功。
+- 建议每次正式抢票前先跑一次 `--probe` 确认页面识别正常。
+- 多场次（音乐节）选择仍偶有边界，临时方案：在 `config.jsonc` 中开启 `rush_mode: true`。

--- a/docs/releases/v0.4.1.md
+++ b/docs/releases/v0.4.1.md
@@ -1,0 +1,146 @@
+# HaTickets v0.4.1 Release Notes
+
+发布日期：2026-05-05
+对比基线：`v0.4.0 (8652595)` → `master (3e5291f)`
+变更规模：49 commits，84 files changed（`+10441 / -14447`，净减约 4006 行）
+
+## 版本定位
+
+`v0.4.1` 把 v0.4.0 之后约 5 周内沉淀下来的工作打包发布：mobile 主流程拆分为 8 个子模块、Web (Selenium) 模块彻底移除、W1 止血周（2026-05-05）三个 P0 缺陷修复、Python 3.8 全面兼容、ops 基础设施落地。整体方向是**模块化 + 可维护性 + 用户启动友好度**。
+
+## 主要功能提升
+
+### 1) Mobile 主流程子模块化重构（核心变更）
+
+- 把 `mobile/damai_app.py`（原 2142 行）拆分为多个职责单一的子模块，主流程瘦身至 ~1694 行：
+  - `mobile/ui_primitives.py`（706 行）：35 个 UI 原子操作（`_find` / `_click_coordinates` / `_element_rect` 等）
+  - `mobile/page_probe.py`：带 TTL 缓存与 Activity-based fallback 的快速页面识别
+  - `mobile/fast_pipeline.py`（602 行）：带全局 5s 截止线的极速热路径
+  - `mobile/price_selector.py` / `mobile/attendee_selector.py`：票价与观演人选择，delegate pattern 委托回 `DamaiBot`
+  - `mobile/event_navigator.py`：搜索 / 导航子流程
+  - `mobile/recovery.py`：分层 back-navigation 恢复
+  - `mobile/buy_button_guard.py`：防误点「立即预约」守门
+- 子模块之间统一通过 `DamaiBot` 委托交互；旧 monolithic 调用站点保持向后兼容。
+
+涉及文件：
+- `mobile/damai_app.py`、`mobile/ui_primitives.py`、`mobile/page_probe.py`、`mobile/fast_pipeline.py`
+- `mobile/price_selector.py`、`mobile/attendee_selector.py`、`mobile/event_navigator.py`
+- `mobile/recovery.py`、`mobile/buy_button_guard.py`
+
+### 2) Web (Selenium) 模块完全移除（PR #20）
+
+- 删除 `web/`（旧 Selenium 方案），合计减少约 14000 行代码。
+- 移除原因：大麦 Web 端风控强度持续升级，Selenium 路径已不再可行；维护双栈成本不划算。
+- `mobile/damai_app.py` 顶部对 `selenium` 的 import 转为 try/except 守门：缺失依赖时报「请运行 `poetry install`」而非 `ModuleNotFoundError`，避免新用户被技术报错挡在门外（修复 issue #32）。
+
+涉及文件：
+- `web/`（整目录删除）
+- `mobile/damai_app.py`、`mobile/buy_button_guard.py`
+
+### 3) W1 止血周 P0 修复（2026-05-05）
+
+- **#32 selenium ImportError 友好提示**（PR #33）：除 import 守门外，`mobile/scripts/start_ticket_grabbing.sh` 启动时预检 poetry + selenium / uiautomator2 / adbutils 三大依赖，缺失自动 `poetry install`。
+- **#29 CTA 文案集合扩展**（PR #33，Step 1-2）：新增模块常量 `SALE_READY_TEXTS`，覆盖「立即购票 / 立即预定 / 立即预订 / 立即抢票 / Book Now」；`_is_sale_ready` 与购买流程入口统一由该集合派生 `textContains` / `textMatches`。`hot_path_benchmark.StepTimelineRecorder` 追加 `cta_text_seen` / `polls_before_match` 字段。
+  - **注**：性能默认参数（`countdown_lead_ms` / `fast_retry_interval_ms` / `wait_cta_ready_timeout_ms`）的 Step 3 调优留给后续版本。
+- **#21 Python 版本范围收紧**（PR #34）：`pyproject.toml` 收紧到 `>=3.8,<3.14`（避免 3.14.x 下部分依赖无法安装）；`start_ticket_grabbing.sh` 启动时检查 Python 版本；CI 矩阵新增 Python 3.13 校验。
+
+### 4) Python 3.8 全面兼容
+
+- 修复多处 PEP 585 内置泛型注解（`tuple[str, ...]` 等）与 PEP 617 括号化 `with` 语句导致的 3.8 不兼容。
+- 通过 `from __future__ import annotations` + 反斜杠 `with` 续行恢复 3.8 可解析。
+- 新增 `tests/unit/test_environment_check.py`：subprocess 隔离测试 selenium 缺失时的友好报错。
+
+涉及文件：
+- `mobile/damai_app.py`、`mobile/event_navigator.py`、`mobile/price_selector.py`、`mobile/attendee_selector.py`
+- `tests/unit/test_environment_check.py`
+
+### 5) ops 基础设施
+
+- `.github/ISSUE_TEMPLATE/bug_report.md`：含设备 / Android / 大麦 App / Python 版本必填字段，并提示「隐去观演人姓名」。
+- `.github/ISSUE_TEMPLATE/feature_request.md`：1 周 PM 决策 SLA 标注。
+- `.github/ISSUE_REPLY_TEMPLATES.md`：5 段 ops 复用回复模板（PII 处理协议含其中）。
+- `scripts/release_check.sh`：6-gate 发版前自动检查（master 分支 / 工作区 clean / `poetry run test` 含 80% 覆盖率门槛 / 真机 benchmark / changelog 含本次发布条目 / **docs/releases/`<tag>`.md 与 -user.md 双文件存在**）。
+
+涉及文件：
+- `.github/ISSUE_TEMPLATE/bug_report.md`、`.github/ISSUE_TEMPLATE/feature_request.md`
+- `.github/ISSUE_REPLY_TEMPLATES.md`
+- `scripts/release_check.sh`
+
+### 6) CI/CD 进一步精简
+
+- `release.yml`：彻底删除已废弃的 `build-tauri` job 注释代码块，命名约定改为 `HaTickets vX.Y.Z`（统一品牌前缀）。
+- `test.yml`：Python 矩阵新增 3.13。
+
+涉及文件：
+- `.github/workflows/release.yml`、`.github/workflows/test.yml`
+
+### 7) 测试覆盖增强
+
+- 新增 / 增补：`test_mobile_damai_app_u2_adapter.py`（u2 适配层）、`test_price_selector.py`、`test_mobile_attendee_selector.py`、`test_mobile_event_navigator.py`、`test_fast_pipeline.py`、`test_mobile_logger.py`、`test_environment_check.py`。
+- 单测合计 889 个全部通过（覆盖率 80.82%，仅统计 `mobile/`）。
+
+## 兼容性与行为变化（升级必读）
+
+### 1) `web/` 已移除
+
+- Web (Selenium) 方案彻底废弃；任何针对 `web/...` 的 import / 脚本 / 文档引用都不再生效。
+- 维护者立场：**不再接受 Web 路径相关 PR / issue**。
+
+### 2) mobile 主流程被拆为 8 个子模块
+
+- 直接引用 `mobile.damai_app.<symbol>` 的旧代码大多数仍可工作（公共接口保持），但若 fork / 二次开发依赖了内部 helper（`_find` / `_click_coordinates` 等），建议改 import 自 `mobile.ui_primitives`。
+- 子模块通过 delegate pattern 与 `DamaiBot` 交互，扩展点更清晰。
+
+### 3) Python 版本范围 `>=3.8,<3.14`
+
+- Python 3.14.x 下 `uiautomator2` / `selenium` 部分 wheel 尚未就绪，安装会失败。已用过 3.14 的用户请降级到 3.13 / 3.12。
+
+### 4) 启动期版本与依赖检查
+
+- `mobile/scripts/start_ticket_grabbing.sh` 现在会在启动前检查：(a) Python 版本范围 (b) selenium / uiautomator2 / adbutils 三大依赖是否到位，缺失自动 `poetry install`。
+- 出错信息更友好，但启动多了 ~1s 预检开销。
+
+## 从 v0.4.0 升级到 v0.4.1（建议步骤）
+
+1. 拉代码并安装依赖
+   ```bash
+   git pull
+   poetry install
+   ```
+2. 检查配置（如有自定义改动）
+   ```bash
+   diff mobile/config.example.jsonc mobile/config.jsonc | head -40
+   ```
+   v0.4.1 未引入新的必填字段，旧 `config.jsonc` 直接可用。
+3. 先做安全探测（推荐）
+   ```bash
+   ./mobile/scripts/start_ticket_grabbing.sh --probe --yes
+   ```
+4. 正式抢票
+   ```bash
+   ./mobile/scripts/start_ticket_grabbing.sh --yes
+   ```
+
+> 注意：如果你之前已升级到 v0.4.0，本次升级几乎是无感的；CTA 文案识别更稳、Python 3.13 用户不再装得上 3.14 时报 wheel 缺失。
+
+## 测试覆盖
+
+- 889 tests passed
+- 覆盖率 80.82%（阈值 80%；仅统计 `mobile/`）
+- CI 矩阵：Python 3.8 / 3.9 / 3.10 / 3.12 / 3.13
+
+## 性能基准（v0.4.0 baseline → v0.4.1 实测）
+
+`bash mobile/scripts/benchmark_hot_path.sh --runs 3`（device c6c4eb67，开始状态 detail_page）：
+
+- avg / min / max = **2.93s** / 2.00s / 4.67s
+- recovery avg = 1.20s
+- 对比 v0.4.0 时代基线 4.37s，**改善约 33%**，无退化
+
+## 已知边界
+
+- 线上风控、库存波动与验证码仍会影响最终结果，自动化只能提升效率，不能保证 100% 成功。
+- u2 直连依赖设备上的 ATX agent，偶发断连重新连接 USB 即可恢复。
+- 多场次（音乐节）演出的场次自主选择仍存在边界场景，临时方案：`config.jsonc` 中 `rush_mode: true`。
+- #29 CTA 文案识别的性能默认参数调优（Step 3）尚未入库，下个 patch 跟进。
+- `release.yml` 不再产出 GitHub Release binary asset；mobile 是源代码方案，用户通过 `git pull` + `poetry install` 升级。

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -10,10 +10,11 @@
 #   C3. `poetry run test` 通过（覆盖率 ≥80% 由 pyproject.toml 强制）
 #   C4. `bash mobile/scripts/benchmark_hot_path.sh --runs 3` 跑通并打印平均耗时
 #   C5. reference/10-changelog.md 含本次发布条目（与 --tag 比对，或要求 7 天内有更新）
+#   C6. docs/releases/<tag>.md 与 docs/releases/<tag>-user.md 同时存在（仅当传 --tag）
 #
 # 用法：
-#   scripts/release_check.sh                # 通用检查
-#   scripts/release_check.sh --tag v0.3.5   # 指定版本号，强校验 changelog
+#   scripts/release_check.sh                # 通用检查（C1-C5；C6 跳过）
+#   scripts/release_check.sh --tag v0.4.5   # 指定版本号，强校验 changelog + docs/releases
 #   scripts/release_check.sh --skip-bench   # 离机环境跳过 benchmark（仅供 CI 调试）
 #
 # 退出码：
@@ -180,6 +181,32 @@ else
             fail "changelog 近 7 天无更新条目；发布前请追加本次变更说明"
             record_fail
         fi
+    fi
+fi
+
+# ── C6：docs/releases/<tag>.md + <tag>-user.md 校验 ───────────────────────
+# 强制 v0.4.0 发布风格：每次正式 tag 必须配套技术版与用户版 release notes
+header "C6. docs/releases/<tag>.md + <tag>-user.md 存在（仅 --tag 时强校验）"
+if [[ -z "$TAG" ]]; then
+    info "未传 --tag，跳过 docs/releases 强校验（通用检查模式）"
+else
+    DOCS_TECH="docs/releases/${TAG}.md"
+    DOCS_USER="docs/releases/${TAG}-user.md"
+    C6_FAIL=0
+    if [[ -f "$DOCS_TECH" ]]; then
+        ok "存在：$DOCS_TECH"
+    else
+        fail "缺失：$DOCS_TECH（技术版 release notes，仿 docs/releases/v0.4.0.md 体例）"
+        C6_FAIL=1
+    fi
+    if [[ -f "$DOCS_USER" ]]; then
+        ok "存在：$DOCS_USER"
+    else
+        fail "缺失：$DOCS_USER（用户版 release notes，仿 docs/releases/v0.4.0-user.md 体例）"
+        C6_FAIL=1
+    fi
+    if [[ $C6_FAIL -ne 0 ]]; then
+        record_fail
     fi
 fi
 


### PR DESCRIPTION
## Summary

把 release 生成基础设施按 v0.4.0 既有风格规范化，并为 v0.4.1 补齐双文件 release notes。

- **release.yml**：(a) `name: "app vX.Y.Z"` → `"HaTickets vX.Y.Z"` 统一品牌前缀；(b) 删除 `build-tauri` job 注释段约 40 行死代码（desktop 已废弃）；(c) 删除 `outputs.release_id`（无下游使用）
- **release_check.sh**：新增 C6 gate — 当 `--tag` 非空时强校验 `docs/releases/<tag>.md` 与 `docs/releases/<tag>-user.md` 同时存在；与 v0.3.0 / v0.4.0 双文件惯例对齐
- **docs/releases/v0.4.1.md**（新建 146 行）：技术版 release notes，对齐 `v0.4.0.md` 体例
- **docs/releases/v0.4.1-user.md**（新建 46 行）：用户版 release notes，对齐 `v0.4.0-user.md` 体例

## 背景

W1-05 任务里 v0.3.1 已发出但偏离 v0.4.0 风格（tag 标题显示 "app v0.3.1" 而非 "HaTickets v0.3.1"，且缺失 docs/releases/ 双文件）。已删除 v0.3.1 的 git tag 与 GitHub Release；本 PR 合入后将以 v0.4.1 重发，使 GitHub Release Latest 指向最新 mobile 版（替代 2026-04-01 旧 desktop 时代的 v0.4.0）。

## Test plan

- [x] `bash -n .github/workflows/release.yml`、`bash -n scripts/release_check.sh` 语法 OK
- [x] `wc -l docs/releases/v0.4.1*.md` 行数与 v0.4.0 体例对齐（146 vs 121 / 46 vs 43）
- [ ] CI（test.yml 5 个 Python 矩阵）在本 PR 上跑绿
- [ ] PR merge 后切回 master，跑 `bash scripts/release_check.sh --tag v0.4.1` 全 6 个 gate 绿
- [ ] tag push 后 `gh release view v0.4.1 --json name` 显示 `"HaTickets v0.4.1"`

## 关联

- 替代已删除的 v0.3.1（PR #33 / #34 / #35 内容载体未变，仍是 master HEAD `3e5291f`）