### PR TITLE
feat(mobile): #26 NLP 自动配置完整修复（4 步）

### DIFF
--- a/mobile/date_utils.py
+++ b/mobile/date_utils.py
@@ -1,0 +1,51 @@
+# -*- coding: UTF-8 -*-
+"""日期格式归一化工具。
+
+NLP 模式下用户输入（"4月6号"）、API 返回（"2026-04-06"）、UI 显示（"04.06"）
+三种格式并存，必须统一为 ``MM.DD`` 后再做匹配。仅依赖标准库，不引入外部依赖。
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+__all__ = ["normalize_date"]
+
+
+_PATTERNS = (
+    # 4月6号 / 4 月 6 日 / 04月06日
+    re.compile(r"(?P<m>\d{1,2})\s*月\s*(?P<d>\d{1,2})\s*[号日好]?"),
+    # 2026-04-06 / 2026/04/06 / 2026.04.06
+    re.compile(r"\d{4}[./-](?P<m>\d{1,2})[./-](?P<d>\d{1,2})"),
+    # 04-06 / 4/6 / 04.06
+    re.compile(r"(?P<m>\d{1,2})[./-](?P<d>\d{1,2})"),
+)
+
+
+def normalize_date(raw: str) -> Optional[str]:
+    """统一日期为 ``MM.DD`` 格式；解析失败返回 ``None``。
+
+    支持格式：
+    - ``4月6号`` / ``4 月 6 日`` / ``04月06日``
+    - ``4/6`` / ``04-06`` / ``04.06``
+    - ``2026-04-06`` / ``2026/04/06`` / ``2026.04.06``
+    """
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+
+    for pattern in _PATTERNS:
+        match = pattern.search(text)
+        if not match:
+            continue
+        try:
+            month = int(match.group("m"))
+            day = int(match.group("d"))
+        except (TypeError, ValueError):
+            continue
+        if 1 <= month <= 12 and 1 <= day <= 31:
+            return f"{month:02d}.{day:02d}"
+    return None

--- a/mobile/item_resolver.py
+++ b/mobile/item_resolver.py
@@ -75,7 +75,9 @@ def city_keyword(city_name: Optional[str]) -> str:
     return re.sub(r"(特别行政区|自治州|地区|盟|市)$", "", city_name.strip())
 
 
-def build_search_keyword(item_name: Optional[str], item_name_display: Optional[str] = None) -> str:
+def build_search_keyword(
+    item_name: Optional[str], item_name_display: Optional[str] = None
+) -> str:
     """Build a search keyword that works better in the Damai app search page."""
     candidates = [item_name or "", item_name_display or ""]
     for candidate in candidates:
@@ -110,6 +112,29 @@ class DamaiItemDetail:
     def city_keyword(self) -> str:
         return city_keyword(self.city_name)
 
+    @property
+    def normalized_dates(self) -> list:
+        """从 ``show_time`` 中抽取所有可识别的 ``MM.DD`` 候选，统一格式。"""
+        try:
+            from mobile.date_utils import normalize_date
+        except ImportError:  # pragma: no cover - 运行环境兼容
+            from date_utils import normalize_date  # type: ignore[no-redef]
+
+        seen: list = []
+        if not self.show_time:
+            return seen
+        # show_time 可能是 "2026-04-06"、"2026.04.06" 或 "2026-04-06 ~ 2026-04-08"
+        for chunk in re.split(r"\s*[~～至到\-]\s*", self.show_time):
+            candidate = normalize_date(chunk)
+            if candidate and candidate not in seen:
+                seen.append(candidate)
+        if not seen:
+            # 兜底：直接对完整 show_time 跑一次正则
+            candidate = normalize_date(self.show_time)
+            if candidate:
+                seen.append(candidate)
+        return seen
+
 
 class DamaiItemResolver:
     """Resolve Damai item metadata through the official mobile mtop endpoint."""
@@ -125,7 +150,9 @@ class DamaiItemResolver:
         return f"https://m.damai.cn/shows/item.html?itemId={item_id}"
 
     def _request(self, url: str, referer: str) -> str:
-        request = Request(url, headers={"User-Agent": DM_USER_AGENT, "Referer": referer})
+        request = Request(
+            url, headers={"User-Agent": DM_USER_AGENT, "Referer": referer}
+        )
         with self.opener.open(request, timeout=self.timeout) as response:
             return response.read().decode("utf-8")
 
@@ -151,7 +178,9 @@ class DamaiItemResolver:
 
         raise DamaiItemResolveError("无法从大麦接口响应中获取 `_m_h5_tk`")
 
-    def fetch_item_detail(self, item_url: Optional[str] = None, item_id: Optional[str] = None) -> DamaiItemDetail:
+    def fetch_item_detail(
+        self, item_url: Optional[str] = None, item_id: Optional[str] = None
+    ) -> DamaiItemDetail:
         resolved_item_id = extract_item_id(item_id or item_url or "")
         referer = self._referer_for_item(resolved_item_id, item_url)
         data_obj = {
@@ -185,7 +214,9 @@ class DamaiItemResolver:
         try:
             payload = json.loads(body)
         except json.JSONDecodeError as exc:
-            raise DamaiItemResolveError(f"大麦详情接口返回了不可解析内容: {exc}") from exc
+            raise DamaiItemResolveError(
+                f"大麦详情接口返回了不可解析内容: {exc}"
+            ) from exc
 
         ret = payload.get("ret") or []
         if not any("SUCCESS" in entry for entry in ret):

--- a/mobile/prompt_parser.py
+++ b/mobile/prompt_parser.py
@@ -133,6 +133,8 @@ class PromptIntent:
     price_hint: Optional[str] = None
     seat_hint: Optional[str] = None
     numeric_price_hint: Optional[int] = None
+    numeric_price_min: Optional[int] = None
+    numeric_price_max: Optional[int] = None
     notes: list[str] = field(default_factory=list)
 
 
@@ -373,6 +375,21 @@ def _parse_price_hints(
     return None, None, None
 
 
+def _parse_price_range(prompt: str) -> tuple[Optional[int], Optional[int]]:
+    """从 ``500-800元`` / ``500到800`` 等区间表达中识别 (min, max)。"""
+    match = re.search(
+        r"([1-9]\d{1,4})\s*[-~到至]\s*([1-9]\d{1,4})\s*元?",
+        prompt or "",
+    )
+    if not match:
+        return None, None
+    low = int(match.group(1))
+    high = int(match.group(2))
+    if low > high:
+        low, high = high, low
+    return low, high
+
+
 def parse_prompt(prompt: str) -> "ParseResult":
     """解析自然语言提示词。
 
@@ -394,6 +411,15 @@ def parse_prompt(prompt: str) -> "ParseResult":
     if attendee_names and not quantity_explicit:
         parsed_quantity = len(attendee_names)
     price_hint, seat_hint, numeric_price = _parse_price_hints(normalized_prompt)
+    price_min, price_max = _parse_price_range(normalized_prompt)
+    if price_min is not None and price_max is not None:
+        # 区间优先：避免「500-800元」被识别为「500元」单值 hint
+        numeric_price = None
+        price_hint = (
+            f"{seat_hint}{price_min}-{price_max}元"
+            if seat_hint
+            else f"{price_min}-{price_max}元"
+        )
     removable_tokens = []
     removable_tokens.extend(attendee_names)
     if parsed_city:
@@ -423,6 +449,8 @@ def parse_prompt(prompt: str) -> "ParseResult":
         price_hint=price_hint,
         seat_hint=seat_hint,
         numeric_price_hint=numeric_price,
+        numeric_price_min=price_min,
+        numeric_price_max=price_max,
     )
 
     if not intent.search_keyword:
@@ -492,7 +520,37 @@ def is_price_option_available(option: dict) -> bool:
     return tag not in _UNAVAILABLE_TAGS
 
 
+def _score_numeric_match(target: int, option_digits: int) -> tuple[int, str]:
+    """对单值数字 hint 进行宽容打分，返回 (分数, 说明)。"""
+    if option_digits == target:
+        return 100, f"{option_digits} 元 = {target} 元 精确命中（+100）"
+    ratio = abs(option_digits - target) / target
+    if ratio <= 0.10:
+        # ±10%：精确点 80 分，到容忍边界 60 分（线性递减）
+        tolerance_score = round(80 - (ratio / 0.10) * 20)
+        return tolerance_score, (
+            f"{option_digits} 元 ≈ {target} 元（差 {ratio * 100:.1f}%，±10% 容忍 +{tolerance_score}）"
+        )
+    return 0, f"{option_digits} 元 与 {target} 元 偏差 {ratio * 100:.1f}% 超出容忍区间"
+
+
+def _score_range_match(low: int, high: int, option_digits: int) -> tuple[int, str]:
+    """区间 hint 命中评分。命中区间 +50；其它情况 0。"""
+    if low <= option_digits <= high:
+        return 50, f"{option_digits} 元 落在区间 [{low}, {high}] 内（+50）"
+    return 0, f"{option_digits} 元 不在区间 [{low}, {high}] 内"
+
+
 def score_price_option(intent: PromptIntent, option: dict) -> int:
+    """对单个 UI 票档进行打分。
+
+    评分构成（与 ``ParseResult.diagnostics`` 同步）：
+    - 文字 hint 包含：+120
+    - seat_hint 包含：+80
+    - 数字 hint 精确：+100；±10% 容忍：60-80 线性递减；超过：0
+    - 区间 hint 命中：+50
+    - 不可用 tag：-1000；常规可预约/预售：+10
+    """
     text = option.get("text") or ""
     tag = option.get("tag") or ""
     normalized_text = normalize_text(text)
@@ -507,12 +565,19 @@ def score_price_option(intent: PromptIntent, option: dict) -> int:
     if intent.seat_hint and normalize_text(intent.seat_hint) in normalized_text:
         score += 80
 
-    if intent.numeric_price_hint is not None:
-        digits = _extract_digits(text)
-        if digits == intent.numeric_price_hint:
-            score += 150
-        elif digits is not None:
-            score -= abs(digits - intent.numeric_price_hint)
+    digits = _extract_digits(text)
+    if digits is not None:
+        if (
+            intent.numeric_price_min is not None
+            and intent.numeric_price_max is not None
+        ):
+            range_score, _ = _score_range_match(
+                intent.numeric_price_min, intent.numeric_price_max, digits
+            )
+            score += range_score
+        elif intent.numeric_price_hint is not None:
+            single_score, _ = _score_numeric_match(intent.numeric_price_hint, digits)
+            score += single_score
 
     if tag in {"可预约", "预售", "可选"}:
         score += 10
@@ -520,22 +585,70 @@ def score_price_option(intent: PromptIntent, option: dict) -> int:
     return score
 
 
+_NEAREST_NEIGHBOR_MAX_RATIO = 0.50
+
+
+def _nearest_numeric_option(target: int, options: Iterable[dict]) -> Optional[dict]:
+    """返回价格数字与 ``target`` 距离最近且可用的票档。
+
+    距离超过 ``±50%`` 不接受（避免 999 元 hint 错配到 380 元这类离谱情况）。
+    """
+    nearest = None
+    nearest_distance = None
+    for option in options:
+        if not is_price_option_available(option):
+            continue
+        digits = _extract_digits(option.get("text") or "")
+        if digits is None:
+            continue
+        distance = abs(digits - target)
+        if nearest_distance is None or distance < nearest_distance:
+            nearest = option
+            nearest_distance = distance
+    if nearest is None or nearest_distance is None:
+        return None
+    if nearest_distance / max(target, 1) > _NEAREST_NEIGHBOR_MAX_RATIO:
+        return None
+    return nearest
+
+
 def choose_price_option(
     intent: PromptIntent, options: Iterable[dict]
 ) -> Optional[dict]:
+    options_list = list(options)
+    if not options_list:
+        return None
+
     ranked = []
-    for option in options:
+    for option in options_list:
         scored = dict(option)
         scored["score"] = score_price_option(intent, option)
         ranked.append(scored)
 
-    if not ranked:
-        return None
-
     ranked.sort(key=lambda item: item["score"], reverse=True)
     best = ranked[0]
 
-    if intent.price_hint and best["score"] < 100:
+    has_numeric = (
+        intent.numeric_price_hint is not None or intent.numeric_price_max is not None
+    )
+
+    # 数字 hint：可以接受最近邻 fallback（30 分）
+    if has_numeric and best["score"] < 60:
+        target = intent.numeric_price_hint
+        if target is None and intent.numeric_price_max is not None:
+            mid = (intent.numeric_price_min + intent.numeric_price_max) // 2
+            target = mid
+        if target is not None:
+            nearest = _nearest_numeric_option(target, options_list)
+            if nearest is not None:
+                fallback = dict(nearest)
+                fallback["score"] = 30
+                fallback["match_reason"] = "nearest_neighbor"
+                return fallback
+        return None
+
+    # 仅文字 hint（如「内场」无具体价格）：保留严格阈值，避免错配看似无关的票档
+    if intent.price_hint and not has_numeric and best["score"] < 100:
         return None
 
     if not intent.price_hint and not is_price_option_available(best):

--- a/mobile/prompt_parser.py
+++ b/mobile/prompt_parser.py
@@ -29,16 +29,73 @@ _CHINESE_DIGITS = {
 }
 
 _KNOWN_CITY_TOKENS = (
-    "北京", "上海", "深圳", "广州", "杭州", "成都", "重庆", "武汉", "南京", "西安",
-    "苏州", "天津", "长沙", "郑州", "青岛", "宁波", "福州", "厦门", "南昌", "沈阳",
-    "大连", "合肥", "无锡", "佛山", "东莞", "珠海", "昆明", "贵阳", "南宁", "长春",
-    "哈尔滨", "太原", "石家庄", "济南", "兰州", "海口", "三亚", "乌鲁木齐", "呼和浩特",
+    "北京",
+    "上海",
+    "深圳",
+    "广州",
+    "杭州",
+    "成都",
+    "重庆",
+    "武汉",
+    "南京",
+    "西安",
+    "苏州",
+    "天津",
+    "长沙",
+    "郑州",
+    "青岛",
+    "宁波",
+    "福州",
+    "厦门",
+    "南昌",
+    "沈阳",
+    "大连",
+    "合肥",
+    "无锡",
+    "佛山",
+    "东莞",
+    "珠海",
+    "昆明",
+    "贵阳",
+    "南宁",
+    "长春",
+    "哈尔滨",
+    "太原",
+    "石家庄",
+    "济南",
+    "兰州",
+    "海口",
+    "三亚",
+    "乌鲁木齐",
+    "呼和浩特",
 )
 
 _REQUEST_STOPWORDS = (
-    "帮我", "帮忙", "抢票", "抢一张", "抢两张", "抢", "买", "订", "门票", "票", "演出票",
-    "给我", "给", "一下", "尽快", "尽量", "麻烦", "我要", "想要", "请", "能不能", "可以", "帮",
-    "票价", "价位",
+    "帮我",
+    "帮忙",
+    "抢票",
+    "抢一张",
+    "抢两张",
+    "抢",
+    "买",
+    "订",
+    "门票",
+    "票",
+    "演出票",
+    "给我",
+    "给",
+    "一下",
+    "尽快",
+    "尽量",
+    "麻烦",
+    "我要",
+    "想要",
+    "请",
+    "能不能",
+    "可以",
+    "帮",
+    "票价",
+    "价位",
 )
 
 _LOW_SIGNAL_KEYWORD_TOKENS = {"演唱会", "音乐会", "演出", "巡演", "live", "门票"}
@@ -78,6 +135,39 @@ class PromptIntent:
     notes: list[str] = field(default_factory=list)
 
 
+@dataclass
+class ParseResult:
+    """诊断框架：parse_prompt 的可观测返回值。
+
+    保留向后兼容：调用方通过属性转发仍可直接读取 intent 字段
+    （如 result.attendee_names 等同 result.intent.attendee_names）。
+    """
+
+    intent: "PromptIntent"
+    matched_item: object = None
+    matched_session: Optional[str] = None
+    matched_price: Optional[str] = None
+    diagnostics: list[str] = field(default_factory=list)
+    confidence: float = 0.0
+
+    _ACTIONABLE_THRESHOLD: ClassVar[float] = 0.6
+
+    def is_actionable(self) -> bool:
+        return (
+            self.confidence >= self._ACTIONABLE_THRESHOLD
+            and self.matched_item is not None
+        )
+
+    def __getattr__(self, name: str):
+        # 仅当常规属性查找失败时才转发到 intent；避免无穷递归
+        if name.startswith("_") or name in {"intent"}:
+            raise AttributeError(name)
+        intent = self.__dict__.get("intent")
+        if intent is None:
+            raise AttributeError(name)
+        return getattr(intent, name)
+
+
 def _normalize_whitespace(text: str) -> str:
     return re.sub(r"\s+", " ", text or "").strip()
 
@@ -94,7 +184,12 @@ def _parse_chinese_int(token: str) -> Optional[int]:
         return 10 + _CHINESE_DIGITS[token[1]]
     if len(token) == 2 and token[1] == "十" and token[0] in _CHINESE_DIGITS:
         return _CHINESE_DIGITS[token[0]] * 10
-    if len(token) == 3 and token[1] == "十" and token[0] in _CHINESE_DIGITS and token[2] in _CHINESE_DIGITS:
+    if (
+        len(token) == 3
+        and token[1] == "十"
+        and token[0] in _CHINESE_DIGITS
+        and token[2] in _CHINESE_DIGITS
+    ):
         return _CHINESE_DIGITS[token[0]] * 10 + _CHINESE_DIGITS[token[2]]
     return None
 
@@ -172,7 +267,9 @@ def _parse_attendee_names(prompt: str) -> list[str]:
     return []
 
 
-def _clean_prompt_for_keyword(prompt: str, removable_tokens: Optional[Iterable[str]] = None) -> str:
+def _clean_prompt_for_keyword(
+    prompt: str, removable_tokens: Optional[Iterable[str]] = None
+) -> str:
     cleaned = prompt
     cleaned = re.sub(r"https?://\S+", " ", cleaned)
     cleaned = re.sub(r"\d{1,2}\s*月\s*\d{1,2}\s*[号日好]?", " ", cleaned)
@@ -221,11 +318,16 @@ def _compact_keyword_phrase(value: str) -> str:
     return _normalize_whitespace(" ".join(compact_tokens))
 
 
-def _parse_artist_and_keyword(prompt: str, removable_tokens: Optional[Iterable[str]] = None) -> tuple[Optional[str], Optional[str], list[str]]:
+def _parse_artist_and_keyword(
+    prompt: str, removable_tokens: Optional[Iterable[str]] = None
+) -> tuple[Optional[str], Optional[str], list[str]]:
     cleaned = _clean_prompt_for_keyword(prompt, removable_tokens=removable_tokens)
 
     artist = None
-    artist_match = re.search(r"([\u4e00-\u9fffA-Za-z0-9·•]+?)(?:的)?(?:演唱会|音乐会|演出|live|LIVE|巡演)", cleaned)
+    artist_match = re.search(
+        r"([\u4e00-\u9fffA-Za-z0-9·•]+?)(?:的)?(?:演唱会|音乐会|演出|live|LIVE|巡演)",
+        cleaned,
+    )
     if artist_match:
         artist = artist_match.group(1).strip(" ，,。！？")
     else:
@@ -245,7 +347,12 @@ def _parse_artist_and_keyword(prompt: str, removable_tokens: Optional[Iterable[s
     for candidate in candidates:
         value = _compact_keyword_phrase(candidate)
         normalized = normalize_text(value)
-        if not value or not normalized or normalized in seen or _is_low_signal_candidate(value):
+        if (
+            not value
+            or not normalized
+            or normalized in seen
+            or _is_low_signal_candidate(value)
+        ):
             continue
         deduped.append(value)
         seen.add(normalized)
@@ -253,7 +360,9 @@ def _parse_artist_and_keyword(prompt: str, removable_tokens: Optional[Iterable[s
     return artist, (deduped[0] if deduped else None), deduped
 
 
-def _parse_price_hints(prompt: str) -> tuple[Optional[str], Optional[str], Optional[int]]:
+def _parse_price_hints(
+    prompt: str,
+) -> tuple[Optional[str], Optional[str], Optional[int]]:
     seat_hint = None
     for token in _SEAT_HINTS:
         if token in prompt:
@@ -274,7 +383,14 @@ def _parse_price_hints(prompt: str) -> tuple[Optional[str], Optional[str], Optio
     return None, None, None
 
 
-def parse_prompt(prompt: str) -> PromptIntent:
+def parse_prompt(prompt: str) -> "ParseResult":
+    """解析自然语言提示词。
+
+    返回 ``ParseResult``。为保持向后兼容，``ParseResult`` 通过 ``__getattr__``
+    把字段访问转发到 ``intent``——历史上以 ``parse_prompt(...).attendee_names``
+    形式读取的代码无需改动。``confidence`` 与 ``diagnostics`` 由解析阶段产出，
+    用于 ``apply`` 模式下的「拒绝写残缺 config」判定。
+    """
     if not isinstance(prompt, str) or len(prompt.strip()) == 0:
         raise ValueError("prompt 不能为空")
 
@@ -282,7 +398,9 @@ def parse_prompt(prompt: str) -> PromptIntent:
     parsed_date = _parse_date(normalized_prompt)
     parsed_city = _parse_city(normalized_prompt)
     attendee_names = _parse_attendee_names(normalized_prompt)
-    parsed_quantity, quantity_explicit = _parse_quantity_with_explicit(normalized_prompt)
+    parsed_quantity, quantity_explicit = _parse_quantity_with_explicit(
+        normalized_prompt
+    )
     if attendee_names and not quantity_explicit:
         parsed_quantity = len(attendee_names)
     price_hint, seat_hint, numeric_price = _parse_price_hints(normalized_prompt)
@@ -334,7 +452,42 @@ def parse_prompt(prompt: str) -> PromptIntent:
     if not intent.price_hint:
         intent.notes.append("提示词中未识别到明确票档偏好，后续会使用查询结果确认票档")
 
-    return intent
+    diagnostics: list[str] = []
+    confidence = 0.0
+    if intent.search_keyword:
+        confidence += 0.4
+        diagnostics.append(f"识别搜索关键词：{intent.search_keyword}（+0.40）")
+    if intent.attendee_names:
+        confidence += 0.30
+        diagnostics.append(
+            f"识别 {len(intent.attendee_names)} 位观演人：{'、'.join(intent.attendee_names)}（+0.30）"
+        )
+    else:
+        diagnostics.append("未识别到观演人，apply 模式必须补充姓名")
+    if intent.date:
+        confidence += 0.15
+        diagnostics.append(f"识别目标日期：{intent.date}（+0.15）")
+    else:
+        diagnostics.append("未识别到具体日期，将依赖页面候选场次")
+    if intent.numeric_price_hint or intent.price_hint:
+        confidence += 0.10
+        diagnostics.append(
+            f"识别票档偏好：{intent.price_hint or intent.numeric_price_hint}（+0.10）"
+        )
+    else:
+        diagnostics.append("未识别到票档偏好，将依赖页面默认推荐")
+    if intent.city:
+        confidence += 0.05
+        diagnostics.append(f"识别目标城市：{intent.city}（+0.05）")
+
+    return ParseResult(
+        intent=intent,
+        matched_item=None,
+        matched_session=intent.date,
+        matched_price=intent.price_hint,
+        diagnostics=diagnostics,
+        confidence=round(confidence, 3),
+    )
 
 
 def _extract_digits(text: str) -> Optional[int]:
@@ -377,7 +530,9 @@ def score_price_option(intent: PromptIntent, option: dict) -> int:
     return score
 
 
-def choose_price_option(intent: PromptIntent, options: Iterable[dict]) -> Optional[dict]:
+def choose_price_option(
+    intent: PromptIntent, options: Iterable[dict]
+) -> Optional[dict]:
     ranked = []
     for option in options:
         scored = dict(option)

--- a/mobile/prompt_parser.py
+++ b/mobile/prompt_parser.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Iterable, Optional
 
 try:
+    from mobile.date_utils import normalize_date as _normalize_date_external
     from mobile.item_resolver import normalize_text
 except ImportError:
     from item_resolver import normalize_text
@@ -218,19 +219,8 @@ def _parse_quantity_with_explicit(prompt: str) -> tuple[int, bool]:
 
 
 def _parse_date(prompt: str) -> Optional[str]:
-    patterns = (
-        r"(\d{1,2})\s*月\s*(\d{1,2})\s*[号日好]?",
-        r"(\d{1,2})[./-](\d{1,2})",
-    )
-    for pattern in patterns:
-        match = re.search(pattern, prompt)
-        if not match:
-            continue
-        month = int(match.group(1))
-        day = int(match.group(2))
-        if 1 <= month <= 12 and 1 <= day <= 31:
-            return f"{month:02d}.{day:02d}"
-    return None
+    """委托给 ``mobile.date_utils.normalize_date``，统一为 ``MM.DD``。"""
+    return _normalize_date_external(prompt)
 
 
 def _parse_city(prompt: str) -> Optional[str]:

--- a/mobile/prompt_runner.py
+++ b/mobile/prompt_runner.py
@@ -619,6 +619,41 @@ def build_updated_config(
     return config_data
 
 
+UNACTIONABLE_EXIT_CODE = 5
+
+
+def _is_stdin_tty() -> bool:
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def _print_unactionable_diagnostics(parse_result, stream=None):
+    stream = stream or sys.stderr
+    print(
+        f"NLP 解析置信度 {parse_result.confidence:.2f}（阈值 0.60），存在以下不确定项：",
+        file=stream,
+    )
+    for line in parse_result.diagnostics:
+        print(f"  - {line}", file=stream)
+
+
+def _handle_unactionable_apply(parse_result, force_non_interactive: bool) -> bool:
+    """is_actionable=False 时的 fallback。
+
+    非交互模式（强制 ``--non-interactive`` 或 stdin 非 TTY）→ 把诊断写到 stderr，
+    返回 ``False`` 表示调用方应 ``exit 5``。
+
+    TTY 模式 → 把诊断写到 stderr，让用户决定是否继续走交互式补缺流程
+    （现有 ``_resolve_confirmed_date`` / ``_resolve_confirmed_price`` 已能交互补缺）。
+    """
+    _print_unactionable_diagnostics(parse_result)
+    if force_non_interactive or not _is_stdin_tty():
+        return False
+    return _prompt_yes_no("解析置信度不足，是否仍然进入交互模式补充缺失项？")
+
+
 def _update_parse_result_post_discovery(parse_result, discovery: dict, chosen_price):
     """在 discover_target_event 之后回填 ParseResult 的匹配状态与诊断。"""
     summary = discovery.get("summary") or {}
@@ -664,6 +699,11 @@ def parse_args(argv=None):
     parser.add_argument(
         "--config",
         help="显式指定配置文件路径；默认写入 mobile/config.jsonc。开发者本地覆盖可配合 HATICKETS_CONFIG_PATH 或 mobile/config.local.jsonc 使用。",
+    )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="强制非交互行为：is_actionable=False 时直接 exit 5 并把诊断写到 stderr，CI 用",
     )
     return parser.parse_args(argv)
 
@@ -739,6 +779,17 @@ def main(argv=None):
         if args.mode == "summary":
             _print_result(True, _success_detail_for_mode(args.mode))
             return 0
+
+        # apply / probe 模式：is_actionable=False 时拒绝写残缺 config
+        if not parse_result.is_actionable():
+            if not _handle_unactionable_apply(
+                parse_result, force_non_interactive=args.non_interactive
+            ):
+                _print_result(
+                    False,
+                    "解析置信度不足，已停止写入配置；请补充提示词后重试或在 TTY 中重新运行进行交互补缺。",
+                )
+                return UNACTIONABLE_EXIT_CODE
 
         date_text = _resolve_confirmed_date(intent, discovery["summary"], args.yes)
         if not date_text:

--- a/mobile/prompt_runner.py
+++ b/mobile/prompt_runner.py
@@ -619,6 +619,34 @@ def build_updated_config(
     return config_data
 
 
+def _update_parse_result_post_discovery(parse_result, discovery: dict, chosen_price):
+    """在 discover_target_event 之后回填 ParseResult 的匹配状态与诊断。"""
+    summary = discovery.get("summary") or {}
+    parse_result.matched_item = summary or None
+    if not summary:
+        return
+
+    intent = parse_result.intent
+    visible_dates = summary.get("dates") or []
+    if intent.date and intent.date in visible_dates:
+        parse_result.matched_session = intent.date
+    elif len(visible_dates) == 1:
+        parse_result.matched_session = visible_dates[0]
+    else:
+        parse_result.matched_session = None
+        parse_result.diagnostics.append(
+            f"日期 {intent.date or '<未指定>'} 在页面候选场次 {visible_dates or '[]'} 中未找到唯一匹配"
+        )
+
+    if chosen_price:
+        parse_result.matched_price = chosen_price.get("text")
+        parse_result.confidence = min(1.0, parse_result.confidence + 0.05)
+    else:
+        parse_result.diagnostics.append(
+            "无法从页面票档中匹配出唯一推荐票档（可能是票档偏好不明确或票档全部售罄）"
+        )
+
+
 def parse_args(argv=None):
     parser = argparse.ArgumentParser(description="自然语言提示词驱动的大麦 mobile 流程")
     parser.add_argument(
@@ -647,7 +675,8 @@ def main(argv=None):
     try:
         base_config_dict = _load_base_config_dict(config_path)
         try:
-            intent = parse_prompt(args.prompt)
+            parse_result = parse_prompt(args.prompt)
+            intent = parse_result.intent
         except ValueError as exc:
             if str(exc) == "无法从提示词中提取搜索关键词":
                 logger.error(_build_missing_keyword_error(base_config_dict, args.mode))
@@ -703,6 +732,8 @@ def main(argv=None):
         chosen_price = choose_price_option(
             intent, discovery["summary"].get("price_options") or []
         )
+        # discover 成功后回填 matched_*，让 is_actionable() 在 apply/probe 模式有依据
+        _update_parse_result_post_discovery(parse_result, discovery, chosen_price)
         print(_format_summary(intent, discovery, chosen_price))
 
         if args.mode == "summary":

--- a/tests/unit/test_date_utils.py
+++ b/tests/unit/test_date_utils.py
@@ -1,0 +1,58 @@
+# -*- coding: UTF-8 -*-
+"""mobile/date_utils.py 单元测试。"""
+
+from __future__ import annotations
+
+import pytest
+
+from mobile.date_utils import normalize_date
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("4月6号", "04.06"),
+        ("4 月 6 日", "04.06"),
+        ("04月06日", "04.06"),
+        ("4/6", "04.06"),
+        ("04-06", "04.06"),
+        ("04.06", "04.06"),
+        ("2026-04-06", "04.06"),
+        ("2026/04/06", "04.06"),
+        ("2026.04.06", "04.06"),
+        ("12月1日演唱会", "12.01"),
+        ("帮我抢 4 月 6 日张杰的演唱会", "04.06"),
+    ],
+)
+def test_normalize_date_valid_formats(raw, expected):
+    assert normalize_date(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "   ",
+        "乱七八糟",
+        "13月5日",  # 月份越界
+        "3月32日",  # 日期越界
+        "abc",
+        "20-99",  # 日期越界
+    ],
+)
+def test_normalize_date_invalid_formats_return_none(raw):
+    assert normalize_date(raw) is None
+
+
+def test_normalize_date_none_input_returns_none():
+    assert normalize_date(None) is None  # type: ignore[arg-type]
+
+
+def test_normalize_date_year_form_takes_precedence_over_short_form():
+    # 形如 2026-04-06 不应误判成 26-04（先匹配带年份模式）
+    assert normalize_date("2026-04-06") == "04.06"
+
+
+def test_normalize_date_handles_leading_zero_padding():
+    assert normalize_date("4/6") == "04.06"
+    assert normalize_date("04/06") == "04.06"

--- a/tests/unit/test_mobile_prompt_parser.py
+++ b/tests/unit/test_mobile_prompt_parser.py
@@ -72,7 +72,9 @@ class TestParsePrompt:
         assert intent.artist == "顽童mj116"
 
     def test_parse_prompt_extracts_single_attendee_name(self):
-        intent = parse_prompt("帮张志涛抢一张 4 月 4 号余佳运的演唱会门票，内场，票价 1080 元")
+        intent = parse_prompt(
+            "帮张志涛抢一张 4 月 4 号余佳运的演唱会门票，内场，票价 1080 元"
+        )
 
         assert intent.attendee_names == ["张志涛"]
         assert intent.artist == "余佳运"
@@ -81,14 +83,18 @@ class TestParsePrompt:
         assert intent.price_hint == "内场1080元"
 
     def test_parse_prompt_extracts_multiple_attendee_names(self):
-        intent = parse_prompt("帮张志涛和李四抢两张 4 月 4 号余佳运的演唱会门票，内场，票价 1080 元")
+        intent = parse_prompt(
+            "帮张志涛和李四抢两张 4 月 4 号余佳运的演唱会门票，内场，票价 1080 元"
+        )
 
         assert intent.attendee_names == ["张志涛", "李四"]
         assert intent.quantity == 2
         assert intent.quantity_explicit is True
 
     def test_parse_prompt_infers_quantity_from_attendee_names_when_omitted(self):
-        intent = parse_prompt("帮张文、张志涛抢，6 月 6 号，陈慧娴的演唱会门票，上海站，内场，票价 1380 元")
+        intent = parse_prompt(
+            "帮张文、张志涛抢，6 月 6 号，陈慧娴的演唱会门票，上海站，内场，票价 1380 元"
+        )
 
         assert intent.attendee_names == ["张文", "张志涛"]
         assert intent.quantity == 2
@@ -96,7 +102,9 @@ class TestParsePrompt:
         assert not any("购票张数" in note for note in intent.notes)
 
     def test_parse_prompt_supports_artist_with_city_station_inside_phrase(self):
-        intent = parse_prompt("给张三和李四抢4 月 6 号张杰的北京站演唱会内场门票，票价 1680 元")
+        intent = parse_prompt(
+            "给张三和李四抢4 月 6 号张杰的北京站演唱会内场门票，票价 1680 元"
+        )
 
         assert intent.attendee_names == ["张三", "李四"]
         assert intent.quantity == 2
@@ -106,7 +114,9 @@ class TestParsePrompt:
         assert intent.price_hint == "内场1680元"
 
     def test_parse_prompt_supports_city_station_before_artist(self):
-        intent = parse_prompt("帮张文、张志涛抢，6 月 6 号，上海站陈慧娴的演唱会门票，内场，票价 1380 元")
+        intent = parse_prompt(
+            "帮张文、张志涛抢，6 月 6 号，上海站陈慧娴的演唱会门票，内场，票价 1380 元"
+        )
 
         assert intent.attendee_names == ["张文", "张志涛"]
         assert intent.quantity == 2
@@ -114,8 +124,12 @@ class TestParsePrompt:
         assert intent.artist == "陈慧娴"
         assert intent.search_keyword == "陈慧娴 演唱会"
 
-    def test_parse_prompt_supports_dot_date_without_misreading_zhang_surname_as_quantity(self):
-        intent = parse_prompt("给张三和李四抢4.6 张杰的北京站演唱会内场门票，票价 1680 元")
+    def test_parse_prompt_supports_dot_date_without_misreading_zhang_surname_as_quantity(
+        self,
+    ):
+        intent = parse_prompt(
+            "给张三和李四抢4.6 张杰的北京站演唱会内场门票，票价 1680 元"
+        )
 
         assert intent.attendee_names == ["张三", "李四"]
         assert intent.quantity == 2
@@ -126,13 +140,17 @@ class TestParsePrompt:
         assert intent.search_keyword == "张杰 演唱会"
 
     def test_parse_prompt_filters_low_signal_noisy_candidate_keywords(self):
-        intent = parse_prompt("给张志涛抢4 月 6 号张杰的北京站演唱会内场门票，票价 1680 元")
+        intent = parse_prompt(
+            "给张志涛抢4 月 6 号张杰的北京站演唱会内场门票，票价 1680 元"
+        )
 
         assert intent.candidate_keywords[:2] == ["张杰 演唱会", "张杰"]
         assert all("价 元" not in keyword for keyword in intent.candidate_keywords)
 
     def test_parse_prompt_adds_note_when_attendee_count_mismatches_quantity(self):
-        intent = parse_prompt("帮张文和张志涛抢一张 4 月 4 号余佳运的演唱会门票，内场，票价 1080 元")
+        intent = parse_prompt(
+            "帮张文和张志涛抢一张 4 月 4 号余佳运的演唱会门票，内场，票价 1080 元"
+        )
 
         assert intent.attendee_names == ["张文", "张志涛"]
         assert intent.quantity == 1
@@ -191,6 +209,7 @@ class TestChoosePriceOption:
 # _parse_chinese_int
 # ---------------------------------------------------------------------------
 
+
 class TestParseChineseInt:
     def test_zero(self):
         assert _parse_chinese_int("零") == 0
@@ -230,6 +249,7 @@ class TestParseChineseInt:
 # _parse_quantity
 # ---------------------------------------------------------------------------
 
+
 class TestParseQuantity:
     def test_arabic_digit(self):
         assert _parse_quantity("买3张") == 3
@@ -262,6 +282,7 @@ class TestParseQuantity:
 # ---------------------------------------------------------------------------
 # _parse_date
 # ---------------------------------------------------------------------------
+
 
 class TestParseDate:
     def test_month_day_ri(self):
@@ -299,6 +320,7 @@ class TestParseDate:
 # _parse_city
 # ---------------------------------------------------------------------------
 
+
 class TestParseCity:
     def test_known_city_exact(self):
         assert _parse_city("北京演唱会") == "北京"
@@ -328,6 +350,7 @@ class TestParseCity:
 # ---------------------------------------------------------------------------
 # _parse_price_hints
 # ---------------------------------------------------------------------------
+
 
 class TestParsePriceHints:
     def test_seat_and_price(self):
@@ -370,6 +393,7 @@ class TestParsePriceHints:
 # is_price_option_available
 # ---------------------------------------------------------------------------
 
+
 class TestIsAvailable:
     def test_available_tag(self):
         assert is_price_option_available({"tag": "可预约"}) is True
@@ -399,6 +423,7 @@ class TestIsAvailable:
 # ---------------------------------------------------------------------------
 # score_price_option
 # ---------------------------------------------------------------------------
+
 
 class TestScorePriceOption:
     def _intent(self, price_hint=None, seat_hint=None, numeric_price=None):
@@ -432,7 +457,8 @@ class TestScorePriceOption:
     def test_numeric_exact_match(self):
         intent = self._intent(numeric_price=1280)
         score = score_price_option(intent, {"text": "1280元", "tag": ""})
-        assert score >= 150
+        # fix-plan #26 Step 3：精确命中分数从 150 降为 100（区分 +120 文字 hint 加分）
+        assert score >= 100
 
     def test_numeric_mismatch_penalty(self):
         intent = self._intent(numeric_price=1280)
@@ -455,6 +481,7 @@ class TestScorePriceOption:
 # choose_price_option (extended)
 # ---------------------------------------------------------------------------
 
+
 class TestChoosePriceOptionExtended:
     def _intent(self, price_hint=None, seat_hint=None, numeric_price=None):
         return PromptIntent(
@@ -469,7 +496,10 @@ class TestChoosePriceOptionExtended:
 
     def test_all_unavailable_with_price_hint_returns_none(self):
         intent = self._intent(price_hint="内场")
-        options = [{"text": "内场580元", "tag": "售罄"}, {"text": "580元", "tag": "无票"}]
+        options = [
+            {"text": "内场580元", "tag": "售罄"},
+            {"text": "580元", "tag": "无票"},
+        ]
         assert choose_price_option(intent, options) is None
 
     def test_no_price_hint_all_unavailable_returns_none(self):
@@ -478,12 +508,16 @@ class TestChoosePriceOptionExtended:
 
     def test_score_field_added_to_result(self):
         intent = self._intent(numeric_price=1280)
-        result = choose_price_option(intent, [{"index": 0, "text": "1280元", "tag": "可预约"}])
+        result = choose_price_option(
+            intent, [{"index": 0, "text": "1280元", "tag": "可预约"}]
+        )
         assert result is not None and "score" in result
 
     def test_single_available_option_returned(self):
         intent = self._intent()
-        result = choose_price_option(intent, [{"index": 0, "text": "580元", "tag": "可选"}])
+        result = choose_price_option(
+            intent, [{"index": 0, "text": "580元", "tag": "可选"}]
+        )
         assert result is not None and result["index"] == 0
 
     def test_high_score_option_wins(self):
@@ -495,10 +529,57 @@ class TestChoosePriceOptionExtended:
         ]
         assert choose_price_option(intent, options)["index"] == 1
 
+    def test_choose_price_option_nearest_neighbor_within_50_percent(self):
+        # fix-plan #26 Step 3：用户输入 899 元，候选 880 元应作为最近邻命中
+        intent = self._intent(numeric_price=899)
+        options = [
+            {"index": 0, "text": "880元", "tag": "可预约"},
+            {"index": 1, "text": "1880元", "tag": "可预约"},
+        ]
+        result = choose_price_option(intent, options)
+        assert result is not None
+        assert result["index"] == 0
+
+    def test_choose_price_option_within_10_percent_tolerance(self):
+        # ±10% 容忍：用户输入 1280 元，候选 1380 元（差 7.8%）也应被接受
+        intent = self._intent(numeric_price=1280)
+        options = [
+            {"index": 0, "text": "1380元", "tag": "可预约"},
+            {"index": 1, "text": "2580元", "tag": "可预约"},
+        ]
+        result = choose_price_option(intent, options)
+        assert result is not None
+        assert result["index"] == 0
+        # 容忍区间分数应至少 60，落在 60-80 区间内
+        assert result["score"] >= 60
+
+    def test_choose_price_option_range_hit(self):
+        # 区间命中：500-800 元区间内的 680 元应得 +50
+        intent = PromptIntent(
+            raw_prompt="test",
+            numeric_price_min=500,
+            numeric_price_max=800,
+        )
+        options = [
+            {"index": 0, "text": "380元", "tag": "可预约"},
+            {"index": 1, "text": "680元", "tag": "可预约"},
+            {"index": 2, "text": "1280元", "tag": "可预约"},
+        ]
+        result = choose_price_option(intent, options)
+        assert result is not None
+        assert result["index"] == 1
+
+    def test_choose_price_option_rejects_extreme_outlier(self):
+        # 距离 > 50% 时拒绝最近邻：999 元 hint vs 380 元 (差距 62%)
+        intent = self._intent(numeric_price=999)
+        options = [{"index": 0, "text": "380元", "tag": "可预约"}]
+        assert choose_price_option(intent, options) is None
+
 
 # ---------------------------------------------------------------------------
 # parse_prompt — validation and notes
 # ---------------------------------------------------------------------------
+
 
 class TestParsePromptValidation:
     def test_empty_string_raises(self):
@@ -540,6 +621,7 @@ class TestParsePromptNotes:
 # ---------------------------------------------------------------------------
 # Edge cases: keyword extraction
 # ---------------------------------------------------------------------------
+
 
 class TestKeywordExtractionEdgeCases:
     def test_only_stopwords_raises_value_error(self):

--- a/tests/unit/test_prompt_runner_unactionable.py
+++ b/tests/unit/test_prompt_runner_unactionable.py
@@ -11,6 +11,8 @@ from mobile.prompt_parser import ParseResult, PromptIntent
 from mobile.prompt_runner import (
     UNACTIONABLE_EXIT_CODE,
     _handle_unactionable_apply,
+    _is_stdin_tty,
+    _update_parse_result_post_discovery,
     parse_args,
 )
 
@@ -90,3 +92,64 @@ class TestUnactionableFallback:
             )
             is False
         )
+
+
+class TestUpdateParseResultPostDiscovery:
+    """覆盖 _update_parse_result_post_discovery 的所有分支。"""
+
+    def _result(self, date=None, confidence=0.5):
+        intent = PromptIntent(raw_prompt="x", search_keyword="k", date=date)
+        return ParseResult(
+            intent=intent, matched_item=None, confidence=confidence, diagnostics=[]
+        )
+
+    def test_no_summary_clears_matched_item(self):
+        r = self._result()
+        _update_parse_result_post_discovery(r, {"summary": {}}, None)
+        assert r.matched_item is None
+
+    def test_intent_date_in_visible_dates(self):
+        r = self._result(date="04.06")
+        summary = {"dates": ["04.05", "04.06"], "title": "X"}
+        _update_parse_result_post_discovery(r, {"summary": summary}, {"text": "880元"})
+        assert r.matched_session == "04.06"
+        assert r.matched_price == "880元"
+        # confidence 应被 +0.05
+        assert r.confidence > 0.5
+
+    def test_single_visible_date_used(self):
+        r = self._result(date=None)
+        summary = {"dates": ["04.07"]}
+        _update_parse_result_post_discovery(r, {"summary": summary}, None)
+        assert r.matched_session == "04.07"
+        # 没 chosen_price 应加 diagnostic
+        assert any("无法从页面票档" in d for d in r.diagnostics)
+
+    def test_multiple_dates_no_match_adds_diagnostic(self):
+        r = self._result(date="04.06")
+        summary = {"dates": ["04.04", "04.05"]}
+        _update_parse_result_post_discovery(r, {"summary": summary}, None)
+        assert r.matched_session is None
+        assert any("未找到唯一匹配" in d for d in r.diagnostics)
+
+    def test_no_dates_with_undefined_intent_date(self):
+        r = self._result(date=None)
+        summary = {"dates": []}
+        _update_parse_result_post_discovery(r, {"summary": summary}, {"text": "580元"})
+        # 没有可见日期且 intent.date 也无 → 走 else 分支，记录 diagnostic
+        assert r.matched_session is None
+        assert any("<未指定>" in d for d in r.diagnostics)
+
+
+class TestIsStdinTty:
+    def test_returns_bool_without_raising(self):
+        # 仅确认调用安全；具体值取决于运行环境
+        result = _is_stdin_tty()
+        assert isinstance(result, bool)
+
+    def test_attribute_error_path(self, monkeypatch):
+        class NoIsattyStdin:
+            pass
+
+        monkeypatch.setattr("mobile.prompt_runner.sys.stdin", NoIsattyStdin())
+        assert _is_stdin_tty() is False

--- a/tests/unit/test_prompt_runner_unactionable.py
+++ b/tests/unit/test_prompt_runner_unactionable.py
@@ -153,3 +153,124 @@ class TestIsStdinTty:
 
         monkeypatch.setattr("mobile.prompt_runner.sys.stdin", NoIsattyStdin())
         assert _is_stdin_tty() is False
+
+
+class TestMainActionableCheck:
+    """覆盖 main() 中 apply 模式下 is_actionable=False 走 UNACTIONABLE_EXIT_CODE 的分支。
+
+    用 monkeypatch 替换核心依赖，避免触碰 ``with \\`` 风格的现有 main 测试。
+    """
+
+    def test_apply_mode_returns_unactionable_exit_code(self, monkeypatch):
+        from mobile import prompt_runner
+
+        # 准备 base_config_dict 与 Config 对象（最小可用）
+        base_config_dict = {
+            "serial": "ABC",
+            "users": ["张志涛"],
+            "city": "北京",
+            "date": "04.06",
+            "price": "580元",
+            "price_index": 0,
+            "keyword": "X",
+            "if_commit_order": False,
+            "probe_only": True,
+            "auto_navigate": True,
+        }
+
+        from mobile.config import Config
+
+        class FakeConfig:
+            def __init__(self):
+                self.city = "北京"
+                self.date = "04.06"
+                self.price = "580元"
+                self.price_index = 0
+
+            def to_dict(self):
+                return {**base_config_dict}
+
+        # 让 parse_prompt 返回置信度低 + 无 matched_item 的 ParseResult
+        from mobile.prompt_parser import ParseResult
+
+        class FakeIntent:
+            raw_prompt = "x"
+            quantity = 1
+            quantity_explicit = False
+            attendee_names = ["张志涛"]
+            date = None
+            city = None
+            artist = None
+            search_keyword = "x"
+            candidate_keywords = ["x"]
+            price_hint = None
+            seat_hint = None
+            numeric_price_hint = None
+            numeric_price_min = None
+            numeric_price_max = None
+            notes = []
+
+        fake_pr = ParseResult(
+            intent=FakeIntent(),
+            matched_item=None,
+            diagnostics=["test diag"],
+            confidence=0.4,
+        )
+
+        class FakeBot:
+            driver = None
+
+            def __init__(self, *_a, **_kw):
+                pass
+
+            def dismiss_startup_popups(self):
+                pass
+
+            def probe_current_page(self):
+                return {"state": "detail_page"}
+
+            def discover_target_event(self, *_a, **_kw):
+                return {
+                    "used_keyword": "x",
+                    "search_results": [],
+                    "page_probe": {"state": "detail_page"},
+                }
+
+            def inspect_current_target_event(self, _probe):
+                return {
+                    "title": "X",
+                    "venue": "Y",
+                    "state": "detail_page",
+                    "reservation_mode": False,
+                    "dates": ["04.04", "04.05"],
+                    "price_options": [],
+                }
+
+        monkeypatch.setattr(
+            prompt_runner, "_load_base_config_dict", lambda _p: base_config_dict
+        )
+        monkeypatch.setattr(prompt_runner, "parse_prompt", lambda _p: fake_pr)
+        monkeypatch.setattr(
+            prompt_runner, "_validate_prompt_requirements", lambda *_a, **_kw: None
+        )
+        monkeypatch.setattr(
+            prompt_runner, "_auto_sync_device_config", lambda c, _m: (c, None)
+        )
+        monkeypatch.setattr(
+            Config, "load_config", classmethod(lambda cls, _p: FakeConfig())
+        )
+        monkeypatch.setattr(prompt_runner, "DamaiBot", FakeBot)
+        monkeypatch.setattr(
+            prompt_runner, "choose_price_option", lambda *_a, **_kw: None
+        )
+        monkeypatch.setattr(prompt_runner, "_format_summary", lambda *_a, **_kw: "")
+
+        # 让 stdin 非 TTY → fallback 直接 exit 5
+        class FakeStdin:
+            def isatty(self):
+                return False
+
+        monkeypatch.setattr(prompt_runner.sys, "stdin", FakeStdin())
+
+        result = prompt_runner.main(["x", "--mode", "apply", "--non-interactive"])
+        assert result == UNACTIONABLE_EXIT_CODE

--- a/tests/unit/test_prompt_runner_unactionable.py
+++ b/tests/unit/test_prompt_runner_unactionable.py
@@ -1,0 +1,92 @@
+# -*- coding: UTF-8 -*-
+"""fix-plan #26 Step 4：``--non-interactive`` 标志 + ``is_actionable=False`` fallback。
+
+放在独立文件，避免与 ``test_mobile_prompt_runner.py`` 中的 ``with \\`` 块互相影响。
+"""
+
+from __future__ import annotations
+
+
+from mobile.prompt_parser import ParseResult, PromptIntent
+from mobile.prompt_runner import (
+    UNACTIONABLE_EXIT_CODE,
+    _handle_unactionable_apply,
+    parse_args,
+)
+
+
+def _unactionable_parse_result() -> ParseResult:
+    intent = PromptIntent(raw_prompt="测试", search_keyword="x")
+    return ParseResult(
+        intent=intent,
+        matched_item=None,  # → is_actionable=False
+        diagnostics=["缺失：观演人姓名", "缺失：明确日期"],
+        confidence=0.4,
+    )
+
+
+class TestNonInteractiveArg:
+    def test_non_interactive_default_false(self):
+        args = parse_args(["张杰演唱会"])
+        assert args.non_interactive is False
+
+    def test_non_interactive_flag_set(self):
+        args = parse_args(["张杰演唱会", "--non-interactive"])
+        assert args.non_interactive is True
+
+    def test_unactionable_exit_code_constant(self):
+        assert UNACTIONABLE_EXIT_CODE == 5
+
+
+class TestUnactionableFallback:
+    def test_force_non_interactive_returns_false_and_writes_stderr(self, capsys):
+        result = _handle_unactionable_apply(
+            _unactionable_parse_result(), force_non_interactive=True
+        )
+        assert result is False
+        captured = capsys.readouterr()
+        assert "0.40" in captured.err
+        assert "缺失：观演人姓名" in captured.err
+
+    def test_non_tty_stdin_returns_false(self, monkeypatch):
+        class FakeStdin:
+            def isatty(self):
+                return False
+
+        monkeypatch.setattr("mobile.prompt_runner.sys.stdin", FakeStdin())
+        result = _handle_unactionable_apply(
+            _unactionable_parse_result(), force_non_interactive=False
+        )
+        assert result is False
+
+    def test_tty_user_accepts_returns_true(self, monkeypatch):
+        class FakeStdin:
+            def isatty(self):
+                return True
+
+        monkeypatch.setattr("mobile.prompt_runner.sys.stdin", FakeStdin())
+        monkeypatch.setattr(
+            "mobile.prompt_runner._prompt_yes_no", lambda *_a, **_kw: True
+        )
+        assert (
+            _handle_unactionable_apply(
+                _unactionable_parse_result(), force_non_interactive=False
+            )
+            is True
+        )
+
+    def test_tty_user_rejects_returns_false(self, monkeypatch):
+        class FakeStdin:
+            def isatty(self):
+                return True
+
+        monkeypatch.setattr("mobile.prompt_runner.sys.stdin", FakeStdin())
+        monkeypatch.setattr(
+            "mobile.prompt_runner._prompt_yes_no", lambda *_a, **_kw: False
+        )
+        assert (
+            _handle_unactionable_apply(
+                _unactionable_parse_result(), force_non_interactive=False
+            )
+            is False
+        )


### PR DESCRIPTION
## Summary
- **Step 1**: 引入 `ParseResult` 诊断框架（`confidence` + `diagnostics` + `is_actionable`），通过 `__getattr__` 转发到 `intent` 保持向后兼容；apply 模式可在写 config 前判断「是否可执行」。
- **Step 2**: 新增 `mobile/date_utils.normalize_date`，统一 4月6号 / 4/6 / 04-06 / 2026-04-06 / 04.06 等日期格式为 `MM.DD`；`prompt_parser._parse_date` 与 `item_resolver.DamaiItemDetail.normalized_dates` 都走它。
- **Step 3**: 价格匹配宽容化：精确 +100、±10% 容忍 60-80 线性递减、区间命中 +50、最近邻 fallback +30（≤±50% 才接受）。新增 `numeric_price_min` / `numeric_price_max` 字段与 `_parse_price_range` 识别 `500-800元` 区间表达。
- **Step 4**: `apply` / `probe` 模式 `is_actionable=False` 时拒绝写残缺 config；非交互（`--non-interactive` 或 stdin 非 TTY）→ exit 5 + diagnostics 到 stderr；TTY → 显示诊断后让用户决定是否进入交互补缺流程。新增 `--non-interactive` 标志。

## Test plan
- [x] `poetry run pytest`：**921 通过，覆盖率 80.39%（≥80%）**。
- [x] `tests/unit/test_date_utils.py`：21 个参数化用例（11 有效格式 + 7 无效格式 + 3 边界）。
- [x] `tests/unit/test_mobile_prompt_parser.py`：4 个新用例（最近邻命中 / ±10% 容忍 / 区间命中 / 超 50% 离群拒绝）；同步更新 `test_numeric_exact_match` 约束（150→100）。
- [x] `tests/unit/test_prompt_runner_unactionable.py`：5 个用例（`--non-interactive` 默认值、显式开启、`force_non_interactive`、非 TTY、TTY 接受/拒绝）。
- [x] `mobile/prompt_runner.py --help` 含 `--non-interactive` 标志。
- [ ] 真机：5 个不同演出（含至少 1 个多场次）NLP probe，4 个 actionable，1 个 fallback diagnostics 输出（W2-03 验证）。
- [ ] 用户冷启动到首次 actionable config 时间 ≤ 15 min（W2-03 验证）。

## 关联
- Closes #26
- 关联 fix-plan: `reference/05-fix-plans/p1-26-nlp-autodetect.md`
- 4 commit 一一对应 4 个 step：

  | Commit | Step |
  |---|---|
  | `d37223b` | Step 1 ParseResult 诊断框架 |
  | `4d300b1` | Step 2 date_utils.normalize_date |
  | `ef94538` | Step 3 价格匹配评分宽容化 |
  | `140bb38` | Step 4 交互式 fallback + --non-interactive |