### PR TITLE
fix(mobile): #31 price_index 越界守护 + page_probe 状态联动

### DIFF
--- a/mobile/config.py
+++ b/mobile/config.py
@@ -5,34 +5,44 @@ __Version__ = "1.0.0"
 __Description__ = "配置类"
 __Created__ = 2023/10/27 09:54
 """
+
 import json
+import logging
 import re
 import sys
 import os
-from datetime import datetime, timezone, timedelta
+from datetime import datetime
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from shared.config_validator import validate_url, validate_non_empty_list
+from shared.config_validator import validate_non_empty_list
 
 DEFAULT_CONFIG_FILENAME = "config.jsonc"
 LOCAL_CONFIG_FILENAME = "config.local.jsonc"
 CONFIG_OVERRIDE_ENV_VAR = "HATICKETS_CONFIG_PATH"
 DEFAULT_CONFIG_FILENAMES = (DEFAULT_CONFIG_FILENAME,)
 
+PRICE_INDEX_LARGE_WARNING_THRESHOLD = 50
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigError(ValueError):
+    """配置加载/校验失败。继承 ValueError 以保持现有 except 兼容。"""
+
 
 def _strip_jsonc_comments(text):
     """移除 JSONC 文件中的 // 和 /* */ 注释"""
     # 移除单行注释（不在字符串内的 //）
-    text = re.sub(r'(?<!:)//.*?$', '', text, flags=re.MULTILINE)
+    text = re.sub(r"(?<!:)//.*?$", "", text, flags=re.MULTILINE)
     # 移除多行注释
-    text = re.sub(r'/\*.*?\*/', '', text, flags=re.DOTALL)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
     return text
 
 
 def _load_config_dict_from_path(path):
     try:
-        with open(path, 'r', encoding='utf-8') as config_file:
+        with open(path, "r", encoding="utf-8") as config_file:
             raw_text = config_file.read()
     except FileNotFoundError:
         raise FileNotFoundError(f"配置文件未找到: {path}")
@@ -87,7 +97,7 @@ def load_config_dict(config_path=None):
 def save_config_dict(config_dict, config_path=None):
     """Persist a config dictionary back to disk as UTF-8 JSON."""
     resolved_path = _resolve_writable_config_path(config_path)
-    with open(resolved_path, 'w', encoding='utf-8') as config_file:
+    with open(resolved_path, "w", encoding="utf-8") as config_file:
         config_file.write(_dump_config_dict(config_dict))
 
 
@@ -113,37 +123,61 @@ def update_runtime_mode(probe_only, if_commit_order, config_path=None):
 
 
 class Config:
-    def __init__(self, keyword, users, city, date, price, price_index, if_commit_order,
-                 probe_only=False,
-                 app_package="cn.damai", app_activity=".launcher.splash.SplashMainActivity",
-                 sell_start_time=None, countdown_lead_ms=3000,
-                 wait_cta_ready_timeout_ms=0,
-                 fast_retry_count=8, fast_retry_interval_ms=120,
-                 rush_mode=False,
-                 auto_navigate=True,
-                 target_title=None, target_venue=None,
-                 serial=None,
-                 # Deprecated Appium-era params — accepted for config file compat, ignored
-                 driver_backend="u2", server_url=None, device_name="Android",
-                 udid=None, platform_version=None):
+    def __init__(
+        self,
+        keyword,
+        users,
+        city,
+        date,
+        price,
+        price_index,
+        if_commit_order,
+        probe_only=False,
+        app_package="cn.damai",
+        app_activity=".launcher.splash.SplashMainActivity",
+        sell_start_time=None,
+        countdown_lead_ms=3000,
+        wait_cta_ready_timeout_ms=0,
+        fast_retry_count=8,
+        fast_retry_interval_ms=120,
+        rush_mode=False,
+        auto_navigate=True,
+        target_title=None,
+        target_venue=None,
+        serial=None,
+        # Deprecated Appium-era params — accepted for config file compat, ignored
+        driver_backend="u2",
+        server_url=None,
+        device_name="Android",
+        udid=None,
+        platform_version=None,
+    ):
 
         # Validate users
         validate_non_empty_list(users, "users")
 
         # Validate price_index
-        if not isinstance(price_index, int) or isinstance(price_index, bool) or price_index < 0:
+        if (
+            not isinstance(price_index, int)
+            or isinstance(price_index, bool)
+            or price_index < 0
+        ):
             raise ValueError(f"price_index 必须是非负整数，实际值: {price_index!r}")
 
         if keyword is None or not isinstance(keyword, str) or len(keyword.strip()) == 0:
             raise ValueError(f"keyword 不能为空，必须是非空字符串，实际值: {keyword!r}")
 
         if not isinstance(if_commit_order, bool):
-            raise ValueError(f"if_commit_order 必须是布尔值，实际值: {if_commit_order!r}")
+            raise ValueError(
+                f"if_commit_order 必须是布尔值，实际值: {if_commit_order!r}"
+            )
 
         if not isinstance(probe_only, bool):
             raise ValueError(f"probe_only 必须是布尔值，实际值: {probe_only!r}")
 
-        if serial is not None and (not isinstance(serial, str) or len(serial.strip()) == 0):
+        if serial is not None and (
+            not isinstance(serial, str) or len(serial.strip()) == 0
+        ):
             raise ValueError(f"serial 必须是非空字符串或 null，实际值: {serial!r}")
 
         if not isinstance(app_package, str) or len(app_package.strip()) == 0:
@@ -155,38 +189,71 @@ class Config:
         if not isinstance(auto_navigate, bool):
             raise ValueError(f"auto_navigate 必须是布尔值，实际值: {auto_navigate!r}")
 
-        if target_title is not None and (not isinstance(target_title, str) or len(target_title.strip()) == 0):
-            raise ValueError(f"target_title 必须是非空字符串或 null，实际值: {target_title!r}")
+        if target_title is not None and (
+            not isinstance(target_title, str) or len(target_title.strip()) == 0
+        ):
+            raise ValueError(
+                f"target_title 必须是非空字符串或 null，实际值: {target_title!r}"
+            )
 
-        if target_venue is not None and (not isinstance(target_venue, str) or len(target_venue.strip()) == 0):
-            raise ValueError(f"target_venue 必须是非空字符串或 null，实际值: {target_venue!r}")
+        if target_venue is not None and (
+            not isinstance(target_venue, str) or len(target_venue.strip()) == 0
+        ):
+            raise ValueError(
+                f"target_venue 必须是非空字符串或 null，实际值: {target_venue!r}"
+            )
 
         # Validate sell_start_time
         if sell_start_time is not None:
             if not isinstance(sell_start_time, str):
-                raise ValueError(f"sell_start_time 必须是 ISO 格式的时间字符串或 null，实际值: {sell_start_time!r}")
+                raise ValueError(
+                    f"sell_start_time 必须是 ISO 格式的时间字符串或 null，实际值: {sell_start_time!r}"
+                )
             try:
                 datetime.fromisoformat(sell_start_time)
             except (ValueError, TypeError):
-                raise ValueError(f"sell_start_time 无法解析为 ISO 时间格式，实际值: {sell_start_time!r}")
+                raise ValueError(
+                    f"sell_start_time 无法解析为 ISO 时间格式，实际值: {sell_start_time!r}"
+                )
 
         # Validate countdown_lead_ms
-        if not isinstance(countdown_lead_ms, int) or isinstance(countdown_lead_ms, bool) or countdown_lead_ms < 0:
-            raise ValueError(f"countdown_lead_ms 必须是非负整数，实际值: {countdown_lead_ms!r}")
+        if (
+            not isinstance(countdown_lead_ms, int)
+            or isinstance(countdown_lead_ms, bool)
+            or countdown_lead_ms < 0
+        ):
+            raise ValueError(
+                f"countdown_lead_ms 必须是非负整数，实际值: {countdown_lead_ms!r}"
+            )
 
-        if not isinstance(wait_cta_ready_timeout_ms, int) or \
-                isinstance(wait_cta_ready_timeout_ms, bool) or wait_cta_ready_timeout_ms < 0:
+        if (
+            not isinstance(wait_cta_ready_timeout_ms, int)
+            or isinstance(wait_cta_ready_timeout_ms, bool)
+            or wait_cta_ready_timeout_ms < 0
+        ):
             raise ValueError(
                 f"wait_cta_ready_timeout_ms 必须是非负整数，实际值: {wait_cta_ready_timeout_ms!r}"
             )
 
         # Validate fast_retry_count
-        if not isinstance(fast_retry_count, int) or isinstance(fast_retry_count, bool) or fast_retry_count < 0:
-            raise ValueError(f"fast_retry_count 必须是非负整数，实际值: {fast_retry_count!r}")
+        if (
+            not isinstance(fast_retry_count, int)
+            or isinstance(fast_retry_count, bool)
+            or fast_retry_count < 0
+        ):
+            raise ValueError(
+                f"fast_retry_count 必须是非负整数，实际值: {fast_retry_count!r}"
+            )
 
         # Validate fast_retry_interval_ms
-        if not isinstance(fast_retry_interval_ms, int) or isinstance(fast_retry_interval_ms, bool) or fast_retry_interval_ms < 0:
-            raise ValueError(f"fast_retry_interval_ms 必须是非负整数，实际值: {fast_retry_interval_ms!r}")
+        if (
+            not isinstance(fast_retry_interval_ms, int)
+            or isinstance(fast_retry_interval_ms, bool)
+            or fast_retry_interval_ms < 0
+        ):
+            raise ValueError(
+                f"fast_retry_interval_ms 必须是非负整数，实际值: {fast_retry_interval_ms!r}"
+            )
 
         if not isinstance(rush_mode, bool):
             raise ValueError(f"rush_mode 必须是布尔值，实际值: {rush_mode!r}")
@@ -208,8 +275,12 @@ class Config:
         self.fast_retry_interval_ms = fast_retry_interval_ms
         self.rush_mode = rush_mode
         self.auto_navigate = auto_navigate
-        self.target_title = target_title.strip() if isinstance(target_title, str) else None
-        self.target_venue = target_venue.strip() if isinstance(target_venue, str) else None
+        self.target_title = (
+            target_title.strip() if isinstance(target_title, str) else None
+        )
+        self.target_venue = (
+            target_venue.strip() if isinstance(target_venue, str) else None
+        )
         self.serial = serial.strip() if isinstance(serial, str) else None
 
     def to_dict(self):
@@ -241,7 +312,14 @@ class Config:
     def load_config(config_path=None):
         config = load_config_dict(config_path)
 
-        required_keys = ['users', 'city', 'date', 'price', 'price_index', 'if_commit_order']
+        required_keys = [
+            "users",
+            "city",
+            "date",
+            "price",
+            "price_index",
+            "if_commit_order",
+        ]
         missing = [k for k in required_keys if k not in config]
         if missing:
             raise KeyError(f"配置文件缺少必需字段: {', '.join(missing)}")
@@ -249,25 +327,39 @@ class Config:
         if "keyword" not in config:
             raise KeyError("配置文件缺少必需字段: keyword")
 
+        # P1 #31 — 启动期校验 price_index 范围
+        raw_price_index = config["price_index"]
+        if isinstance(raw_price_index, int) and not isinstance(raw_price_index, bool):
+            if raw_price_index < 0:
+                raise ConfigError(f"price_index 不能为负数（当前 {raw_price_index}）")
+            if raw_price_index > PRICE_INDEX_LARGE_WARNING_THRESHOLD:
+                logger.warning(
+                    "price_index=%d 异常大（>%d），请确认 mobile/config.jsonc 是否填错",
+                    raw_price_index,
+                    PRICE_INDEX_LARGE_WARNING_THRESHOLD,
+                )
+
         return Config(
-            keyword=config.get('keyword'),
-            users=config['users'],
-            city=config['city'],
-            date=config['date'],
-            price=config['price'],
-            price_index=config['price_index'],
-            if_commit_order=config['if_commit_order'],
-            probe_only=config.get('probe_only', False),
-            app_package=config.get('app_package', 'cn.damai'),
-            app_activity=config.get('app_activity', '.launcher.splash.SplashMainActivity'),
-            sell_start_time=config.get('sell_start_time'),
-            countdown_lead_ms=config.get('countdown_lead_ms', 3000),
-            wait_cta_ready_timeout_ms=config.get('wait_cta_ready_timeout_ms', 0),
-            fast_retry_count=config.get('fast_retry_count', 8),
-            fast_retry_interval_ms=config.get('fast_retry_interval_ms', 120),
-            rush_mode=config.get('rush_mode', False),
-            auto_navigate=config.get('auto_navigate', True),
-            target_title=config.get('target_title'),
-            target_venue=config.get('target_venue'),
-            serial=config.get('serial'),
+            keyword=config.get("keyword"),
+            users=config["users"],
+            city=config["city"],
+            date=config["date"],
+            price=config["price"],
+            price_index=config["price_index"],
+            if_commit_order=config["if_commit_order"],
+            probe_only=config.get("probe_only", False),
+            app_package=config.get("app_package", "cn.damai"),
+            app_activity=config.get(
+                "app_activity", ".launcher.splash.SplashMainActivity"
+            ),
+            sell_start_time=config.get("sell_start_time"),
+            countdown_lead_ms=config.get("countdown_lead_ms", 3000),
+            wait_cta_ready_timeout_ms=config.get("wait_cta_ready_timeout_ms", 0),
+            fast_retry_count=config.get("fast_retry_count", 8),
+            fast_retry_interval_ms=config.get("fast_retry_interval_ms", 120),
+            rush_mode=config.get("rush_mode", False),
+            auto_navigate=config.get("auto_navigate", True),
+            target_title=config.get("target_title"),
+            target_venue=config.get("target_venue"),
+            serial=config.get("serial"),
         )

--- a/mobile/damai_app.py
+++ b/mobile/damai_app.py
@@ -12,6 +12,7 @@ import re
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone, timedelta
+from pathlib import Path
 
 try:
     from selenium.webdriver.common.by import By
@@ -55,7 +56,11 @@ try:
     from mobile.fast_pipeline import FastPipeline, poll_until, batch_shell_taps
     from mobile.recovery import RecoveryHelper
     from mobile.event_navigator import EventNavigator
-    from mobile.price_selector import PriceSelector
+    from mobile.price_selector import (
+        PriceSelector,
+        PriceSelectorError,
+        SoldOutError,
+    )
     from mobile.attendee_selector import AttendeeSelector
 except ImportError:
     from buy_button_guard import BuyButtonGuard
@@ -65,6 +70,7 @@ except ImportError:
     from event_navigator import EventNavigator
     from price_selector import PriceSelector
     from attendee_selector import AttendeeSelector
+
 
 logger = get_logger(__name__)
 
@@ -547,6 +553,54 @@ class DamaiBot(UIPrimitives):
         if hasattr(self, "_price_sel"):
             return self._price_sel._select_price_option(cached_coords)
         return False
+
+    # ------------------------------------------------------------------
+    # Failure diagnostics (P1 #31)
+    # ------------------------------------------------------------------
+
+    def _save_price_failure_dump(self, reason: str = "") -> Path | None:
+        """Persist a UI hierarchy XML (and best-effort screenshot) to tmp/.
+
+        Called when the price selection path fails so post-mortem analysis
+        does not need a live device. ``tmp/`` is git-ignored.
+        Returns the dump path on success, or ``None`` if nothing could be
+        captured (e.g. driver unavailable).
+        """
+        try:
+            tmp_dir = Path("tmp")
+            tmp_dir.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+            xml_path = tmp_dir / f"price_dump_{ts}.xml"
+
+            xml_text = ""
+            try:
+                if self._using_u2():
+                    xml_text = self.d.dump_hierarchy()
+            except Exception as exc:  # pragma: no cover - logged only
+                logger.warning("dump_hierarchy 失败: %s", exc)
+                xml_text = ""
+
+            if not xml_text:
+                logger.warning("无法获取 UI hierarchy，跳过 dump 落盘")
+                return None
+
+            xml_path.write_text(xml_text, encoding="utf-8")
+            suffix = f"（reason={reason}）" if reason else ""
+            logger.error("failure dump saved to %s%s", xml_path, suffix)
+
+            # best-effort screenshot — never block the dump on screenshot failure
+            png_path = xml_path.with_suffix(".png")
+            try:
+                if self._using_u2() and hasattr(self.d, "screenshot"):
+                    self.d.screenshot(str(png_path))
+                    logger.error("failure screenshot saved to %s", png_path)
+            except Exception as exc:  # pragma: no cover - logged only
+                logger.debug("screenshot 不可用: %s", exc)
+
+            return xml_path
+        except Exception as exc:  # pragma: no cover - logged only
+            logger.warning("保存 price dump 失败: %s", exc)
+            return None
 
     def _keyword_tokens(self):
         if hasattr(self, "_navigator"):
@@ -1696,7 +1750,18 @@ class DamaiBot(UIPrimitives):
                 logger.info("开发验证极速路径：检测到已处于可调数量状态，跳过票档点击")
             else:
                 logger.info("选择票价...")
-                if not self._select_price_option(cached_coords=price_coords):
+                try:
+                    selected = self._select_price_option(cached_coords=price_coords)
+                except SoldOutError as exc:
+                    self._save_price_failure_dump(reason=f"sold_out: {exc}")
+                    logger.error("票档已售罄，停止本轮抢票: %s", exc)
+                    return False
+                except PriceSelectorError as exc:
+                    self._save_price_failure_dump(reason=str(exc))
+                    logger.error("价格选择失败: %s", exc)
+                    return False
+                if not selected:
+                    self._save_price_failure_dump(reason="select returned False")
                     return False
 
             # 4. 数量选择

--- a/mobile/page_probe.py
+++ b/mobile/page_probe.py
@@ -19,6 +19,67 @@ except ImportError:
 
 logger = get_logger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Price panel state detection (P1 #31, Step 3)
+# ---------------------------------------------------------------------------
+
+# Resource IDs / text patterns checked when classifying the price panel state.
+_PRICE_LOADING_INDICATORS = (
+    "cn.damai:id/loading_progress",
+    "cn.damai:id/sku_loading",
+    "cn.damai:id/loading_view",
+)
+_PRICE_READY_CONTAINERS = (
+    "cn.damai:id/project_detail_perform_price_flowlayout",
+    "cn.damai:id/layout_price",
+)
+_PRICE_SOLD_OUT_TEXTS = (
+    "已售罄",
+    "全部售罄",
+    "无票",
+    "暂无可售票档",
+    "缺货登记",
+)
+
+
+def _safe_exists(driver: Any, **selector: Any) -> bool:
+    """Return ``driver(**selector).exists`` swallowing any device error."""
+    try:
+        return bool(driver(**selector).exists)
+    except Exception:
+        return False
+
+
+def detect_price_panel_state(driver: Any) -> str:
+    """Classify the visible price panel state.
+
+    Returns one of: ``"loading"``, ``"ready"``, ``"sold_out"``, ``"unknown"``.
+
+    The order is intentional:
+      1. ``loading`` — a loading spinner is present, caller should wait briefly.
+      2. ``sold_out`` — visible text matches a sold-out marker.
+      3. ``ready`` — a known price container resource-id exists.
+      4. ``unknown`` — none of the above; caller should fall back gracefully.
+    """
+    # 1. loading spinner takes priority — the panel may render later
+    for resource_id in _PRICE_LOADING_INDICATORS:
+        if _safe_exists(driver, resourceId=resource_id):
+            return "loading"
+
+    # 2. sold-out markers (text/textContains) — never try to click empty cards
+    for text in _PRICE_SOLD_OUT_TEXTS:
+        if _safe_exists(driver, text=text) or _safe_exists(driver, textContains=text):
+            return "sold_out"
+
+    # 3. ready when a known price container is present
+    for container_id in _PRICE_READY_CONTAINERS:
+        if _safe_exists(driver, resourceId=container_id):
+            return "ready"
+
+    return "unknown"
+
+
 # Activity substrings → state mapping (used by fast probe)
 _ACTIVITY_STATE_MAP = (
     ("ProjectDetail", "detail_page"),
@@ -53,7 +114,9 @@ class PageProbe:
         cache_ttl_s: How long (seconds) a cached probe result stays valid.
     """
 
-    def __init__(self, device: Any, config: Any = None, cache_ttl_s: float = 0.5) -> None:
+    def __init__(
+        self, device: Any, config: Any = None, cache_ttl_s: float = 0.5
+    ) -> None:
         self._device = device
         self._config = config
         self._bot = None
@@ -80,8 +143,13 @@ class PageProbe:
             A dict describing the page state and key element presence.
         """
         now = time.time()
-        if self._cached_result is not None and (now - self._cached_at) < self._cache_ttl_s:
-            logger.debug("page probe: returning cached result (age=%.3fs)", now - self._cached_at)
+        if (
+            self._cached_result is not None
+            and (now - self._cached_at) < self._cache_ttl_s
+        ):
+            logger.debug(
+                "page probe: returning cached result (age=%.3fs)", now - self._cached_at
+            )
             return self._cached_result
 
         if fast:
@@ -149,8 +217,12 @@ class PageProbe:
 
         if "NcovSku" in activity:
             reservation = self._check_reservation_mode()
-            return _make_result(state="sku_page", price_container=True, quantity_picker=True,
-                                reservation_mode=reservation)
+            return _make_result(
+                state="sku_page",
+                price_container=True,
+                quantity_picker=True,
+                reservation_mode=reservation,
+            )
 
         if "MainActivity" in activity:
             return _make_result(state="homepage")
@@ -196,7 +268,9 @@ class PageProbe:
         purchase_bar = self._exists_by_resource_id(
             "cn.damai:id/trade_project_detail_purchase_status_bar_container_fl"
         )
-        price_layout = self._exists_by_resource_id("cn.damai:id/project_detail_price_layout")
+        price_layout = self._exists_by_resource_id(
+            "cn.damai:id/project_detail_price_layout"
+        )
         title_tv = self._exists_by_resource_id("cn.damai:id/title_tv")
         if purchase_bar or price_layout or title_tv:
             return _make_result(
@@ -207,7 +281,9 @@ class PageProbe:
             )
 
         # Check homepage (fallback)
-        search_header = self._exists_by_resource_id("cn.damai:id/homepage_header_search")
+        search_header = self._exists_by_resource_id(
+            "cn.damai:id/homepage_header_search"
+        )
         search_btn = self._exists_by_resource_id(
             "cn.damai:id/pioneer_homepage_header_search_btn"
         )

--- a/mobile/price_selector.py
+++ b/mobile/price_selector.py
@@ -165,7 +165,16 @@ class PriceSelector:
     # ------------------------------------------------------------------
 
     def select_by_index(self, xml_root=None) -> bool:
-        """Select price option by config.price_index. Returns True on success."""
+        """Select price option by config.price_index. Returns True on success.
+
+        Before attempting to click, the price panel state is sampled via
+        ``page_probe.detect_price_panel_state`` (P1 #31). On ``loading`` the
+        method waits up to 2s for the panel to appear; on ``sold_out`` it
+        raises ``SoldOutError``; on ``ready`` / ``unknown`` it proceeds with
+        the existing coordinate-based click path.
+        """
+        self._await_price_panel_or_raise()
+
         coords = self.get_price_coords_by_index(xml_root=xml_root)
         if coords is None:
             logger.warning(f"无法定位 price_index={self._config.price_index} 的坐标")
@@ -173,6 +182,46 @@ class PriceSelector:
         self._click_coordinates(*coords)
         logger.info(f"通过配置索引选择票价: price_index={self._config.price_index}")
         return True
+
+    def _await_price_panel_or_raise(self, *, max_wait_s: float = 2.0) -> str:
+        """Sample the price panel state, blocking up to ``max_wait_s`` on loading.
+
+        Returns the final state. Raises ``SoldOutError`` when the panel
+        reports sold-out, and ``PriceSelectorError("加载超时")`` if it stays
+        in ``loading`` past the timeout.
+        """
+        # Lazy import to avoid hard dependency on page_probe in unit tests
+        # that exercise PriceSelector in isolation (the import below is
+        # cheap; we only delay it to keep top-of-file import order minimal).
+        try:
+            from mobile.page_probe import detect_price_panel_state
+        except ImportError:  # pragma: no cover - fallback for non-package runs
+            from page_probe import detect_price_panel_state  # type: ignore
+
+        state = detect_price_panel_state(self._d)
+        if state == "loading":
+            import time as _time
+
+            deadline = _time.monotonic() + max_wait_s
+            while _time.monotonic() < deadline:
+                _time.sleep(0.1)
+                state = detect_price_panel_state(self._d)
+                if state != "loading":
+                    break
+            if state == "loading":
+                raise PriceSelectorError(
+                    f"价格面板加载超时（>{max_wait_s:.1f}s），疑似设备/网络异常"
+                )
+
+        if state == "sold_out":
+            raise SoldOutError("价格面板检测到全部票档售罄")
+
+        if state == "unknown":
+            logger.warning(
+                "price panel state=unknown — 选择器/UI 可能已变更，继续尝试索引点击"
+            )
+
+        return state
 
     def get_price_coords_by_index(self, xml_root=None) -> Optional[Tuple[int, int]]:
         """Get coordinates for price option at config.price_index."""

--- a/mobile/price_selector.py
+++ b/mobile/price_selector.py
@@ -13,7 +13,9 @@ import shutil
 import subprocess
 import tempfile
 import xml.etree.ElementTree as ET
-from typing import TYPE_CHECKING, Optional, Tuple
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Optional, Sequence, Tuple
 
 from selenium.webdriver.common.by import By
 
@@ -32,19 +34,117 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_PRICE_UNAVAILABLE_TAGS = {"无票", "缺货", "缺货登记", "售罄", "已售罄", "不可选", "暂不可售"}
+_PRICE_UNAVAILABLE_TAGS = {
+    "无票",
+    "缺货",
+    "缺货登记",
+    "售罄",
+    "已售罄",
+    "不可选",
+    "暂不可售",
+}
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic exceptions and price-card data class (P1 #31)
+# ---------------------------------------------------------------------------
+
+
+class PriceSelectorError(RuntimeError):
+    """价格选择失败：卡片为空 / index 越界 / 加载超时等。
+
+    Inherits from RuntimeError so existing broad ``except Exception`` /
+    ``except RuntimeError`` call sites keep working unchanged.
+    """
+
+
+class SoldOutError(RuntimeError):
+    """价格面板检测到全部票档售罄；与越界明确区分以便上层决定是否重试。"""
+
+
+@dataclass(frozen=True)
+class PriceCard:
+    """A single clickable price card surfaced from the Damai SKU/detail page."""
+
+    index: int
+    price_text: str
+    coords: Optional[Tuple[int, int]] = None
+    tag: str = ""
+    raw_texts: Tuple[str, ...] = field(default_factory=tuple)
+
+
+def _safe_call_dump_writer(
+    dump_writer: Optional[Callable[[Path], None]],
+    dump_on_fail: Optional[Path],
+) -> Optional[Path]:
+    """Persist a UI dump if a writer + path were provided. Best-effort, never raises."""
+    if dump_writer is None or dump_on_fail is None:
+        return None
+    try:
+        dump_writer(dump_on_fail)
+        return dump_on_fail
+    except Exception as exc:  # pragma: no cover - logged for diagnostics
+        logger.warning("price dump 写入失败 (%s): %s", dump_on_fail, exc)
+        return None
+
+
+def select_price_by_index(
+    cards: Sequence[PriceCard],
+    index: int,
+    *,
+    dump_on_fail: Optional[Path] = None,
+    dump_writer: Optional[Callable[[Path], None]] = None,
+) -> PriceCard:
+    """Return ``cards[index]`` with actionable diagnostics on failure.
+
+    On any failure the optional ``dump_writer`` is invoked with ``dump_on_fail``
+    so the caller (e.g. DamaiBot) can persist a hierarchy XML before the
+    exception bubbles up. The dump path, if any, is appended to the message.
+
+    Raises:
+        PriceSelectorError: when ``cards`` is empty or ``index`` is out of range.
+    """
+
+    if not cards:
+        saved = _safe_call_dump_writer(dump_writer, dump_on_fail)
+        suffix = f"\nUI dump 已保存：{saved}" if saved else ""
+        raise PriceSelectorError(
+            "未发现可点击价格卡片。可能原因：\n"
+            "  1. 演出尚未开售（CTA 显示「待开售」）\n"
+            "  2. 价格区已售罄\n"
+            "  3. 大麦 App UI 变更，需更新选择器" + suffix
+        )
+
+    if index < 0 or index >= len(cards):
+        saved = _safe_call_dump_writer(dump_writer, dump_on_fail)
+        suffix = f"\nUI dump 已保存：{saved}" if saved else ""
+        available = "\n".join(
+            f"  [{c.index}] {c.price_text or '(空)'}" + (f" [{c.tag}]" if c.tag else "")
+            for c in cards
+        )
+        raise PriceSelectorError(
+            f"price_index={index} 越界（可用 0..{len(cards) - 1}）。\n"
+            f"可用价档：\n{available}\n"
+            "请修改 mobile/config.jsonc 中 price_index" + suffix
+        )
+
+    return cards[index]
+
+
 _MAGICK_BIN = shutil.which("magick")
 _TESSERACT_BIN = shutil.which("tesseract")
-_OCR_CHAR_TRANSLATIONS = str.maketrans({
-    "O": "0",
-    "o": "0",
-    "I": "1",
-    "l": "1",
-    "|": "1",
-    "S": "5",
-    "s": "5",
-    "B": "8",
-})
+_OCR_CHAR_TRANSLATIONS = str.maketrans(
+    {
+        "O": "0",
+        "o": "0",
+        "I": "1",
+        "l": "1",
+        "|": "1",
+        "S": "5",
+        "s": "5",
+        "B": "8",
+    }
+)
 
 
 class PriceSelector:
@@ -78,7 +178,9 @@ class PriceSelector:
         """Get coordinates for price option at config.price_index."""
         if self._bot is not None:
             try:
-                return self._bot._get_price_option_coordinates_by_config_index(xml_root=xml_root)
+                return self._bot._get_price_option_coordinates_by_config_index(
+                    xml_root=xml_root
+                )
             except Exception as exc:
                 logger.warning(f"获取票价坐标失败: {exc}")
                 return None
@@ -148,6 +250,7 @@ class PriceSelector:
             # Retry once after short wait (cards may still be loading)
             if xml_root is not None:
                 import time
+
                 time.sleep(0.3)
                 result = self._get_price_coords_from_xml(None)  # fresh XML dump
                 if result is not None:
@@ -155,12 +258,16 @@ class PriceSelector:
             return None
 
         try:
-            price_container = bot._find(By.ID, "cn.damai:id/project_detail_perform_price_flowlayout")
+            price_container = bot._find(
+                By.ID, "cn.damai:id/project_detail_perform_price_flowlayout"
+            )
         except Exception:
             return None
 
         try:
-            cards = bot._container_find_elements(price_container, By.CLASS_NAME, "android.widget.FrameLayout")
+            cards = bot._container_find_elements(
+                price_container, By.CLASS_NAME, "android.widget.FrameLayout"
+            )
         except Exception:
             return None
         clickable_cards = [card for card in cards if bot._is_clickable(card)]
@@ -193,7 +300,8 @@ class PriceSelector:
             for node in xml_root.iter("node"):
                 if node.get("resource-id") == container_id:
                     cards = [
-                        child for child in node
+                        child
+                        for child in node
                         if child.get("class") == "android.widget.FrameLayout"
                         and child.get("clickable") == "true"
                     ]
@@ -205,7 +313,9 @@ class PriceSelector:
                             f"中的 {len(cards)} 个可点击卡片"
                         )
                         continue
-                    bounds = bot._parse_bounds(cards[self._config.price_index].get("bounds", ""))
+                    bounds = bot._parse_bounds(
+                        cards[self._config.price_index].get("bounds", "")
+                    )
                     if bounds:
                         left, top, right, bottom = bounds
                         return ((left + right) // 2, (top + bottom) // 2)
@@ -224,7 +334,10 @@ class PriceSelector:
         normalized_target = normalize_text(self._config.price)
         normalized_text = normalize_text(text)
         if normalized_target and normalized_text:
-            if normalized_target in normalized_text or normalized_text in normalized_target:
+            if (
+                normalized_target in normalized_text
+                or normalized_text in normalized_target
+            ):
                 return True
 
         target_digits = self._extract_price_digits(self._config.price)
@@ -240,8 +353,12 @@ class PriceSelector:
         """Click a visible price card by its clickable-card index."""
         bot = self._bot
         try:
-            price_container = bot._find(By.ID, "cn.damai:id/project_detail_perform_price_flowlayout")
-            cards = bot._container_find_elements(price_container, By.CLASS_NAME, "android.widget.FrameLayout")
+            price_container = bot._find(
+                By.ID, "cn.damai:id/project_detail_perform_price_flowlayout"
+            )
+            cards = bot._container_find_elements(
+                price_container, By.CLASS_NAME, "android.widget.FrameLayout"
+            )
         except Exception:
             return False
 
@@ -260,14 +377,18 @@ class PriceSelector:
         bot = self._bot
         # Primary: element click — Damai price cards may not respond to coordinate taps
         if self._click_price_card_element(self._config.price_index):
-            logger.info(f"通过配置索引直接选择票价: price_index={self._config.price_index}")
+            logger.info(
+                f"通过配置索引直接选择票价: price_index={self._config.price_index}"
+            )
             return True
         # Fallback: coordinate click
         target_coords = coords or bot._get_price_option_coordinates_by_config_index()
         if not target_coords:
             return False
         if burst:
-            bot._burst_click_coordinates(*target_coords, count=2, interval_ms=25, duration=25)
+            bot._burst_click_coordinates(
+                *target_coords, count=2, interval_ms=25, duration=25
+            )
         else:
             bot._click_coordinates(*target_coords, duration=30)
         logger.info(f"通过配置索引直接选择票价: price_index={self._config.price_index}")
@@ -280,10 +401,14 @@ class PriceSelector:
         not raw touch coordinates.
         """
         try:
-            container = self._d(resourceId="cn.damai:id/project_detail_perform_price_flowlayout")
+            container = self._d(
+                resourceId="cn.damai:id/project_detail_perform_price_flowlayout"
+            )
             if not container.exists:
                 return False
-            children = container.child(className="android.widget.FrameLayout", clickable=True)
+            children = container.child(
+                className="android.widget.FrameLayout", clickable=True
+            )
             if children.count > index:
                 children[index].click()
                 return True
@@ -303,9 +428,7 @@ class PriceSelector:
             "cn.damai:id/project_price_pre",
             "cn.damai:id/project_price_suffix",
         )
-        suffix_ids = (
-            "cn.damai:id/bricks_dm_common_price_suffix",
-        )
+        suffix_ids = ("cn.damai:id/bricks_dm_common_price_suffix",)
 
         prefix = ""
         value_parts = []
@@ -360,13 +483,22 @@ class PriceSelector:
         bot = self._bot
         if self._config.rush_mode:
             _burst = self._config.if_commit_order
-            if bot._click_price_option_by_config_index(burst=_burst, coords=cached_coords):
+            if bot._click_price_option_by_config_index(
+                burst=_burst, coords=cached_coords
+            ):
                 return True
 
         visible_options = bot.get_visible_price_options(allow_ocr=False)
 
         if visible_options:
-            indexed_option = next((option for option in visible_options if option["index"] == self._config.price_index), None)
+            indexed_option = next(
+                (
+                    option
+                    for option in visible_options
+                    if option["index"] == self._config.price_index
+                ),
+                None,
+            )
             if indexed_option:
                 if not bot._is_price_option_available(indexed_option):
                     logger.warning(
@@ -374,7 +506,9 @@ class PriceSelector:
                         f"[{indexed_option.get('tag') or '不可售'}]"
                     )
                     return False
-                if not indexed_option.get("text") or bot._price_text_matches_target(indexed_option.get("text") or ""):
+                if not indexed_option.get("text") or bot._price_text_matches_target(
+                    indexed_option.get("text") or ""
+                ):
                     if bot._click_visible_price_option(indexed_option["index"]):
                         logger.info(
                             f"通过配置索引快速选择票价: {indexed_option.get('text') or self._config.price} "
@@ -385,7 +519,8 @@ class PriceSelector:
                 return True
 
             matched_options = [
-                option for option in visible_options
+                option
+                for option in visible_options
                 if bot._price_text_matches_target(option.get("text") or "")
             ]
             for option in matched_options:
@@ -419,7 +554,11 @@ class PriceSelector:
             return fast_result
 
         visible_options = bot.get_visible_price_options()
-        matched_options = [option for option in visible_options if bot._price_text_matches_target(option.get("text") or "")]
+        matched_options = [
+            option
+            for option in visible_options
+            if bot._price_text_matches_target(option.get("text") or "")
+        ]
 
         for option in matched_options:
             if not bot._is_price_option_available(option):
@@ -435,7 +574,14 @@ class PriceSelector:
                 return True
 
         if visible_options:
-            indexed_option = next((option for option in visible_options if option["index"] == self._config.price_index), None)
+            indexed_option = next(
+                (
+                    option
+                    for option in visible_options
+                    if option["index"] == self._config.price_index
+                ),
+                None,
+            )
             if indexed_option and bot._is_price_option_available(indexed_option):
                 if bot._click_visible_price_option(indexed_option["index"]):
                     logger.info(
@@ -455,20 +601,28 @@ class PriceSelector:
             logger.info(f"通过文本匹配选择票价: {self._config.price}")
             return True
 
-        logger.info(f"文本匹配失败，使用索引选择票价: price_index={self._config.price_index}")
+        logger.info(
+            f"文本匹配失败，使用索引选择票价: price_index={self._config.price_index}"
+        )
         logger.info(f"通过配置索引直接选择票价: price_index={self._config.price_index}")
         try:
-            price_container = bot._find(By.ID, "cn.damai:id/project_detail_perform_price_flowlayout")
+            price_container = bot._find(
+                By.ID, "cn.damai:id/project_detail_perform_price_flowlayout"
+            )
             if not bot._using_u2():
                 target_price = price_container.find_element(
                     ANDROID_UIAUTOMATOR,
-                    f'new UiSelector().className("android.widget.FrameLayout").index({self._config.price_index}).clickable(true)'
+                    f'new UiSelector().className("android.widget.FrameLayout").index({self._config.price_index}).clickable(true)',
                 )
             else:
-                cards = bot._container_find_elements(price_container, By.CLASS_NAME, "android.widget.FrameLayout")
+                cards = bot._container_find_elements(
+                    price_container, By.CLASS_NAME, "android.widget.FrameLayout"
+                )
                 clickable_cards = [card for card in cards if bot._is_clickable(card)]
                 if not (0 <= self._config.price_index < len(clickable_cards)):
-                    logger.warning(f"price_index={self._config.price_index} 超出可点击卡片数量 {len(clickable_cards)}")
+                    logger.warning(
+                        f"price_index={self._config.price_index} 超出可点击卡片数量 {len(clickable_cards)}"
+                    )
                     return False
                 target_price = clickable_cards[self._config.price_index]
             bot._click_element_center(target_price, duration=30)
@@ -478,7 +632,12 @@ class PriceSelector:
             try:
                 if not bot._using_u2() and bot.wait is not None:
                     price_container = bot.wait.until(
-                        EC.presence_of_element_located((By.ID, "cn.damai:id/project_detail_perform_price_flowlayout"))
+                        EC.presence_of_element_located(
+                            (
+                                By.ID,
+                                "cn.damai:id/project_detail_perform_price_flowlayout",
+                            )
+                        )
                     )
                 else:
                     price_container = bot._wait_for_element(
@@ -489,13 +648,19 @@ class PriceSelector:
                 if not bot._using_u2():
                     target_price = price_container.find_element(
                         ANDROID_UIAUTOMATOR,
-                        f'new UiSelector().className("android.widget.FrameLayout").index({self._config.price_index}).clickable(true)'
+                        f'new UiSelector().className("android.widget.FrameLayout").index({self._config.price_index}).clickable(true)',
                     )
                 else:
-                    cards = bot._container_find_elements(price_container, By.CLASS_NAME, "android.widget.FrameLayout")
-                    clickable_cards = [card for card in cards if bot._is_clickable(card)]
+                    cards = bot._container_find_elements(
+                        price_container, By.CLASS_NAME, "android.widget.FrameLayout"
+                    )
+                    clickable_cards = [
+                        card for card in cards if bot._is_clickable(card)
+                    ]
                     if not (0 <= self._config.price_index < len(clickable_cards)):
-                        logger.warning(f"备用方案: price_index={self._config.price_index} 超出 {len(clickable_cards)}")
+                        logger.warning(
+                            f"备用方案: price_index={self._config.price_index} 超出 {len(clickable_cards)}"
+                        )
                         return False
                     target_price = clickable_cards[self._config.price_index]
                 bot._click_element_center(target_price, duration=30)
@@ -594,10 +759,7 @@ class PriceSelector:
             return focus_13
 
         ranked = sorted(
-            (
-                (count, price)
-                for price, count in price_counts.items()
-            ),
+            ((count, price) for price, count in price_counts.items()),
             reverse=True,
         )
         if ranked:
@@ -698,16 +860,22 @@ class PriceSelector:
 
         # Fast path: work entirely from a pre-parsed hierarchy XML (no ADB round-trips).
         if xml_root is not None and bot._using_u2():
-            return self._get_visible_price_options_from_xml(xml_root, allow_ocr=allow_ocr)
+            return self._get_visible_price_options_from_xml(
+                xml_root, allow_ocr=allow_ocr
+            )
 
         try:
-            price_container = bot._find(By.ID, "cn.damai:id/project_detail_perform_price_flowlayout")
+            price_container = bot._find(
+                By.ID, "cn.damai:id/project_detail_perform_price_flowlayout"
+            )
         except Exception:
             return []
 
         options = []
         try:
-            cards = bot._container_find_elements(price_container, By.CLASS_NAME, "android.widget.FrameLayout")
+            cards = bot._container_find_elements(
+                price_container, By.CLASS_NAME, "android.widget.FrameLayout"
+            )
         except Exception:
             cards = []
 
@@ -724,7 +892,9 @@ class PriceSelector:
         screenshot_path = None
         if allow_ocr and cards and _MAGICK_BIN and _TESSERACT_BIN:
             try:
-                with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
+                with tempfile.NamedTemporaryFile(
+                    suffix=".png", delete=False
+                ) as tmp_file:
                     screenshot_path = tmp_file.name
                 if not bot._using_u2():
                     bot.driver.get_screenshot_as_file(screenshot_path)
@@ -742,21 +912,41 @@ class PriceSelector:
             source = "ui" if text else ""
             tag = ""
             for candidate in texts:
-                if candidate in {"可预约", "预售", "无票", "已预约", "缺货", "售罄", "已售罄", "可选"}:
+                if candidate in {
+                    "可预约",
+                    "预售",
+                    "无票",
+                    "已预约",
+                    "缺货",
+                    "售罄",
+                    "已售罄",
+                    "可选",
+                }:
                     tag = candidate
                     break
-            card_data.append({"index": index, "text": text, "tag": tag, "raw_texts": texts, "source": source})
+            card_data.append(
+                {
+                    "index": index,
+                    "text": text,
+                    "tag": tag,
+                    "raw_texts": texts,
+                    "source": source,
+                }
+            )
             if not text and screenshot_path:
                 ocr_tasks.append((index, bot._element_rect(card)))
 
         # Second pass: OCR in parallel for all cards that need it.
         ocr_results: dict[int, str] = {}
         if ocr_tasks and screenshot_path:
+
             def _run_ocr(args):
                 idx, rect = args
                 return idx, self._ocr_price_text_from_card(screenshot_path, rect)
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(ocr_tasks), 4)) as executor:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=min(len(ocr_tasks), 4)
+            ) as executor:
                 for idx, ocr_text in executor.map(_run_ocr, ocr_tasks):
                     if ocr_text:
                         ocr_results[idx] = ocr_text
@@ -768,13 +958,15 @@ class PriceSelector:
                 entry["source"] = "ocr"
             if not entry["text"] and not entry["tag"]:
                 continue
-            options.append({
-                "index": index,
-                "text": entry["text"],
-                "tag": entry["tag"],
-                "raw_texts": entry["raw_texts"],
-                "source": entry["source"] or "ui",
-            })
+            options.append(
+                {
+                    "index": index,
+                    "text": entry["text"],
+                    "tag": entry["tag"],
+                    "raw_texts": entry["raw_texts"],
+                    "source": entry["source"] or "ui",
+                }
+            )
 
         if screenshot_path and os.path.exists(screenshot_path):
             try:
@@ -791,7 +983,10 @@ class PriceSelector:
         # Locate the price container node by resource-id.
         price_container_node = None
         for node in xml_root.iter("node"):
-            if node.get("resource-id") == "cn.damai:id/project_detail_perform_price_flowlayout":
+            if (
+                node.get("resource-id")
+                == "cn.damai:id/project_detail_perform_price_flowlayout"
+            ):
                 price_container_node = node
                 break
         if price_container_node is None:
@@ -803,7 +998,8 @@ class PriceSelector:
 
         # Direct children that are clickable FrameLayouts = price cards.
         card_nodes = [
-            child for child in price_container_node
+            child
+            for child in price_container_node
             if child.get("class") == "android.widget.FrameLayout"
             and child.get("clickable") == "true"
         ]
@@ -814,13 +1010,24 @@ class PriceSelector:
         screenshot_path = None
         if allow_ocr and _MAGICK_BIN and _TESSERACT_BIN:
             try:
-                with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
+                with tempfile.NamedTemporaryFile(
+                    suffix=".png", delete=False
+                ) as tmp_file:
                     screenshot_path = tmp_file.name
                 bot.d.screenshot(screenshot_path)
             except Exception:
                 screenshot_path = None
 
-        _UNAVAILABLE = {"可预约", "预售", "无票", "已预约", "缺货", "售罄", "已售罄", "可选"}
+        _UNAVAILABLE = {
+            "可预约",
+            "预售",
+            "无票",
+            "已预约",
+            "缺货",
+            "售罄",
+            "已售罄",
+            "可选",
+        }
 
         card_data = []
         ocr_tasks = []
@@ -841,22 +1048,35 @@ class PriceSelector:
             card_bounds = bot._parse_bounds(card_node.get("bounds", ""))
             if not price_text and screenshot_path and card_bounds:
                 left, top, right, bottom = card_bounds
-                rect = {"x": left, "y": top, "width": right - left, "height": bottom - top}
+                rect = {
+                    "x": left,
+                    "y": top,
+                    "width": right - left,
+                    "height": bottom - top,
+                }
                 ocr_tasks.append((index, rect))
 
-            card_data.append({
-                "index": index, "text": price_text, "tag": tag,
-                "raw_texts": texts, "source": source,
-            })
+            card_data.append(
+                {
+                    "index": index,
+                    "text": price_text,
+                    "tag": tag,
+                    "raw_texts": texts,
+                    "source": source,
+                }
+            )
 
         # Parallel OCR for cards whose price text wasn't in the UI tree.
         ocr_results: dict[int, str] = {}
         if ocr_tasks and screenshot_path:
+
             def _run_ocr(args):
                 idx, rect = args
                 return idx, self._ocr_price_text_from_card(screenshot_path, rect)
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(ocr_tasks), 4)) as executor:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=min(len(ocr_tasks), 4)
+            ) as executor:
                 for idx, ocr_text in executor.map(_run_ocr, ocr_tasks):
                     if ocr_text:
                         ocr_results[idx] = ocr_text
@@ -869,13 +1089,15 @@ class PriceSelector:
                 entry["source"] = "ocr"
             if not entry["text"] and not entry["tag"]:
                 continue
-            options.append({
-                "index": idx,
-                "text": entry["text"],
-                "tag": entry["tag"],
-                "raw_texts": entry["raw_texts"],
-                "source": entry["source"] or "ui",
-            })
+            options.append(
+                {
+                    "index": idx,
+                    "text": entry["text"],
+                    "tag": entry["tag"],
+                    "raw_texts": entry["raw_texts"],
+                    "source": entry["source"] or "ui",
+                }
+            )
 
         if screenshot_path and os.path.exists(screenshot_path):
             try:

--- a/tests/unit/test_mobile_config.py
+++ b/tests/unit/test_mobile_config.py
@@ -1,11 +1,13 @@
 """Unit tests for mobile/config.py"""
+
 import json
-import os
 
 import pytest
 
 from mobile.config import (
     Config,
+    ConfigError,
+    PRICE_INDEX_LARGE_WARNING_THRESHOLD,
     _load_config_dict_from_path,
     _resolve_existing_config_path,
     _resolve_writable_config_path,
@@ -36,7 +38,6 @@ def _make(**overrides):
 
 
 class TestStripJsoncComments:
-
     def test_strip_single_line_comments(self):
         text = '{\n  "key": "value" // this is a comment\n}'
         result = _strip_jsonc_comments(text)
@@ -58,7 +59,6 @@ class TestStripJsoncComments:
 
 
 class TestMobileConfigInit:
-
     def test_config_init_stores_all_attributes(self):
         cfg = Config(
             keyword="周深",
@@ -86,7 +86,6 @@ class TestMobileConfigInit:
 
 
 class TestMobileConfigValidation:
-
     def test_serial_string_is_valid(self):
         cfg = Config(**_make(serial="c6c4eb67"))
         assert cfg.serial == "c6c4eb67"
@@ -161,7 +160,6 @@ class TestMobileConfigValidation:
 
 
 class TestMobileConfigNewFields:
-
     def test_sell_start_time_valid_iso(self):
         cfg = Config(**_make(sell_start_time="2026-04-01T20:00:00+08:00"))
         assert cfg.sell_start_time == "2026-04-01T20:00:00+08:00"
@@ -220,12 +218,15 @@ class TestMobileConfigNewFields:
 
 
 class TestMobileConfigLoadConfig:
-
     def test_load_config_dict_from_missing_path_raises(self, tmp_path):
-        with pytest.raises(FileNotFoundError, match=f"配置文件未找到: {tmp_path / 'missing.jsonc'}"):
+        with pytest.raises(
+            FileNotFoundError, match=f"配置文件未找到: {tmp_path / 'missing.jsonc'}"
+        ):
             _load_config_dict_from_path(tmp_path / "missing.jsonc")
 
-    def test_resolve_existing_config_path_uses_default_config(self, tmp_path, monkeypatch):
+    def test_resolve_existing_config_path_uses_default_config(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.chdir(tmp_path)
         monkeypatch.delenv("HATICKETS_CONFIG_PATH", raising=False)
         (tmp_path / "config.local.jsonc").write_text("{}", encoding="utf-8")
@@ -233,21 +234,27 @@ class TestMobileConfigLoadConfig:
 
         assert _resolve_existing_config_path() == "config.jsonc"
 
-    def test_resolve_existing_config_path_uses_env_override(self, tmp_path, monkeypatch):
+    def test_resolve_existing_config_path_uses_env_override(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "config.local.jsonc").write_text("{}", encoding="utf-8")
         monkeypatch.setenv("HATICKETS_CONFIG_PATH", "config.local.jsonc")
 
         assert _resolve_existing_config_path() == "config.local.jsonc"
 
-    def test_resolve_writable_config_path_defaults_to_shared(self, tmp_path, monkeypatch):
+    def test_resolve_writable_config_path_defaults_to_shared(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.chdir(tmp_path)
         monkeypatch.delenv("HATICKETS_CONFIG_PATH", raising=False)
         (tmp_path / "config.jsonc").write_text("{}", encoding="utf-8")
 
         assert _resolve_writable_config_path() == "config.jsonc"
 
-    def test_resolve_writable_config_path_uses_env_override(self, tmp_path, monkeypatch):
+    def test_resolve_writable_config_path_uses_env_override(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("HATICKETS_CONFIG_PATH", "config.local.jsonc")
 
@@ -255,7 +262,11 @@ class TestMobileConfigLoadConfig:
 
     def test_load_config_success(self, mock_mobile_config_file, monkeypatch):
         mock_mobile_config_file()
-        monkeypatch.chdir(mock_mobile_config_file.__wrapped__ if hasattr(mock_mobile_config_file, '__wrapped__') else mock_mobile_config_file().parent)
+        monkeypatch.chdir(
+            mock_mobile_config_file.__wrapped__
+            if hasattr(mock_mobile_config_file, "__wrapped__")
+            else mock_mobile_config_file().parent
+        )
         # Re-create since chdir changed
         config_data = {
             "app_package": "cn.damai",
@@ -294,7 +305,9 @@ class TestMobileConfigLoadConfig:
             "price_index": 0,
             "if_commit_order": False,
         }
-        (tmp_path / "config.jsonc").write_text(json.dumps(config_data), encoding="utf-8")
+        (tmp_path / "config.jsonc").write_text(
+            json.dumps(config_data), encoding="utf-8"
+        )
 
         cfg = Config.load_config()
         assert cfg.serial == "abc123"
@@ -327,7 +340,9 @@ class TestMobileConfigLoadConfig:
             "price_index": 0,
             "if_commit_order": False,
         }
-        (tmp_path / "config.jsonc").write_text(json.dumps(config_data), encoding="utf-8")
+        (tmp_path / "config.jsonc").write_text(
+            json.dumps(config_data), encoding="utf-8"
+        )
 
         with pytest.raises(KeyError, match="keyword"):
             Config.load_config()
@@ -420,7 +435,9 @@ class TestMobileConfigLoadConfig:
             "probe_only": True,
             "rush_mode": True,
         }
-        (tmp_path / "config.jsonc").write_text(json.dumps(config_data), encoding="utf-8")
+        (tmp_path / "config.jsonc").write_text(
+            json.dumps(config_data), encoding="utf-8"
+        )
 
         cfg = Config.load_config()
         assert cfg.rush_mode is True
@@ -438,7 +455,9 @@ class TestMobileConfigLoadConfig:
             "probe_only": True,
             "wait_cta_ready_timeout_ms": 45000,
         }
-        (tmp_path / "config.jsonc").write_text(json.dumps(config_data), encoding="utf-8")
+        (tmp_path / "config.jsonc").write_text(
+            json.dumps(config_data), encoding="utf-8"
+        )
 
         cfg = Config.load_config()
         assert cfg.wait_cta_ready_timeout_ms == 45000
@@ -454,20 +473,32 @@ class TestMobileConfigLoadConfig:
             "price_index": 0,
             "if_commit_order": False,
         }
-        (tmp_path / "config.jsonc").write_text(json.dumps({
-            **shared_fields,
-            "keyword": "from-default",
-        }), encoding="utf-8")
-        (tmp_path / "config.local.jsonc").write_text(json.dumps({
-            **shared_fields,
-            "keyword": "from-local",
-        }), encoding="utf-8")
+        (tmp_path / "config.jsonc").write_text(
+            json.dumps(
+                {
+                    **shared_fields,
+                    "keyword": "from-default",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (tmp_path / "config.local.jsonc").write_text(
+            json.dumps(
+                {
+                    **shared_fields,
+                    "keyword": "from-local",
+                }
+            ),
+            encoding="utf-8",
+        )
 
         cfg = Config.load_config()
 
         assert cfg.keyword == "from-default"
 
-    def test_load_config_uses_env_override_for_config_local_jsonc(self, tmp_path, monkeypatch):
+    def test_load_config_uses_env_override_for_config_local_jsonc(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.chdir(tmp_path)
         shared_fields = {
             "users": ["A"],
@@ -477,14 +508,24 @@ class TestMobileConfigLoadConfig:
             "price_index": 0,
             "if_commit_order": False,
         }
-        (tmp_path / "config.jsonc").write_text(json.dumps({
-            **shared_fields,
-            "keyword": "from-default",
-        }), encoding="utf-8")
-        (tmp_path / "config.local.jsonc").write_text(json.dumps({
-            **shared_fields,
-            "keyword": "from-local",
-        }), encoding="utf-8")
+        (tmp_path / "config.jsonc").write_text(
+            json.dumps(
+                {
+                    **shared_fields,
+                    "keyword": "from-default",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (tmp_path / "config.local.jsonc").write_text(
+            json.dumps(
+                {
+                    **shared_fields,
+                    "keyword": "from-local",
+                }
+            ),
+            encoding="utf-8",
+        )
         monkeypatch.setenv("HATICKETS_CONFIG_PATH", "config.local.jsonc")
 
         cfg = Config.load_config()
@@ -509,7 +550,9 @@ class TestMobileConfigLoadConfig:
         assert (tmp_path / "config.jsonc").exists()
         assert load_config_dict() == source
 
-    def test_save_config_dict_uses_env_override_for_config_local_jsonc(self, tmp_path, monkeypatch):
+    def test_save_config_dict_uses_env_override_for_config_local_jsonc(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.chdir(tmp_path)
         source = {
             "keyword": "test",
@@ -531,6 +574,7 @@ class TestMobileConfigLoadConfig:
 # ---------------------------------------------------------------------------
 # Uncovered validation branches
 # ---------------------------------------------------------------------------
+
 
 class TestUncoveredBranches:
     def test_keyword_none_raises(self):
@@ -558,6 +602,62 @@ class TestUncoveredBranches:
             "probe_only": False,
         }
         import json
+
         (tmp_path / "config.jsonc").write_text(json.dumps(source))
         with pytest.raises(KeyError, match="keyword"):
             Config.load_config()
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — load_config price_index range validation (P1 #31)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfigPriceIndexRange:
+    def _config_dict(self, price_index):
+        return {
+            "keyword": "周深",
+            "users": ["A"],
+            "city": "深圳",
+            "date": "01.01",
+            "price": "100元",
+            "price_index": price_index,
+            "if_commit_order": False,
+        }
+
+    def test_negative_price_index_raises_config_error(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.jsonc").write_text(
+            json.dumps(self._config_dict(-1)), encoding="utf-8"
+        )
+        with pytest.raises(ConfigError, match="price_index 不能为负数"):
+            Config.load_config()
+
+    def test_config_error_is_value_error_subclass(self):
+        # ConfigError keeps backwards-compat with broad "except ValueError"
+        assert issubclass(ConfigError, ValueError)
+
+    def test_large_price_index_logs_warning(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.chdir(tmp_path)
+        oversized = PRICE_INDEX_LARGE_WARNING_THRESHOLD + 1
+        (tmp_path / "config.jsonc").write_text(
+            json.dumps(self._config_dict(oversized)), encoding="utf-8"
+        )
+        with caplog.at_level("WARNING", logger="mobile.config"):
+            cfg = Config.load_config()
+        assert cfg.price_index == oversized
+        assert any(
+            "price_index" in rec.message and "异常大" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_threshold_value_does_not_warn(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.jsonc").write_text(
+            json.dumps(self._config_dict(PRICE_INDEX_LARGE_WARNING_THRESHOLD)),
+            encoding="utf-8",
+        )
+        with caplog.at_level("WARNING", logger="mobile.config"):
+            cfg = Config.load_config()
+        assert cfg.price_index == PRICE_INDEX_LARGE_WARNING_THRESHOLD
+        assert not any("异常大" in rec.message for rec in caplog.records)

--- a/tests/unit/test_mobile_damai_app.py
+++ b/tests/unit/test_mobile_damai_app.py
@@ -392,7 +392,9 @@ class TestBatchClick:
         """Failed clicks log a warning but processing continues."""
         elements = [("by1", "v1"), ("by2", "v2")]
         with caplog.at_level("WARNING", logger="mobile.ui_primitives"):
-            with patch.object(bot, "ultra_fast_click", side_effect=[False, True]) as ufc:
+            with patch.object(
+                bot, "ultra_fast_click", side_effect=[False, True]
+            ) as ufc:
                 with patch("mobile.ui_primitives.time"):
                     bot.batch_click(elements, delay=0.1)
 
@@ -423,7 +425,9 @@ class TestUltraBatchClick:
         el1 = _make_mock_element(x=10, y=20, width=100, height=50)
 
         with caplog.at_level("DEBUG", logger="mobile.ui_primitives"):
-            with patch.object( bot, "_wait_for_element", side_effect=[el1, TimeoutException("timeout")] ):
+            with patch.object(
+                bot, "_wait_for_element", side_effect=[el1, TimeoutException("timeout")]
+            ):
                 with patch("mobile.ui_primitives.time"):
                     bot.ultra_batch_click([(By.ID, "v1"), (By.ID, "v2")], timeout=2)
 
@@ -517,9 +521,18 @@ class TestAutoNavigation:
             assert bot._current_page_matches_target({"state": "sku_page"}) is False
 
     def test_exit_non_target_event_context_backs_out_until_search_page(self, bot):
-        with patch.object( bot, "_current_page_matches_target", side_effect=[False, False] ):
+        with patch.object(
+            bot, "_current_page_matches_target", side_effect=[False, False]
+        ):
             with patch.object(bot, "dismiss_startup_popups"):
-                with patch.object( bot, "probe_current_page", side_effect=[ {"state": "detail_page"}, {"state": "search_page"}, ], ):
+                with patch.object(
+                    bot,
+                    "probe_current_page",
+                    side_effect=[
+                        {"state": "detail_page"},
+                        {"state": "search_page"},
+                    ],
+                ):
                     result = bot._exit_non_target_event_context({"state": "sku_page"})
 
         assert result["state"] == "search_page"
@@ -528,14 +541,38 @@ class TestAutoNavigation:
     def test_discover_target_event_exits_wrong_sku_page_before_search(self, bot):
         bot.config.keyword = "余佳运 演唱会"
 
-        with patch.object( bot, "_recover_to_navigation_start", return_value={"state": "sku_page"} ):
-            with patch.object( bot, "_current_page_matches_target", side_effect=[False, False] ):
-                with patch.object( bot, "_exit_non_target_event_context", return_value={"state": "search_page"}, ) as exit_context:
-                    with patch.object( bot, "_submit_search_keyword", return_value=True ) as submit_keyword:
-                        with patch.object( bot, "_open_target_from_search_results", return_value={ "opened": True, "search_results": [{"score": 80, "title": "余佳运演唱会"}], }, ):
-                            with patch.object( bot, "probe_current_page", return_value={"state": "detail_page"} ):
+        with patch.object(
+            bot, "_recover_to_navigation_start", return_value={"state": "sku_page"}
+        ):
+            with patch.object(
+                bot, "_current_page_matches_target", side_effect=[False, False]
+            ):
+                with patch.object(
+                    bot,
+                    "_exit_non_target_event_context",
+                    return_value={"state": "search_page"},
+                ) as exit_context:
+                    with patch.object(
+                        bot, "_submit_search_keyword", return_value=True
+                    ) as submit_keyword:
+                        with patch.object(
+                            bot,
+                            "_open_target_from_search_results",
+                            return_value={
+                                "opened": True,
+                                "search_results": [
+                                    {"score": 80, "title": "余佳运演唱会"}
+                                ],
+                            },
+                        ):
+                            with patch.object(
+                                bot,
+                                "probe_current_page",
+                                return_value={"state": "detail_page"},
+                            ):
                                 result = bot.discover_target_event(
-                                    ["余佳运 演唱会"], initial_probe={"state": "sku_page"}
+                                    ["余佳运 演唱会"],
+                                    initial_probe={"state": "sku_page"},
                                 )
 
         assert result is not None
@@ -543,9 +580,17 @@ class TestAutoNavigation:
         submit_keyword.assert_called_once()
 
     def test_navigate_to_target_event_from_search_page(self, bot):
-        with patch.object( bot, "_recover_to_navigation_start", return_value={"state": "search_page"}, ):
-            with patch.object( bot, "_submit_search_keyword", return_value=True ) as submit_keyword:
-                with patch.object( bot, "_open_target_from_search_results", return_value=True ) as open_target:
+        with patch.object(
+            bot,
+            "_recover_to_navigation_start",
+            return_value={"state": "search_page"},
+        ):
+            with patch.object(
+                bot, "_submit_search_keyword", return_value=True
+            ) as submit_keyword:
+                with patch.object(
+                    bot, "_open_target_from_search_results", return_value=True
+                ) as open_target:
                     result = bot.navigate_to_target_event({"state": "unknown"})
 
         assert result is True
@@ -554,7 +599,9 @@ class TestAutoNavigation:
 
     def test_recover_to_navigation_start_handles_back_key_failure(self, bot):
         with patch.object(bot, "_press_keycode_safe", return_value=False):
-            with patch.object(bot, "probe_current_page", return_value={"state": "unknown"}):
+            with patch.object(
+                bot, "probe_current_page", return_value={"state": "unknown"}
+            ):
                 with patch.object(bot.d, "app_start") as app_start:
                     with patch("mobile.damai_app.time.sleep"):
                         result = bot._recover_to_navigation_start({"state": "unknown"})
@@ -565,9 +612,15 @@ class TestAutoNavigation:
     def test_fast_retry_does_not_submit_when_commit_disabled(self, bot):
         bot.config.if_commit_order = False
 
-        with patch.object( bot, "probe_current_page", return_value={"state": "order_confirm_page"} ):
-            with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
-                with patch.object( bot, "smart_wait_for_element", return_value=True ) as wait_for_element:
+        with patch.object(
+            bot, "probe_current_page", return_value={"state": "order_confirm_page"}
+        ):
+            with patch.object(
+                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
+            ):
+                with patch.object(
+                    bot, "smart_wait_for_element", return_value=True
+                ) as wait_for_element:
                     with patch.object(bot, "smart_wait_and_click") as smart_click:
                         result = bot._fast_retry_from_current_state()
 
@@ -577,7 +630,9 @@ class TestAutoNavigation:
 
     def test_run_with_retry_stops_on_terminal_failure(self, bot):
         with patch("mobile.damai_app.time.sleep"):
-            with patch.object( bot, "run_ticket_grabbing", side_effect=self._mark_terminal_failure(bot) ):
+            with patch.object(
+                bot, "run_ticket_grabbing", side_effect=self._mark_terminal_failure(bot)
+            ):
                 with patch.object(bot, "_fast_retry_from_current_state") as fast_retry:
                     with patch.object(bot, "_setup_driver") as setup_driver:
                         result = bot.run_with_retry(max_retries=3)
@@ -606,10 +661,35 @@ class TestRunTicketGrabbing:
 
         with patch.object(bot, "dismiss_startup_popups"):
             with patch.object(bot, "check_session_valid", return_value=True):
-                with patch.object( bot, "navigate_to_target_event", return_value=True ) as navigate:
-                    with patch.object( bot, "probe_current_page", side_effect=[ { "state": "homepage", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, "reservation_mode": False, }, { "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, "reservation_mode": False, }, ], ):
+                with patch.object(
+                    bot, "navigate_to_target_event", return_value=True
+                ) as navigate:
+                    with patch.object(
+                        bot,
+                        "probe_current_page",
+                        side_effect=[
+                            {
+                                "state": "homepage",
+                                "purchase_button": False,
+                                "price_container": False,
+                                "quantity_picker": False,
+                                "submit_button": False,
+                                "reservation_mode": False,
+                            },
+                            {
+                                "state": "detail_page",
+                                "purchase_button": True,
+                                "price_container": True,
+                                "quantity_picker": False,
+                                "submit_button": False,
+                                "reservation_mode": False,
+                            },
+                        ],
+                    ):
                         with patch("mobile.damai_app.time") as mock_time:
-                            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.3)
+                            mock_time.time.side_effect = _make_time_side_effect(
+                                0.0, 0.3
+                            )
                             result = bot.run_ticket_grabbing()
 
         assert result is True
@@ -620,7 +700,17 @@ class TestRunTicketGrabbing:
         bot.config.auto_navigate = False
 
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "homepage", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "homepage",
+                    "purchase_button": False,
+                    "price_container": False,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "smart_wait_and_click") as smart_click:
                     with patch("mobile.damai_app.time") as mock_time:
                         mock_time.time.return_value = 0.0
@@ -634,7 +724,17 @@ class TestRunTicketGrabbing:
         bot.config.probe_only = True
 
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": True,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "smart_wait_and_click") as smart_click:
                     with patch("mobile.damai_app.time") as mock_time:
                         mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
@@ -649,7 +749,17 @@ class TestRunTicketGrabbing:
 
         with caplog.at_level("INFO", logger="mobile.damai_app"):
             with patch.object(bot, "dismiss_startup_popups"):
-                with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(
+                    bot,
+                    "probe_current_page",
+                    return_value={
+                        "state": "detail_page",
+                        "purchase_button": True,
+                        "price_container": True,
+                        "quantity_picker": False,
+                        "submit_button": False,
+                    },
+                ):
                     with patch("mobile.damai_app.time") as mock_time:
                         mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
                         result = bot.run_ticket_grabbing()
@@ -665,7 +775,17 @@ class TestRunTicketGrabbing:
         bot.config.probe_only = True
 
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": False,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch("mobile.damai_app.time") as mock_time:
                     mock_time.time.return_value = 0.0
                     result = bot.run_ticket_grabbing()
@@ -677,7 +797,17 @@ class TestRunTicketGrabbing:
         bot.config.probe_only = True
 
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "sku_page",
+                    "purchase_button": False,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "smart_wait_and_click") as smart_click:
                     with patch("mobile.damai_app.time") as mock_time:
                         mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
@@ -689,22 +819,56 @@ class TestRunTicketGrabbing:
     def test_run_ticket_grabbing_success(self, bot):
         """All phases succeed, returns True."""
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": True,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "wait_for_sale_start"):
-                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
-                        with patch.object(bot, "_wait_for_submit_ready", return_value=True):
-                            with patch.object(bot, "smart_wait_and_click", return_value=True):
-                                with patch.object(bot, "ultra_fast_click", return_value=True):
+                    with patch.object(
+                        bot,
+                        "_enter_purchase_flow_from_detail_page",
+                        return_value={
+                            "state": "sku_page",
+                            "price_container": True,
+                            "reservation_mode": False,
+                        },
+                    ):
+                        with patch.object(
+                            bot, "_wait_for_submit_ready", return_value=True
+                        ):
+                            with patch.object(
+                                bot, "smart_wait_and_click", return_value=True
+                            ):
+                                with patch.object(
+                                    bot, "ultra_fast_click", return_value=True
+                                ):
                                     with patch.object(bot, "ultra_batch_click"):
-                                        with patch.object(bot, "_submit_order_fast", return_value="success"):
-                                            with patch("mobile.damai_app.time") as mock_time:
+                                        with patch.object(
+                                            bot,
+                                            "_submit_order_fast",
+                                            return_value="success",
+                                        ):
+                                            with patch(
+                                                "mobile.damai_app.time"
+                                            ) as mock_time:
                                                 # Provide enough time.time() values for the confirm-retry loop
-                                                mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
+                                                mock_time.time.side_effect = (
+                                                    _make_time_side_effect(0.0, 1.5)
+                                                )
                                                 # Mock find_element for price container + target_price
                                                 mock_price_container = Mock()
                                                 mock_target = _make_mock_element()
                                                 mock_price_container.find_element.return_value = mock_target
-                                                bot.driver.find_element.return_value = mock_price_container
+                                                bot.driver.find_element.return_value = (
+                                                    mock_price_container
+                                                )
                                                 bot.driver.find_elements.return_value = []  # no quantity layout
 
                                                 result = bot.run_ticket_grabbing()
@@ -718,17 +882,53 @@ class TestRunTicketGrabbing:
         bot.config.if_commit_order = False
 
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": True,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "wait_for_sale_start"):
-                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, "price_coords": (240, 1560), "buy_button_coords": (320, 1880), }, ) as enter_purchase_flow:
-                        with patch.object( bot, "_select_price_option", return_value=True ) as select_price:
-                            with patch.object(bot, "_wait_for_submit_ready", return_value=True):
-                                with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
-                                    with patch.object(bot, "_burst_click_coordinates") as burst_click_coords:
-                                        with patch.object(bot, "ultra_fast_click", return_value=True):
+                    with patch.object(
+                        bot,
+                        "_enter_purchase_flow_from_detail_page",
+                        return_value={
+                            "state": "sku_page",
+                            "price_container": True,
+                            "reservation_mode": False,
+                            "price_coords": (240, 1560),
+                            "buy_button_coords": (320, 1880),
+                        },
+                    ) as enter_purchase_flow:
+                        with patch.object(
+                            bot, "_select_price_option", return_value=True
+                        ) as select_price:
+                            with patch.object(
+                                bot, "_wait_for_submit_ready", return_value=True
+                            ):
+                                with patch.object(
+                                    bot,
+                                    "_ensure_attendees_selected_on_confirm_page",
+                                    return_value=True,
+                                ):
+                                    with patch.object(
+                                        bot, "_burst_click_coordinates"
+                                    ) as burst_click_coords:
+                                        with patch.object(
+                                            bot, "ultra_fast_click", return_value=True
+                                        ):
                                             with patch.object(bot, "ultra_batch_click"):
-                                                with patch("mobile.damai_app.time") as mock_time:
-                                                    mock_time.time.side_effect = _make_time_side_effect(0.0, 0.9)
+                                                with patch(
+                                                    "mobile.damai_app.time"
+                                                ) as mock_time:
+                                                    mock_time.time.side_effect = (
+                                                        _make_time_side_effect(0.0, 0.9)
+                                                    )
                                                     mock_price_container = Mock()
                                                     mock_target = _make_mock_element()
                                                     mock_price_container.find_element.return_value = mock_target
@@ -749,20 +949,54 @@ class TestRunTicketGrabbing:
         bot.config.if_commit_order = False
 
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": True,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "wait_for_sale_start"):
-                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
-                        with patch.object( bot, "_wait_for_submit_ready", return_value=True ) as wait_submit_ready:
-                            with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
-                                with patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click:
-                                    with patch.object(bot, "ultra_fast_click", return_value=True):
+                    with patch.object(
+                        bot,
+                        "_enter_purchase_flow_from_detail_page",
+                        return_value={
+                            "state": "sku_page",
+                            "price_container": True,
+                            "reservation_mode": False,
+                        },
+                    ):
+                        with patch.object(
+                            bot, "_wait_for_submit_ready", return_value=True
+                        ) as wait_submit_ready:
+                            with patch.object(
+                                bot,
+                                "_ensure_attendees_selected_on_confirm_page",
+                                return_value=True,
+                            ):
+                                with patch.object(
+                                    bot, "smart_wait_and_click", return_value=True
+                                ) as smart_click:
+                                    with patch.object(
+                                        bot, "ultra_fast_click", return_value=True
+                                    ):
                                         with patch.object(bot, "ultra_batch_click"):
-                                            with patch("mobile.damai_app.time") as mock_time:
-                                                mock_time.time.side_effect = _make_time_side_effect(0.0, 1.2)
+                                            with patch(
+                                                "mobile.damai_app.time"
+                                            ) as mock_time:
+                                                mock_time.time.side_effect = (
+                                                    _make_time_side_effect(0.0, 1.2)
+                                                )
                                                 mock_price_container = Mock()
                                                 mock_target = _make_mock_element()
                                                 mock_price_container.find_element.return_value = mock_target
-                                                bot.driver.find_element.return_value = mock_price_container
+                                                bot.driver.find_element.return_value = (
+                                                    mock_price_container
+                                                )
                                                 bot.driver.find_elements.return_value = []
 
                                                 result = bot.run_ticket_grabbing()
@@ -776,19 +1010,51 @@ class TestRunTicketGrabbing:
 
         with caplog.at_level("INFO", logger="mobile.damai_app"):
             with patch.object(bot, "dismiss_startup_popups"):
-                with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(
+                    bot,
+                    "probe_current_page",
+                    return_value={
+                        "state": "detail_page",
+                        "purchase_button": True,
+                        "price_container": True,
+                        "quantity_picker": False,
+                        "submit_button": False,
+                    },
+                ):
                     with patch.object(bot, "wait_for_sale_start"):
-                        with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
-                            with patch.object(bot, "_wait_for_submit_ready", return_value=True):
-                                with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
-                                    with patch.object(bot, "ultra_fast_click", return_value=True):
+                        with patch.object(
+                            bot,
+                            "_enter_purchase_flow_from_detail_page",
+                            return_value={
+                                "state": "sku_page",
+                                "price_container": True,
+                                "reservation_mode": False,
+                            },
+                        ):
+                            with patch.object(
+                                bot, "_wait_for_submit_ready", return_value=True
+                            ):
+                                with patch.object(
+                                    bot,
+                                    "_ensure_attendees_selected_on_confirm_page",
+                                    return_value=True,
+                                ):
+                                    with patch.object(
+                                        bot, "ultra_fast_click", return_value=True
+                                    ):
                                         with patch.object(bot, "ultra_batch_click"):
-                                            with patch("mobile.damai_app.time") as mock_time:
-                                                mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
+                                            with patch(
+                                                "mobile.damai_app.time"
+                                            ) as mock_time:
+                                                mock_time.time.side_effect = (
+                                                    _make_time_side_effect(0.0, 0.8)
+                                                )
                                                 mock_price_container = Mock()
                                                 mock_target = _make_mock_element()
                                                 mock_price_container.find_element.return_value = mock_target
-                                                bot.driver.find_element.return_value = mock_price_container
+                                                bot.driver.find_element.return_value = (
+                                                    mock_price_container
+                                                )
                                                 bot.driver.find_elements.return_value = []
 
                                                 result = bot.run_ticket_grabbing()
@@ -804,19 +1070,45 @@ class TestRunTicketGrabbing:
         bot.config.if_commit_order = False
 
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "sku_page",
+                    "purchase_button": False,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "wait_for_sale_start"):
-                    with patch.object( bot, "_wait_for_submit_ready", return_value=True ) as wait_submit_ready:
-                        with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
-                            with patch.object(bot, "smart_wait_and_click") as smart_click:
-                                with patch.object(bot, "ultra_fast_click", return_value=True):
+                    with patch.object(
+                        bot, "_wait_for_submit_ready", return_value=True
+                    ) as wait_submit_ready:
+                        with patch.object(
+                            bot,
+                            "_ensure_attendees_selected_on_confirm_page",
+                            return_value=True,
+                        ):
+                            with patch.object(
+                                bot, "smart_wait_and_click"
+                            ) as smart_click:
+                                with patch.object(
+                                    bot, "ultra_fast_click", return_value=True
+                                ):
                                     with patch.object(bot, "ultra_batch_click"):
-                                        with patch("mobile.damai_app.time") as mock_time:
-                                            mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
+                                        with patch(
+                                            "mobile.damai_app.time"
+                                        ) as mock_time:
+                                            mock_time.time.side_effect = (
+                                                _make_time_side_effect(0.0, 0.8)
+                                            )
                                             mock_price_container = Mock()
                                             mock_target = _make_mock_element()
                                             mock_price_container.find_element.return_value = mock_target
-                                            bot.driver.find_element.return_value = mock_price_container
+                                            bot.driver.find_element.return_value = (
+                                                mock_price_container
+                                            )
                                             bot.driver.find_elements.return_value = []
 
                                             result = bot.run_ticket_grabbing()
@@ -833,7 +1125,36 @@ class TestRunTicketGrabbing:
 
         with caplog.at_level("WARNING", logger="mobile.damai_app"):
             with patch.object(bot, "dismiss_startup_popups"):
-                with patch.object( bot, "probe_current_page", side_effect=[ { "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, "reservation_mode": True, }, { "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, "reservation_mode": True, }, { "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, "reservation_mode": True, }, ], ):
+                with patch.object(
+                    bot,
+                    "probe_current_page",
+                    side_effect=[
+                        {
+                            "state": "sku_page",
+                            "purchase_button": False,
+                            "price_container": True,
+                            "quantity_picker": False,
+                            "submit_button": False,
+                            "reservation_mode": True,
+                        },
+                        {
+                            "state": "sku_page",
+                            "purchase_button": False,
+                            "price_container": True,
+                            "quantity_picker": False,
+                            "submit_button": False,
+                            "reservation_mode": True,
+                        },
+                        {
+                            "state": "sku_page",
+                            "purchase_button": False,
+                            "price_container": True,
+                            "quantity_picker": False,
+                            "submit_button": False,
+                            "reservation_mode": True,
+                        },
+                    ],
+                ):
                     with patch.object(bot, "wait_for_sale_start"):
                         with patch.object(bot, "ultra_fast_click") as fast_click:
                             with patch("mobile.damai_app.time") as mock_time:
@@ -858,19 +1179,51 @@ class TestRunTicketGrabbing:
 
         with caplog.at_level("WARNING", logger="mobile.damai_app"):
             with patch.object(bot, "dismiss_startup_popups"):
-                with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(
+                    bot,
+                    "probe_current_page",
+                    return_value={
+                        "state": "detail_page",
+                        "purchase_button": True,
+                        "price_container": True,
+                        "quantity_picker": False,
+                        "submit_button": False,
+                    },
+                ):
                     with patch.object(bot, "wait_for_sale_start"):
-                        with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
-                            with patch.object(bot, "_wait_for_submit_ready", return_value=False):
-                                with patch.object(bot, "smart_wait_and_click", return_value=True):
-                                    with patch.object(bot, "ultra_fast_click", return_value=True):
-                                        with patch.object(bot, "ultra_batch_click", return_value=0):
-                                            with patch("mobile.damai_app.time") as mock_time:
-                                                mock_time.time.side_effect = _make_time_monotonic(0.0, 2.0)
+                        with patch.object(
+                            bot,
+                            "_enter_purchase_flow_from_detail_page",
+                            return_value={
+                                "state": "sku_page",
+                                "price_container": True,
+                                "reservation_mode": False,
+                            },
+                        ):
+                            with patch.object(
+                                bot, "_wait_for_submit_ready", return_value=False
+                            ):
+                                with patch.object(
+                                    bot, "smart_wait_and_click", return_value=True
+                                ):
+                                    with patch.object(
+                                        bot, "ultra_fast_click", return_value=True
+                                    ):
+                                        with patch.object(
+                                            bot, "ultra_batch_click", return_value=0
+                                        ):
+                                            with patch(
+                                                "mobile.damai_app.time"
+                                            ) as mock_time:
+                                                mock_time.time.side_effect = (
+                                                    _make_time_monotonic(0.0, 2.0)
+                                                )
                                                 mock_price_container = Mock()
                                                 mock_target = _make_mock_element()
                                                 mock_price_container.find_element.return_value = mock_target
-                                                bot.driver.find_element.return_value = mock_price_container
+                                                bot.driver.find_element.return_value = (
+                                                    mock_price_container
+                                                )
                                                 bot.driver.find_elements.return_value = []
 
                                                 result = bot.run_ticket_grabbing()
@@ -881,9 +1234,21 @@ class TestRunTicketGrabbing:
     def test_run_ticket_grabbing_city_fail(self, bot):
         """City selection fails, returns False immediately."""
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": True,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "wait_for_sale_start"):
-                    with patch.object(bot, "_select_city_from_detail_page", return_value=False):
+                    with patch.object(
+                        bot, "_select_city_from_detail_page", return_value=False
+                    ):
                         with patch("mobile.damai_app.time") as mock_time:
                             mock_time.time.return_value = 0.0
                             result = bot.run_ticket_grabbing()
@@ -893,9 +1258,21 @@ class TestRunTicketGrabbing:
     def test_run_ticket_grabbing_book_fail(self, bot):
         """Booking button fails, returns False."""
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": True,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "wait_for_sale_start"):
-                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value=None ):
+                    with patch.object(
+                        bot, "_enter_purchase_flow_from_detail_page", return_value=None
+                    ):
                         with patch.object(bot, "ultra_batch_click"):
                             with patch("mobile.damai_app.time") as mock_time:
                                 mock_time.time.return_value = 0.0
@@ -906,9 +1283,21 @@ class TestRunTicketGrabbing:
     def test_run_ticket_grabbing_exception_returns_false(self, bot):
         """Unexpected exception in flow returns False."""
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": True,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "wait_for_sale_start"):
-                    with patch.object(bot, "smart_wait_and_click", side_effect=RuntimeError("boom")):
+                    with patch.object(
+                        bot, "smart_wait_and_click", side_effect=RuntimeError("boom")
+                    ):
                         with patch("mobile.damai_app.time") as mock_time:
                             mock_time.time.return_value = 0.0
                             result = bot.run_ticket_grabbing()
@@ -920,20 +1309,54 @@ class TestRunTicketGrabbing:
     ):
         """Submit timeout should fail closed to avoid false success and duplicate submit."""
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": True,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "wait_for_sale_start"):
-                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
-                        with patch.object(bot, "_wait_for_submit_ready", return_value=True):
-                            with patch.object(bot, "smart_wait_and_click", return_value=True):
-                                with patch.object(bot, "ultra_fast_click", return_value=True):
+                    with patch.object(
+                        bot,
+                        "_enter_purchase_flow_from_detail_page",
+                        return_value={
+                            "state": "sku_page",
+                            "price_container": True,
+                            "reservation_mode": False,
+                        },
+                    ):
+                        with patch.object(
+                            bot, "_wait_for_submit_ready", return_value=True
+                        ):
+                            with patch.object(
+                                bot, "smart_wait_and_click", return_value=True
+                            ):
+                                with patch.object(
+                                    bot, "ultra_fast_click", return_value=True
+                                ):
                                     with patch.object(bot, "ultra_batch_click"):
-                                        with patch.object( bot, "_submit_order_fast", return_value="timeout" ) as submit_fast:
-                                            with patch("mobile.damai_app.time") as mock_time:
-                                                mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
+                                        with patch.object(
+                                            bot,
+                                            "_submit_order_fast",
+                                            return_value="timeout",
+                                        ) as submit_fast:
+                                            with patch(
+                                                "mobile.damai_app.time"
+                                            ) as mock_time:
+                                                mock_time.time.side_effect = (
+                                                    _make_time_side_effect(0.0, 1.0)
+                                                )
                                                 mock_price_container = Mock()
                                                 mock_target = _make_mock_element()
                                                 mock_price_container.find_element.return_value = mock_target
-                                                bot.driver.find_element.return_value = mock_price_container
+                                                bot.driver.find_element.return_value = (
+                                                    mock_price_container
+                                                )
                                                 bot.driver.find_elements.return_value = []
 
                                                 result = bot.run_ticket_grabbing()
@@ -947,17 +1370,53 @@ class TestRunTicketGrabbing:
     ):
         """Existing unpaid order means submit flow already succeeded and only payment is pending."""
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": True,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "wait_for_sale_start"):
-                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
-                        with patch.object(bot, "_wait_for_submit_ready", return_value=True):
-                            with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
-                                with patch.object(bot, "smart_wait_and_click", return_value=True):
-                                    with patch.object(bot, "ultra_fast_click", return_value=True):
+                    with patch.object(
+                        bot,
+                        "_enter_purchase_flow_from_detail_page",
+                        return_value={
+                            "state": "sku_page",
+                            "price_container": True,
+                            "reservation_mode": False,
+                        },
+                    ):
+                        with patch.object(
+                            bot, "_wait_for_submit_ready", return_value=True
+                        ):
+                            with patch.object(
+                                bot,
+                                "_ensure_attendees_selected_on_confirm_page",
+                                return_value=True,
+                            ):
+                                with patch.object(
+                                    bot, "smart_wait_and_click", return_value=True
+                                ):
+                                    with patch.object(
+                                        bot, "ultra_fast_click", return_value=True
+                                    ):
                                         with patch.object(bot, "ultra_batch_click"):
-                                            with patch.object(bot, "_submit_order_fast", return_value="existing_order"):
-                                                with patch("mobile.damai_app.time") as mock_time:
-                                                    mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
+                                            with patch.object(
+                                                bot,
+                                                "_submit_order_fast",
+                                                return_value="existing_order",
+                                            ):
+                                                with patch(
+                                                    "mobile.damai_app.time"
+                                                ) as mock_time:
+                                                    mock_time.time.side_effect = (
+                                                        _make_time_side_effect(0.0, 1.0)
+                                                    )
                                                     mock_price_container = Mock()
                                                     mock_target = _make_mock_element()
                                                     mock_price_container.find_element.return_value = mock_target
@@ -975,7 +1434,19 @@ class TestRunTicketGrabbing:
     ):
         with patch.object(bot, "dismiss_startup_popups"):
             with patch.object(bot, "check_session_valid", return_value=True):
-                with patch.object( bot, "probe_current_page", return_value={ "state": "pending_order_dialog", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, "reservation_mode": False, "pending_order_dialog": True, }, ):
+                with patch.object(
+                    bot,
+                    "probe_current_page",
+                    return_value={
+                        "state": "pending_order_dialog",
+                        "purchase_button": False,
+                        "price_container": False,
+                        "quantity_picker": False,
+                        "submit_button": False,
+                        "reservation_mode": False,
+                        "pending_order_dialog": True,
+                    },
+                ):
                     result = bot.run_ticket_grabbing()
 
         assert result is True
@@ -999,18 +1470,52 @@ class TestRunTicketGrabbing:
 
         with patch.object(bot, "dismiss_startup_popups"):
             with patch.object(bot, "check_session_valid", return_value=True):
-                with patch.object( bot, "probe_current_page", return_value=detail_probe ) as probe_page:
-                    with patch.object(bot, "_prepare_detail_page_hot_path") as prepare_detail:
+                with patch.object(
+                    bot, "probe_current_page", return_value=detail_probe
+                ) as probe_page:
+                    with patch.object(
+                        bot, "_prepare_detail_page_hot_path"
+                    ) as prepare_detail:
                         with patch.object(bot, "wait_for_sale_start"):
-                            with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
-                                with patch.object(bot, "_select_price_option", return_value=True):
-                                    with patch.object(bot, "_wait_for_submit_ready", return_value=True):
-                                        with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
-                                            with patch.object(bot, "_submit_order_fast", return_value="success"):
-                                                with patch.object(bot, "ultra_fast_click", return_value=True):
-                                                    with patch.object(bot, "ultra_batch_click"):
-                                                        with patch("mobile.damai_app.time") as mock_time:
-                                                            mock_time.time.side_effect = _make_time_side_effect(0.0, 1.0)
+                            with patch.object(
+                                bot,
+                                "_enter_purchase_flow_from_detail_page",
+                                return_value={
+                                    "state": "sku_page",
+                                    "price_container": True,
+                                    "reservation_mode": False,
+                                },
+                            ):
+                                with patch.object(
+                                    bot, "_select_price_option", return_value=True
+                                ):
+                                    with patch.object(
+                                        bot, "_wait_for_submit_ready", return_value=True
+                                    ):
+                                        with patch.object(
+                                            bot,
+                                            "_ensure_attendees_selected_on_confirm_page",
+                                            return_value=True,
+                                        ):
+                                            with patch.object(
+                                                bot,
+                                                "_submit_order_fast",
+                                                return_value="success",
+                                            ):
+                                                with patch.object(
+                                                    bot,
+                                                    "ultra_fast_click",
+                                                    return_value=True,
+                                                ):
+                                                    with patch.object(
+                                                        bot, "ultra_batch_click"
+                                                    ):
+                                                        with patch(
+                                                            "mobile.damai_app.time"
+                                                        ) as mock_time:
+                                                            mock_time.time.side_effect = _make_time_side_effect(
+                                                                0.0, 1.0
+                                                            )
                                                             bot.driver.find_elements.return_value = []
 
                                                             result = bot.run_ticket_grabbing()
@@ -1023,7 +1528,17 @@ class TestRunTicketGrabbing:
     def test_run_ticket_grabbing_no_driver_quit_in_finally(self, bot):
         """Verify driver.quit is NOT called inside run_ticket_grabbing's finally block."""
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": True,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "wait_for_sale_start"):
                     with patch.object(bot, "smart_wait_and_click", return_value=False):
                         with patch("mobile.damai_app.time") as mock_time:
@@ -1039,18 +1554,40 @@ class TestRunTicketGrabbing:
         bot.config.if_commit_order = False
 
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", return_value={ "state": "sku_page", "purchase_button": False, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+            with patch.object(
+                bot,
+                "probe_current_page",
+                return_value={
+                    "state": "sku_page",
+                    "purchase_button": False,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ):
                 with patch.object(bot, "wait_for_sale_start"):
                     with patch.object(bot, "_wait_for_submit_ready", return_value=True):
-                        with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
-                            with patch.object(bot, "ultra_fast_click", return_value=True):
-                                with patch.object(bot, "ultra_batch_click") as batch_click:
+                        with patch.object(
+                            bot,
+                            "_ensure_attendees_selected_on_confirm_page",
+                            return_value=True,
+                        ):
+                            with patch.object(
+                                bot, "ultra_fast_click", return_value=True
+                            ):
+                                with patch.object(
+                                    bot, "ultra_batch_click"
+                                ) as batch_click:
                                     with patch("mobile.damai_app.time") as mock_time:
-                                        mock_time.time.side_effect = _make_time_side_effect(0.0, 0.8)
+                                        mock_time.time.side_effect = (
+                                            _make_time_side_effect(0.0, 0.8)
+                                        )
                                         mock_price_container = Mock()
                                         mock_target = _make_mock_element()
                                         mock_price_container.find_element.return_value = mock_target
-                                        bot.driver.find_element.return_value = mock_price_container
+                                        bot.driver.find_element.return_value = (
+                                            mock_price_container
+                                        )
                                         bot.driver.find_elements.return_value = []
 
                                         result = bot.run_ticket_grabbing()
@@ -1080,7 +1617,9 @@ class TestPageStateHelpers:
         bot.config.keyword = "张杰 演唱会"
 
         with patch.object(bot, "_find_all", return_value=[card]):
-            with patch.object( bot, "_container_find_elements", side_effect=fake_container_find ):
+            with patch.object(
+                bot, "_container_find_elements", side_effect=fake_container_find
+            ):
                 results = bot.collect_search_results()
 
         assert results == [
@@ -1098,7 +1637,9 @@ class TestPageStateHelpers:
     def test_wait_for_purchase_entry_result_detects_sku_without_full_probe(self, bot):
         with patch.object(bot, "_has_any_element", side_effect=[False, True]):
             with patch.object(bot, "is_reservation_sku_mode", return_value=False):
-                result = bot._wait_for_purchase_entry_result(timeout=0.2, poll_interval=0)
+                result = bot._wait_for_purchase_entry_result(
+                    timeout=0.2, poll_interval=0
+                )
 
         assert result["state"] == "sku_page"
         assert result["reservation_mode"] is False
@@ -1153,13 +1694,31 @@ class TestPageStateHelpers:
 
         with patch.object(bot, "_select_price_option", return_value=True):
             with patch.object(bot, "_has_element", return_value=False):
-                with patch.object( bot, "_wait_for_submit_ready", side_effect=[False, True] ) as wait_ready:
-                    with patch.object( bot, "_click_sku_buy_button_element", return_value=True ) as element_click:
-                        with patch.object(bot, "_burst_click_coordinates") as burst_click:
-                            with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ):
+                with patch.object(
+                    bot, "_wait_for_submit_ready", side_effect=[False, True]
+                ) as wait_ready:
+                    with patch.object(
+                        bot, "_click_sku_buy_button_element", return_value=True
+                    ) as element_click:
+                        with patch.object(
+                            bot, "_burst_click_coordinates"
+                        ) as burst_click:
+                            with patch.object(
+                                bot,
+                                "_ensure_attendees_selected_on_confirm_page",
+                                return_value=True,
+                            ):
                                 with patch("mobile.damai_app.time.sleep"):
-                                    with patch("mobile.damai_app.time.time", side_effect=_make_time_monotonic()):
-                                        assert bot.run_ticket_grabbing(initial_page_probe=initial_probe) is True
+                                    with patch(
+                                        "mobile.damai_app.time.time",
+                                        side_effect=_make_time_monotonic(),
+                                    ):
+                                        assert (
+                                            bot.run_ticket_grabbing(
+                                                initial_page_probe=initial_probe
+                                            )
+                                            is True
+                                        )
 
         assert wait_ready.call_count == 2
         burst_click.assert_called_once_with(
@@ -1178,10 +1737,22 @@ class TestPageStateHelpers:
             checked_state["value"] = "true"
             return True
 
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: 'textContains("实名观演人")' in value, ):
-            with patch.object(bot, "_attendee_checkbox_elements", return_value=[checkbox]):
-                with patch.object( bot, "_attendee_required_count_on_confirm_page", return_value=1 ):
-                    with patch.object( bot, "_select_attendee_checkbox_by_name", side_effect=_select_side_effect, ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: 'textContains("实名观演人")' in value,
+        ):
+            with patch.object(
+                bot, "_attendee_checkbox_elements", return_value=[checkbox]
+            ):
+                with patch.object(
+                    bot, "_attendee_required_count_on_confirm_page", return_value=1
+                ):
+                    with patch.object(
+                        bot,
+                        "_select_attendee_checkbox_by_name",
+                        side_effect=_select_side_effect,
+                    ):
                         assert bot._ensure_attendees_selected_on_confirm_page() is True
 
     def test_attendee_selected_count_falls_back_to_page_source(self, bot):
@@ -1202,10 +1773,14 @@ class TestPageStateHelpers:
         checkbox = Mock()
         checkbox.click = Mock()
 
-        with patch.object( bot, "_click_element_center", side_effect=Exception("center failed") ):
+        with patch.object(
+            bot, "_click_element_center", side_effect=Exception("center failed")
+        ):
             with patch.object(bot, "_burst_click_element_center", return_value=None):
                 with patch.object(bot, "_is_checkbox_selected", return_value=False):
-                    with patch.object(bot, "_attendee_selected_count", side_effect=[0, 1]):
+                    with patch.object(
+                        bot, "_attendee_selected_count", side_effect=[0, 1]
+                    ):
                         assert bot._click_attendee_checkbox(checkbox) is True
 
         checkbox.click.assert_called_once()
@@ -1224,7 +1799,9 @@ class TestPageStateHelpers:
 
         with patch.object(bot, "_find_all", side_effect=_find_all_side_effect):
             with patch.object(bot, "_is_checkbox_selected", return_value=False):
-                with patch.object( bot, "_click_attendee_checkbox", return_value=True ) as click_checkbox:
+                with patch.object(
+                    bot, "_click_attendee_checkbox", return_value=True
+                ) as click_checkbox:
                     assert bot._select_attendee_checkbox_by_name("张志涛") is True
 
         assert any("contains(normalize-space(@text)" in xpath for xpath in seen_xpaths)
@@ -1233,7 +1810,11 @@ class TestPageStateHelpers:
     def test_ensure_attendees_selected_fails_when_section_visible_but_no_checkbox(
         self, bot
     ):
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: 'textContains("实名观演人")' in value, ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: 'textContains("实名观演人")' in value,
+        ):
             with patch.object(bot, "_attendee_checkbox_elements", return_value=[]):
                 assert bot._ensure_attendees_selected_on_confirm_page() is False
 
@@ -1257,9 +1838,13 @@ class TestPageStateHelpers:
                 return []
             return [checkbox1, checkbox2]
 
-        with patch.object( bot, "_attendee_checkbox_elements", side_effect=_delayed_checkbox ):
+        with patch.object(
+            bot, "_attendee_checkbox_elements", side_effect=_delayed_checkbox
+        ):
             with patch.object(bot, "_attendee_selected_count", return_value=0):
-                with patch.object(bot, "_click_attendee_checkbox_fast", return_value=True):
+                with patch.object(
+                    bot, "_click_attendee_checkbox_fast", return_value=True
+                ):
                     assert (
                         bot._ensure_attendees_selected_on_confirm_page(
                             require_attendee_section=True
@@ -1304,9 +1889,19 @@ class TestPageStateHelpers:
             return []
 
         with patch.object(bot, "_find", return_value=price_container):
-            with patch.object( bot, "_container_find_elements", side_effect=fake_container_find ):
+            with patch.object(
+                bot, "_container_find_elements", side_effect=fake_container_find
+            ):
                 with patch.object(bot, "_is_clickable", return_value=True):
-                    with patch.object( bot, "_collect_descendant_texts", side_effect=lambda c, **kw: ( ["内场", "1280", "可预约"] if c is card_a else ["看台", "380", "无票"] ), ):
+                    with patch.object(
+                        bot,
+                        "_collect_descendant_texts",
+                        side_effect=lambda c, **kw: (
+                            ["内场", "1280", "可预约"]
+                            if c is card_a
+                            else ["看台", "380", "无票"]
+                        ),
+                    ):
                         options = bot.get_visible_price_options()
 
         assert options == [
@@ -1329,11 +1924,15 @@ class TestPageStateHelpers:
     def test_purchase_bar_text_ready_distinguishes_reservation_from_purchase(self, bot):
         purchase_bar = Mock()
         with patch.object(bot.driver, "find_element", return_value=purchase_bar):
-            with patch.object(bot, "_collect_descendant_texts", return_value=["立即购买"]):
+            with patch.object(
+                bot, "_collect_descendant_texts", return_value=["立即购买"]
+            ):
                 assert bot._purchase_bar_text_ready() is True
 
         with patch.object(bot.driver, "find_element", return_value=purchase_bar):
-            with patch.object(bot, "_collect_descendant_texts", return_value=["抢票预约"]):
+            with patch.object(
+                bot, "_collect_descendant_texts", return_value=["抢票预约"]
+            ):
                 assert bot._purchase_bar_text_ready() is False
 
     def test_normalize_ocr_price_text(self, bot):
@@ -1385,7 +1984,9 @@ class TestPageStateHelpers:
 
         with patch("mobile.price_selector._MAGICK_BIN", "magick"):
             with patch("mobile.price_selector._TESSERACT_BIN", "tesseract"):
-                with patch("mobile.price_selector.subprocess.run", side_effect=fake_run) as run:
+                with patch(
+                    "mobile.price_selector.subprocess.run", side_effect=fake_run
+                ) as run:
                     result = bot._ocr_price_text_from_card("/tmp/sku.png", rect)
 
         assert result == "1380元"
@@ -1396,7 +1997,13 @@ class TestPageStateHelpers:
         assert first_tesseract_cmd[first_tesseract_cmd.index("--psm") + 1] == "13"
 
     def test_probe_current_page_detects_homepage(self, bot):
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: ( (by, value) == (By.ID, "cn.damai:id/homepage_header_search") ), ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: (
+                (by, value) == (By.ID, "cn.damai:id/homepage_header_search")
+            ),
+        ):
             with patch.object(bot, "_get_current_activity", return_value=""):
                 result = bot._probe_current_page_element_based()
 
@@ -1405,14 +2012,20 @@ class TestPageStateHelpers:
 
     def test_probe_current_page_detects_homepage_by_activity(self, bot):
         with patch.object(bot, "_has_element", return_value=False):
-            with patch.object( bot, "_get_current_activity", return_value=".homepage.MainActivity" ):
+            with patch.object(
+                bot, "_get_current_activity", return_value=".homepage.MainActivity"
+            ):
                 result = bot._probe_current_page_element_based()
 
                 assert result["state"] == "homepage"
 
     def test_probe_current_page_detects_search_activity(self, bot):
         with patch.object(bot, "_has_element", return_value=False):
-            with patch.object( bot, "_get_current_activity", return_value="com.alibaba.pictures.bricks.search.v2.SearchActivity", ):
+            with patch.object(
+                bot,
+                "_get_current_activity",
+                return_value="com.alibaba.pictures.bricks.search.v2.SearchActivity",
+            ):
                 result = bot._probe_current_page_element_based()
 
                 assert result["state"] == "search_page"
@@ -1425,8 +2038,16 @@ class TestPageStateHelpers:
             (By.ID, "cn.damai:id/project_detail_price_layout"),
         }
 
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
-            with patch.object( bot, "_get_current_activity", return_value=".trade.newtradeorder.ui.projectdetail.ui.activity.ProjectDetailActivity", ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: (by, value) in present,
+        ):
+            with patch.object(
+                bot,
+                "_get_current_activity",
+                return_value=".trade.newtradeorder.ui.projectdetail.ui.activity.ProjectDetailActivity",
+            ):
                 result = bot._probe_current_page_element_based()
 
                 assert result["state"] == "detail_page"
@@ -1439,8 +2060,16 @@ class TestPageStateHelpers:
             (By.ID, "cn.damai:id/layout_sku"),
         }
 
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
-            with patch.object( bot, "_get_current_activity", return_value=".commonbusiness.seatbiz.sku.qilin.ui.NcovSkuActivity", ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: (by, value) in present,
+        ):
+            with patch.object(
+                bot,
+                "_get_current_activity",
+                return_value=".commonbusiness.seatbiz.sku.qilin.ui.NcovSkuActivity",
+            ):
                 result = bot._probe_current_page_element_based()
 
                 assert result["state"] == "sku_page"
@@ -1454,8 +2083,16 @@ class TestPageStateHelpers:
             (ANDROID_UIAUTOMATOR, 'new UiSelector().text("预约想看场次")'),
         }
 
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
-            with patch.object( bot, "_get_current_activity", return_value=".commonbusiness.seatbiz.sku.qilin.ui.NcovSkuActivity", ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: (by, value) in present,
+        ):
+            with patch.object(
+                bot,
+                "_get_current_activity",
+                return_value=".commonbusiness.seatbiz.sku.qilin.ui.NcovSkuActivity",
+            ):
                 result = bot._probe_current_page_element_based()
 
                 assert result["state"] == "sku_page"
@@ -1466,7 +2103,11 @@ class TestPageStateHelpers:
             (By.ID, "cn.damai:id/damai_theme_dialog_confirm_btn"),
         }
 
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: (by, value) in present,
+        ):
             with patch.object(bot, "_get_current_activity", return_value=""):
                 result = bot._probe_current_page_element_based()
 
@@ -1484,7 +2125,11 @@ class TestPageStateHelpers:
             (By.ID, "cn.damai:id/checkbox"),
         }
 
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: (by, value) in present,
+        ):
             with patch.object(bot, "_get_current_activity", return_value=""):
                 result = bot._probe_current_page_element_based()
 
@@ -1504,14 +2149,20 @@ class TestPageStateHelpers:
             (ANDROID_UIAUTOMATOR, 'new UiSelector().text("下次再说")'),
         }
 
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: (by, value) in present,
+        ):
             with patch.object(bot, "ultra_fast_click", return_value=True) as fast_click:
                 with patch("mobile.damai_app.time.sleep"):
                     result = bot.dismiss_startup_popups()
 
                     assert result is True
                     fast_click.assert_any_call(By.ID, "android:id/ok")
-                    fast_click.assert_any_call(By.ID, "cn.damai:id/id_boot_action_agree")
+                    fast_click.assert_any_call(
+                        By.ID, "cn.damai:id/id_boot_action_agree"
+                    )
                     fast_click.assert_any_call(
                         By.ID, "cn.damai:id/damai_theme_dialog_cancel_btn"
                     )
@@ -1531,7 +2182,11 @@ class TestPageStateHelpers:
             (ANDROID_UIAUTOMATOR, 'new UiSelector().text("知道了")'),
         }
 
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: (by, value) in present,
+        ):
             with patch.object(bot, "ultra_fast_click", return_value=True) as fast_click:
                 with patch("mobile.damai_app.time.sleep"):
                     assert bot._dismiss_fast_blocking_dialogs() is True
@@ -1563,7 +2218,9 @@ class TestRunWithRetry:
     def test_run_with_retry_success_second_attempt(self, bot):
         """Fails once, sets up driver again, succeeds second time."""
         with patch.object(bot, "run_ticket_grabbing", side_effect=[False, True]):
-            with patch.object(bot, "_fast_retry_from_current_state", return_value=False):
+            with patch.object(
+                bot, "_fast_retry_from_current_state", return_value=False
+            ):
                 with patch.object(bot, "_setup_driver") as mock_setup:
                     with patch("mobile.damai_app.time"):
                         result = bot.run_with_retry(max_retries=3)
@@ -1574,7 +2231,9 @@ class TestRunWithRetry:
     def test_run_with_retry_all_fail(self, bot):
         """All retries fail, returns False."""
         with patch.object(bot, "run_ticket_grabbing", return_value=False):
-            with patch.object(bot, "_fast_retry_from_current_state", return_value=False):
+            with patch.object(
+                bot, "_fast_retry_from_current_state", return_value=False
+            ):
                 with patch.object(bot, "_setup_driver"):
                     with patch("mobile.damai_app.time"):
                         result = bot.run_with_retry(max_retries=3)
@@ -1584,7 +2243,9 @@ class TestRunWithRetry:
     def test_run_with_retry_driver_quit_between_retries(self, bot):
         """Between retries, driver.quit and _setup_driver are called."""
         with patch.object(bot, "run_ticket_grabbing", side_effect=[False, False, True]):
-            with patch.object(bot, "_fast_retry_from_current_state", return_value=False):
+            with patch.object(
+                bot, "_fast_retry_from_current_state", return_value=False
+            ):
                 with patch.object(bot, "_setup_driver") as mock_setup:
                     with patch("mobile.damai_app.time"):
                         bot.run_with_retry(max_retries=3)
@@ -1599,7 +2260,9 @@ class TestRunWithRetry:
 
         with patch.object(bot, "run_ticket_grabbing", side_effect=[False, True]):
             with patch.object(bot, "_setup_driver") as mock_setup:
-                with patch.object(bot, "_fast_retry_from_current_state", return_value=False):
+                with patch.object(
+                    bot, "_fast_retry_from_current_state", return_value=False
+                ):
                     with patch("mobile.damai_app.time"):
                         result = bot.run_with_retry(max_retries=3)
 
@@ -1609,7 +2272,9 @@ class TestRunWithRetry:
     def test_run_with_retry_uses_fast_retry(self, bot):
         """Verify fast retry is attempted before driver recreation."""
         with patch.object(bot, "run_ticket_grabbing", side_effect=[False, False]):
-            with patch.object( bot, "_fast_retry_from_current_state", return_value=False ) as fast_retry:
+            with patch.object(
+                bot, "_fast_retry_from_current_state", return_value=False
+            ) as fast_retry:
                 with patch.object(bot, "_setup_driver"):
                     with patch("mobile.damai_app.time"):
                         bot.run_with_retry(max_retries=2)
@@ -1620,7 +2285,9 @@ class TestRunWithRetry:
     def test_run_with_retry_first_fast_retry_has_no_extra_sleep(self, bot):
         """The first fast retry should execute immediately after a failed attempt."""
         with patch.object(bot, "run_ticket_grabbing", return_value=False):
-            with patch.object( bot, "_fast_retry_from_current_state", side_effect=[False, True] ):
+            with patch.object(
+                bot, "_fast_retry_from_current_state", side_effect=[False, True]
+            ):
                 with patch.object(bot, "_setup_driver"):
                     with patch("mobile.damai_app.time.sleep") as mock_sleep:
                         result = bot.run_with_retry(max_retries=1)
@@ -1633,7 +2300,9 @@ class TestRunWithRetry:
         bot.config.auto_navigate = False
 
         with patch.object(bot, "run_ticket_grabbing", side_effect=[False, False]):
-            with patch.object(bot, "_fast_retry_from_current_state", return_value=False):
+            with patch.object(
+                bot, "_fast_retry_from_current_state", return_value=False
+            ):
                 with patch.object(bot, "_setup_driver") as mock_setup:
                     with patch("mobile.damai_app.time"):
                         result = bot.run_with_retry(max_retries=2)
@@ -1767,9 +2436,21 @@ class TestWaitForSaleStart:
         mock_sleep.assert_not_called()
 
     def test_prepare_detail_page_hot_path_preselects_date_and_city(self, bot):
-        with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+        with patch.object(
+            bot,
+            "probe_current_page",
+            return_value={
+                "state": "detail_page",
+                "purchase_button": True,
+                "price_container": True,
+                "quantity_picker": False,
+                "submit_button": False,
+            },
+        ):
             with patch.object(bot, "select_performance_date") as select_date:
-                with patch.object( bot, "_select_city_from_detail_page", return_value=True ) as select_city:
+                with patch.object(
+                    bot, "_select_city_from_detail_page", return_value=True
+                ) as select_city:
                     result = bot._prepare_detail_page_hot_path()
 
         assert result is True
@@ -1777,7 +2458,9 @@ class TestWaitForSaleStart:
         select_city.assert_called_once_with(timeout=0.6)
 
     def test_prepare_detail_page_hot_path_returns_false_outside_detail_page(self, bot):
-        with patch.object(bot, "probe_current_page", return_value={"state": "homepage"}):
+        with patch.object(
+            bot, "probe_current_page", return_value={"state": "homepage"}
+        ):
             with patch.object(bot, "select_performance_date") as select_date:
                 with patch.object(bot, "_select_city_from_detail_page") as select_city:
                     result = bot._prepare_detail_page_hot_path()
@@ -1807,7 +2490,9 @@ class TestDetailPagePurchaseEntry:
 
     def test_enter_purchase_flow_returns_none_when_city_selection_fails(self, bot):
         with patch.object(bot, "select_performance_date") as select_date:
-            with patch.object( bot, "_select_city_from_detail_page", return_value=False ) as select_city:
+            with patch.object(
+                bot, "_select_city_from_detail_page", return_value=False
+            ) as select_city:
                 result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         assert result is None
@@ -1822,7 +2507,9 @@ class TestDetailPagePurchaseEntry:
 
         with patch.object(bot, "_cached_tap", return_value=False):
             with patch.object(bot, "smart_wait_and_click", return_value=True):
-                with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ):
+                with patch.object(
+                    bot, "_wait_for_purchase_entry_result", return_value=next_probe
+                ):
                     result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         assert result == next_probe
@@ -1832,7 +2519,9 @@ class TestDetailPagePurchaseEntry:
         next_probe = {"state": "sku_page", "reservation_mode": False}
 
         with patch.object(bot, "_cached_tap", return_value=True) as cached_tap:
-            with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ) as wait_result:
+            with patch.object(
+                bot, "_wait_for_purchase_entry_result", return_value=next_probe
+            ) as wait_result:
                 result = bot._enter_purchase_flow_from_detail_page(prepared=True)
 
         assert result == next_probe
@@ -1843,8 +2532,12 @@ class TestDetailPagePurchaseEntry:
         next_probe = {"state": "order_confirm_page", "submit_button": True}
 
         with patch.object(bot, "ultra_fast_click", return_value=False):
-            with patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click:
-                with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ) as wait_result:
+            with patch.object(
+                bot, "smart_wait_and_click", return_value=True
+            ) as smart_click:
+                with patch.object(
+                    bot, "_wait_for_purchase_entry_result", return_value=next_probe
+                ) as wait_result:
                     result = bot._enter_purchase_flow_from_detail_page(prepared=True)
 
         assert result == next_probe
@@ -1869,7 +2562,9 @@ class TestSaleReadiness:
     ):
         purchase_bar = Mock()
         with patch.object(bot.driver, "find_element", return_value=purchase_bar):
-            with patch.object(bot, "_collect_descendant_texts", return_value=["", "   "]):
+            with patch.object(
+                bot, "_collect_descendant_texts", return_value=["", "   "]
+            ):
                 assert bot._purchase_bar_text_ready() is False
 
     def test_is_sale_ready_detects_ready_selector(self, bot):
@@ -1885,11 +2580,19 @@ class TestSaleReadiness:
     def test_is_sale_ready_uses_sku_mode_to_block_reservation(self, bot):
         present = {(By.ID, "cn.damai:id/project_detail_perform_price_flowlayout")}
 
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: (by, value) in present,
+        ):
             with patch.object(bot, "is_reservation_sku_mode", return_value=True):
                 assert bot._is_sale_ready() is False
 
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: (by, value) in present,
+        ):
             with patch.object(bot, "is_reservation_sku_mode", return_value=False):
                 assert bot._is_sale_ready() is True
 
@@ -1898,7 +2601,11 @@ class TestSaleReadiness:
             (By.ID, "cn.damai:id/trade_project_detail_purchase_status_bar_container_fl")
         }
 
-        with patch.object( bot, "_has_element", side_effect=lambda by, value: (by, value) in present, ):
+        with patch.object(
+            bot,
+            "_has_element",
+            side_effect=lambda by, value: (by, value) in present,
+        ):
             with patch.object(bot, "_purchase_bar_text_ready", return_value=True):
                 assert bot._is_sale_ready() is True
 
@@ -1931,7 +2638,9 @@ class TestFastRetry:
         }
         # First call from dismiss_startup_popups fallback returns unknown;
         # second call (in back-loop with fast=True) returns detail_page.
-        with patch.object( bot, "probe_current_page", side_effect=[unknown_probe, detail_probe] ):
+        with patch.object(
+            bot, "probe_current_page", side_effect=[unknown_probe, detail_probe]
+        ):
             with patch.object(bot, "dismiss_startup_popups"):
                 with patch("mobile.damai_app.time.sleep"):
                     result = bot._recover_to_detail_page_for_local_retry(
@@ -1943,7 +2652,17 @@ class TestFastRetry:
 
     def test_fast_retry_from_detail_page(self, bot):
         """probe returns detail_page, re-runs full flow."""
-        with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+        with patch.object(
+            bot,
+            "probe_current_page",
+            return_value={
+                "state": "detail_page",
+                "purchase_button": True,
+                "price_container": True,
+                "quantity_picker": False,
+                "submit_button": False,
+            },
+        ):
             with patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg:
                 result = bot._fast_retry_from_current_state()
 
@@ -1952,8 +2671,20 @@ class TestFastRetry:
 
     def test_fast_retry_from_order_confirm_page(self, bot):
         """probe returns order_confirm_page, re-attempts submit only."""
-        with patch.object( bot, "probe_current_page", return_value={ "state": "order_confirm_page", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": True, }, ):
-            with patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click:
+        with patch.object(
+            bot,
+            "probe_current_page",
+            return_value={
+                "state": "order_confirm_page",
+                "purchase_button": False,
+                "price_container": False,
+                "quantity_picker": False,
+                "submit_button": True,
+            },
+        ):
+            with patch.object(
+                bot, "smart_wait_and_click", return_value=True
+            ) as smart_click:
                 result = bot._fast_retry_from_current_state()
 
         assert result is True
@@ -1964,9 +2695,23 @@ class TestFastRetry:
     ):
         bot.config.if_commit_order = False
 
-        with patch.object( bot, "probe_current_page", return_value={ "state": "order_confirm_page", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": True, }, ):
-            with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True ) as ensure_attendees:
-                with patch.object( bot, "smart_wait_for_element", return_value=True ) as wait_element:
+        with patch.object(
+            bot,
+            "probe_current_page",
+            return_value={
+                "state": "order_confirm_page",
+                "purchase_button": False,
+                "price_container": False,
+                "quantity_picker": False,
+                "submit_button": True,
+            },
+        ):
+            with patch.object(
+                bot, "_ensure_attendees_selected_on_confirm_page", return_value=True
+            ) as ensure_attendees:
+                with patch.object(
+                    bot, "smart_wait_for_element", return_value=True
+                ) as wait_element:
                     result = bot._fast_retry_from_current_state()
 
         assert result is True
@@ -1994,10 +2739,24 @@ class TestFastRetry:
         bot.item_detail = _make_item_detail()
         bot.config.auto_navigate = True
 
-        with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+        with patch.object(
+            bot,
+            "probe_current_page",
+            return_value={
+                "state": "detail_page",
+                "purchase_button": True,
+                "price_container": True,
+                "quantity_picker": False,
+                "submit_button": False,
+            },
+        ):
             with patch.object(bot, "_current_page_matches_target", return_value=False):
-                with patch.object( bot, "navigate_to_target_event", return_value=True ) as navigate:
-                    with patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg:
+                with patch.object(
+                    bot, "navigate_to_target_event", return_value=True
+                ) as navigate:
+                    with patch.object(
+                        bot, "run_ticket_grabbing", return_value=True
+                    ) as run_tg:
                         result = bot._fast_retry_from_current_state()
 
         assert result is True
@@ -2008,7 +2767,17 @@ class TestFastRetry:
         bot.item_detail = _make_item_detail()
         bot.config.auto_navigate = False
 
-        with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+        with patch.object(
+            bot,
+            "probe_current_page",
+            return_value={
+                "state": "detail_page",
+                "purchase_button": True,
+                "price_container": True,
+                "quantity_picker": False,
+                "submit_button": False,
+            },
+        ):
             with patch.object(bot, "_current_page_matches_target", return_value=False):
                 with patch.object(bot, "navigate_to_target_event") as navigate:
                     with patch.object(bot, "run_ticket_grabbing") as run_tg:
@@ -2022,9 +2791,31 @@ class TestFastRetry:
         """Manual-start retry recovers locally before re-running the flow."""
         bot.config.auto_navigate = False
 
-        with patch.object( bot, "probe_current_page", return_value={ "state": "unknown", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, }, ):
-            with patch.object( bot, "_recover_to_detail_page_for_local_retry", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ) as recover_local:
-                with patch.object(bot, "run_ticket_grabbing", return_value=False) as run_tg:
+        with patch.object(
+            bot,
+            "probe_current_page",
+            return_value={
+                "state": "unknown",
+                "purchase_button": False,
+                "price_container": False,
+                "quantity_picker": False,
+                "submit_button": False,
+            },
+        ):
+            with patch.object(
+                bot,
+                "_recover_to_detail_page_for_local_retry",
+                return_value={
+                    "state": "detail_page",
+                    "purchase_button": True,
+                    "price_container": True,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ) as recover_local:
+                with patch.object(
+                    bot, "run_ticket_grabbing", return_value=False
+                ) as run_tg:
                     with patch("mobile.damai_app.time.sleep"):
                         result = bot._fast_retry_from_current_state()
 
@@ -2036,8 +2827,28 @@ class TestFastRetry:
         """Manual-start retry stops if it cannot recover to a detail/sku page."""
         bot.config.auto_navigate = False
 
-        with patch.object( bot, "probe_current_page", return_value={ "state": "unknown", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, }, ):
-            with patch.object( bot, "_recover_to_detail_page_for_local_retry", return_value={ "state": "homepage", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, }, ) as recover_local:
+        with patch.object(
+            bot,
+            "probe_current_page",
+            return_value={
+                "state": "unknown",
+                "purchase_button": False,
+                "price_container": False,
+                "quantity_picker": False,
+                "submit_button": False,
+            },
+        ):
+            with patch.object(
+                bot,
+                "_recover_to_detail_page_for_local_retry",
+                return_value={
+                    "state": "homepage",
+                    "purchase_button": False,
+                    "price_container": False,
+                    "quantity_picker": False,
+                    "submit_button": False,
+                },
+            ) as recover_local:
                 with patch.object(bot, "run_ticket_grabbing") as run_tg:
                     result = bot._fast_retry_from_current_state()
 
@@ -2048,9 +2859,23 @@ class TestFastRetry:
     def test_fast_retry_from_unknown_uses_auto_navigation_when_enabled(self, bot):
         bot.config.auto_navigate = True
 
-        with patch.object( bot, "probe_current_page", return_value={ "state": "unknown", "purchase_button": False, "price_container": False, "quantity_picker": False, "submit_button": False, }, ):
-            with patch.object( bot, "navigate_to_target_event", return_value=True ) as navigate:
-                with patch.object(bot, "run_ticket_grabbing", return_value=True) as run_tg:
+        with patch.object(
+            bot,
+            "probe_current_page",
+            return_value={
+                "state": "unknown",
+                "purchase_button": False,
+                "price_container": False,
+                "quantity_picker": False,
+                "submit_button": False,
+            },
+        ):
+            with patch.object(
+                bot, "navigate_to_target_event", return_value=True
+            ) as navigate:
+                with patch.object(
+                    bot, "run_ticket_grabbing", return_value=True
+                ) as run_tg:
                     result = bot._fast_retry_from_current_state()
 
         assert result is True
@@ -2066,7 +2891,11 @@ class TestFastRetry:
 class TestVerifyOrderResult:
     def test_verify_order_success_payment_activity(self, bot):
         """Activity contains 'Pay', returns 'success'."""
-        with patch.object( bot, "_get_current_activity", return_value="com.alipay.android.app.PayActivity", ):
+        with patch.object(
+            bot,
+            "_get_current_activity",
+            return_value="com.alipay.android.app.PayActivity",
+        ):
             with patch("mobile.damai_app.time") as mock_time:
                 mock_time.time.side_effect = _make_time_side_effect(0.0, 0.1)
                 result = bot.verify_order_result(timeout=5)
@@ -2257,7 +3086,9 @@ class TestSelectPerformanceDate:
 class TestCheckSessionValid:
     def test_check_session_valid_logged_in(self, bot):
         """No login indicators, returns True."""
-        with patch.object( bot, "_get_current_activity", return_value="ProjectDetailActivity" ):
+        with patch.object(
+            bot, "_get_current_activity", return_value="ProjectDetailActivity"
+        ):
             with patch.object(bot, "_has_element", return_value=False):
                 result = bot.check_session_valid()
 
@@ -2266,7 +3097,11 @@ class TestCheckSessionValid:
     def test_check_session_valid_login_activity(self, bot, caplog):
         """LoginActivity detected, returns False."""
         with caplog.at_level("ERROR", logger="mobile.damai_app"):
-            with patch.object( bot, "_get_current_activity", return_value="com.taobao.login.LoginActivity", ):
+            with patch.object(
+                bot,
+                "_get_current_activity",
+                return_value="com.taobao.login.LoginActivity",
+            ):
                 result = bot.check_session_valid()
 
         assert result is False
@@ -2275,7 +3110,9 @@ class TestCheckSessionValid:
     def test_check_session_valid_sign_activity(self, bot, caplog):
         """SignActivity detected, returns False."""
         with caplog.at_level("ERROR", logger="mobile.damai_app"):
-            with patch.object( bot, "_get_current_activity", return_value="com.taobao.SignActivity" ):
+            with patch.object(
+                bot, "_get_current_activity", return_value="com.taobao.SignActivity"
+            ):
                 result = bot.check_session_valid()
 
         assert result is False
@@ -2288,8 +3125,12 @@ class TestCheckSessionValid:
             return "请先登录" in value
 
         with caplog.at_level("ERROR", logger="mobile.damai_app"):
-            with patch.object(bot, "_get_current_activity", return_value="SomeActivity"):
-                with patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+            with patch.object(
+                bot, "_get_current_activity", return_value="SomeActivity"
+            ):
+                with patch.object(
+                    bot, "_has_element", side_effect=has_element_side_effect
+                ):
                     result = bot.check_session_valid()
 
         assert result is False
@@ -2354,8 +3195,12 @@ class TestSkuInspectionHelpers:
     def test_ensure_sku_page_for_inspection_enters_sku_from_detail_page(self, bot):
         next_probe = {"state": "sku_page", "reservation_mode": False}
 
-        with patch.object(bot, "smart_wait_and_click", return_value=True) as smart_click:
-            with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ) as wait_entry:
+        with patch.object(
+            bot, "smart_wait_and_click", return_value=True
+        ) as smart_click:
+            with patch.object(
+                bot, "_wait_for_purchase_entry_result", return_value=next_probe
+            ) as wait_entry:
                 result = bot.ensure_sku_page_for_inspection({"state": "detail_page"})
 
         assert result == next_probe
@@ -2364,7 +3209,9 @@ class TestSkuInspectionHelpers:
 
     def test_ensure_sku_page_for_inspection_returns_probe_when_click_fails(self, bot):
         with patch.object(bot, "smart_wait_and_click", return_value=False):
-            with patch.object( bot, "probe_current_page", return_value={"state": "detail_page"} ) as probe:
+            with patch.object(
+                bot, "probe_current_page", return_value={"state": "detail_page"}
+            ) as probe:
                 result = bot.ensure_sku_page_for_inspection({"state": "detail_page"})
 
         assert result == {"state": "detail_page"}
@@ -2376,12 +3223,28 @@ class TestSkuInspectionHelpers:
 
         with patch.object(bot, "smart_wait_and_click", return_value=True):
             with patch.object(bot, "_dump_hierarchy_xml", return_value=None):
-                with patch.object( bot, "_wait_for_purchase_entry_result", return_value=sku_probe ):
-                    with patch.object( bot, "_get_detail_title_text", side_effect=["", "马思唯上海站"] ):
-                        with patch.object( bot, "_get_detail_venue_text", side_effect=["", "上海市 · 浦发银行东方体育中心"], ):
-                            with patch.object(bot, "get_visible_date_options", return_value=["04.04"]):
-                                with patch.object(bot, "get_visible_price_options", return_value=prices):
-                                    summary = bot.inspect_current_target_event({"state": "detail_page"})
+                with patch.object(
+                    bot, "_wait_for_purchase_entry_result", return_value=sku_probe
+                ):
+                    with patch.object(
+                        bot, "_get_detail_title_text", side_effect=["", "马思唯上海站"]
+                    ):
+                        with patch.object(
+                            bot,
+                            "_get_detail_venue_text",
+                            side_effect=["", "上海市 · 浦发银行东方体育中心"],
+                        ):
+                            with patch.object(
+                                bot, "get_visible_date_options", return_value=["04.04"]
+                            ):
+                                with patch.object(
+                                    bot,
+                                    "get_visible_price_options",
+                                    return_value=prices,
+                                ):
+                                    summary = bot.inspect_current_target_event(
+                                        {"state": "detail_page"}
+                                    )
 
         assert summary == {
             "state": "sku_page",
@@ -2395,12 +3258,28 @@ class TestSkuInspectionHelpers:
     def test_inspect_current_target_event_skips_price_reads_outside_sku_page(self, bot):
         with patch.object(bot, "smart_wait_and_click", return_value=True):
             with patch.object(bot, "_dump_hierarchy_xml", return_value=None):
-                with patch.object( bot, "_wait_for_purchase_entry_result", return_value={"state": "detail_page"}, ):
-                    with patch.object(bot, "_get_detail_title_text", return_value="马思唯上海站"):
-                        with patch.object( bot, "_get_detail_venue_text", return_value="浦发银行东方体育中心" ):
-                            with patch.object(bot, "get_visible_date_options") as get_dates:
-                                with patch.object(bot, "get_visible_price_options") as get_prices:
-                                    summary = bot.inspect_current_target_event({"state": "detail_page"})
+                with patch.object(
+                    bot,
+                    "_wait_for_purchase_entry_result",
+                    return_value={"state": "detail_page"},
+                ):
+                    with patch.object(
+                        bot, "_get_detail_title_text", return_value="马思唯上海站"
+                    ):
+                        with patch.object(
+                            bot,
+                            "_get_detail_venue_text",
+                            return_value="浦发银行东方体育中心",
+                        ):
+                            with patch.object(
+                                bot, "get_visible_date_options"
+                            ) as get_dates:
+                                with patch.object(
+                                    bot, "get_visible_price_options"
+                                ) as get_prices:
+                                    summary = bot.inspect_current_target_event(
+                                        {"state": "detail_page"}
+                                    )
 
         assert summary["state"] == "detail_page"
         assert summary["dates"] == []
@@ -2415,8 +3294,12 @@ class TestSkuInspectionHelpers:
             return "登录/注册" in value
 
         with caplog.at_level("ERROR", logger="mobile.damai_app"):
-            with patch.object(bot, "_get_current_activity", return_value="SomeActivity"):
-                with patch.object(bot, "_has_element", side_effect=has_element_side_effect):
+            with patch.object(
+                bot, "_get_current_activity", return_value="SomeActivity"
+            ):
+                with patch.object(
+                    bot, "_has_element", side_effect=has_element_side_effect
+                ):
                     result = bot.check_session_valid()
 
         assert result is False
@@ -2586,11 +3469,19 @@ class TestXmlHierarchyHelpers:
         sku_probe = {"state": "sku_page", "reservation_mode": False}
 
         with patch.object(bot, "probe_current_page", return_value=sku_probe):
-            with patch.object(bot, "ensure_sku_page_for_inspection", return_value=sku_probe):
+            with patch.object(
+                bot, "ensure_sku_page_for_inspection", return_value=sku_probe
+            ):
                 with patch.object(bot, "_get_detail_title_text", return_value="演唱会"):
-                    with patch.object(bot, "_get_detail_venue_text", return_value="场馆"):
-                        with patch.object(bot, "get_visible_date_options", return_value=["04.06"]):
-                            with patch.object(bot, "get_visible_price_options", return_value=[]):
+                    with patch.object(
+                        bot, "_get_detail_venue_text", return_value="场馆"
+                    ):
+                        with patch.object(
+                            bot, "get_visible_date_options", return_value=["04.06"]
+                        ):
+                            with patch.object(
+                                bot, "get_visible_price_options", return_value=[]
+                            ):
                                 bot.inspect_current_target_event()
 
         # Hierarchy should only be dumped once (no re-dump since page didn't navigate).
@@ -2609,7 +3500,9 @@ class TestPriceSelection:
         bot.config.rush_mode = True
         bot.config.price_index = 5
 
-        with patch.object( bot, "_click_price_option_by_config_index", return_value=True ) as click_index:
+        with patch.object(
+            bot, "_click_price_option_by_config_index", return_value=True
+        ) as click_index:
             with patch.object(bot, "get_visible_price_options") as get_visible:
                 result = bot._select_price_option_fast()
 
@@ -2620,7 +3513,9 @@ class TestPriceSelection:
     def test_select_price_option_fast_rush_mode_uses_cached_coordinates(self, bot):
         bot.config.rush_mode = True
 
-        with patch.object( bot, "_click_price_option_by_config_index", return_value=True ) as click_index:
+        with patch.object(
+            bot, "_click_price_option_by_config_index", return_value=True
+        ) as click_index:
             with patch.object(bot, "get_visible_price_options") as get_visible:
                 result = bot._select_price_option_fast(cached_coords=(240, 1560))
 
@@ -2632,8 +3527,16 @@ class TestPriceSelection:
         bot.config.price = "899元"
         bot.config.price_index = 5
 
-        with patch.object( bot, "get_visible_price_options", return_value=[ {"index": 5, "text": "", "tag": "", "source": "ui"}, ], ) as get_visible:
-            with patch.object( bot, "_click_visible_price_option", return_value=True ) as click_visible:
+        with patch.object(
+            bot,
+            "get_visible_price_options",
+            return_value=[
+                {"index": 5, "text": "", "tag": "", "source": "ui"},
+            ],
+        ) as get_visible:
+            with patch.object(
+                bot, "_click_visible_price_option", return_value=True
+            ) as click_visible:
                 result = bot._select_price_option_fast()
 
         assert result is True
@@ -2641,7 +3544,11 @@ class TestPriceSelection:
         click_visible.assert_called_once_with(5)
 
     def test_click_price_option_by_config_index_bursts_clicks_in_rush_mode(self, bot):
-        with patch.object( bot, "_get_price_option_coordinates_by_config_index", return_value=(260, 1540), ):
+        with patch.object(
+            bot,
+            "_get_price_option_coordinates_by_config_index",
+            return_value=(260, 1540),
+        ):
             with patch.object(bot, "_burst_click_coordinates") as burst_click:
                 result = bot._click_price_option_by_config_index(burst=True)
 
@@ -2657,7 +3564,9 @@ class TestPriceSelection:
         bot.config.price_index = 5
 
         with patch.object(bot, "get_visible_price_options", return_value=[]):
-            with patch.object( bot, "_click_price_option_by_config_index", return_value=True ) as click_index:
+            with patch.object(
+                bot, "_click_price_option_by_config_index", return_value=True
+            ) as click_index:
                 with patch.object(bot, "ultra_fast_click", return_value=False):
                     result = bot._select_price_option_fast()
 
@@ -2668,8 +3577,17 @@ class TestPriceSelection:
         bot.config.price = "899元"
         bot.config.price_index = 5
 
-        with patch.object( bot, "get_visible_price_options", return_value=[ {"index": 0, "text": "看台699元", "tag": "", "source": "ocr"}, {"index": 5, "text": "看台899元", "tag": "", "source": "ocr"}, ], ):
-            with patch.object( bot, "_click_visible_price_option", return_value=True ) as click_visible:
+        with patch.object(
+            bot,
+            "get_visible_price_options",
+            return_value=[
+                {"index": 0, "text": "看台699元", "tag": "", "source": "ocr"},
+                {"index": 5, "text": "看台899元", "tag": "", "source": "ocr"},
+            ],
+        ):
+            with patch.object(
+                bot, "_click_visible_price_option", return_value=True
+            ) as click_visible:
                 with patch.object(bot, "ultra_fast_click") as fast_click:
                     result = bot._select_price_option()
 
@@ -2681,7 +3599,18 @@ class TestPriceSelection:
         bot.config.price = "899元"
         bot.config.price_index = 5
 
-        with patch.object( bot, "get_visible_price_options", return_value=[ { "index": 5, "text": "看台899元", "tag": "缺货登记", "source": "ocr", }, ], ):
+        with patch.object(
+            bot,
+            "get_visible_price_options",
+            return_value=[
+                {
+                    "index": 5,
+                    "text": "看台899元",
+                    "tag": "缺货登记",
+                    "source": "ocr",
+                },
+            ],
+        ):
             with patch.object(bot, "_click_visible_price_option") as click_visible:
                 with patch.object(bot, "ultra_fast_click") as fast_click:
                     result = bot._select_price_option()
@@ -2699,7 +3628,9 @@ class TestPriceSelection:
 
         with patch.object(bot, "ultra_fast_click", side_effect=[True, True]):
             with patch.object(bot, "smart_wait_and_click", return_value=False):
-                with patch.object( bot, "verify_order_result", side_effect=["timeout", "success"] ) as verify_result:
+                with patch.object(
+                    bot, "verify_order_result", side_effect=["timeout", "success"]
+                ) as verify_result:
                     result = bot._submit_order_fast(submit_selectors)
 
         assert result == "success"
@@ -2714,7 +3645,11 @@ class TestPriceSelection:
 
         with patch.object(bot, "ultra_fast_click", side_effect=[True, False, False]):
             with patch.object(bot, "smart_wait_and_click", return_value=False):
-                with patch.object( bot, "verify_order_result", side_effect=["timeout", "existing_order"] ) as verify_result:
+                with patch.object(
+                    bot,
+                    "verify_order_result",
+                    side_effect=["timeout", "existing_order"],
+                ) as verify_result:
                     result = bot._submit_order_fast(submit_selectors)
 
         assert result == "existing_order"
@@ -2724,20 +3659,56 @@ class TestPriceSelection:
         """Text-based price match works, index fallback not used."""
         with patch.object(bot, "dismiss_startup_popups"):
             with patch.object(bot, "check_session_valid", return_value=True):
-                with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                with patch.object(
+                    bot,
+                    "probe_current_page",
+                    return_value={
+                        "state": "detail_page",
+                        "purchase_button": True,
+                        "price_container": True,
+                        "quantity_picker": False,
+                        "submit_button": False,
+                    },
+                ):
                     with patch.object(bot, "wait_for_sale_start"):
                         with patch.object(bot, "select_performance_date"):
-                            with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
-                                with patch.object(bot, "_wait_for_submit_ready", return_value=True):
-                                    with patch.object(bot, "smart_wait_and_click", return_value=True):
-                                        with patch.object(bot, "ultra_fast_click", return_value=True) as ufc:
+                            with patch.object(
+                                bot,
+                                "_enter_purchase_flow_from_detail_page",
+                                return_value={
+                                    "state": "sku_page",
+                                    "price_container": True,
+                                    "reservation_mode": False,
+                                },
+                            ):
+                                with patch.object(
+                                    bot, "_wait_for_submit_ready", return_value=True
+                                ):
+                                    with patch.object(
+                                        bot, "smart_wait_and_click", return_value=True
+                                    ):
+                                        with patch.object(
+                                            bot, "ultra_fast_click", return_value=True
+                                        ) as ufc:
                                             with patch.object(bot, "ultra_batch_click"):
-                                                with patch.object(bot, "_submit_order_fast", return_value="success"):
-                                                    with patch("mobile.damai_app.time") as mock_time:
-                                                        mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
+                                                with patch.object(
+                                                    bot,
+                                                    "_submit_order_fast",
+                                                    return_value="success",
+                                                ):
+                                                    with patch(
+                                                        "mobile.damai_app.time"
+                                                    ) as mock_time:
+                                                        mock_time.time.side_effect = (
+                                                            _make_time_side_effect(
+                                                                0.0, 1.5
+                                                            )
+                                                        )
                                                         bot.driver.find_elements.return_value = []
 
-                                                        result = bot.run_ticket_grabbing()
+                                                        result = (
+                                                            bot.run_ticket_grabbing()
+                                                        )
 
         assert result is True
         # ultra_fast_click should have been called with the price text selector
@@ -2767,25 +3738,93 @@ class TestPriceSelection:
             with caplog.at_level("INFO"):
                 with patch.object(bot, "dismiss_startup_popups"):
                     with patch.object(bot, "check_session_valid", return_value=True):
-                        with patch.object( bot, "probe_current_page", return_value={ "state": "detail_page", "purchase_button": True, "price_container": True, "quantity_picker": False, "submit_button": False, }, ):
+                        with patch.object(
+                            bot,
+                            "probe_current_page",
+                            return_value={
+                                "state": "detail_page",
+                                "purchase_button": True,
+                                "price_container": True,
+                                "quantity_picker": False,
+                                "submit_button": False,
+                            },
+                        ):
                             with patch.object(bot, "wait_for_sale_start"):
                                 with patch.object(bot, "select_performance_date"):
-                                    with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value={ "state": "sku_page", "price_container": True, "reservation_mode": False, }, ):
-                                        with patch.object(bot, "_wait_for_submit_ready", return_value=True):
-                                            with patch.object(bot, "smart_wait_and_click", return_value=True):
-                                                with patch.object( bot, "ultra_fast_click", side_effect=ultra_fast_click_side_effect ):
-                                                    with patch.object(bot, "ultra_batch_click"):
-                                                        with patch.object(bot, "_submit_order_fast", return_value="success"):
-                                                            with patch("mobile.damai_app.time") as mock_time:
-                                                                mock_time.time.side_effect = _make_time_side_effect(0.0, 1.5)
+                                    with patch.object(
+                                        bot,
+                                        "_enter_purchase_flow_from_detail_page",
+                                        return_value={
+                                            "state": "sku_page",
+                                            "price_container": True,
+                                            "reservation_mode": False,
+                                        },
+                                    ):
+                                        with patch.object(
+                                            bot,
+                                            "_wait_for_submit_ready",
+                                            return_value=True,
+                                        ):
+                                            with patch.object(
+                                                bot,
+                                                "smart_wait_and_click",
+                                                return_value=True,
+                                            ):
+                                                with patch.object(
+                                                    bot,
+                                                    "ultra_fast_click",
+                                                    side_effect=ultra_fast_click_side_effect,
+                                                ):
+                                                    with patch.object(
+                                                        bot, "ultra_batch_click"
+                                                    ):
+                                                        with patch.object(
+                                                            bot,
+                                                            "_submit_order_fast",
+                                                            return_value="success",
+                                                        ):
+                                                            with patch(
+                                                                "mobile.damai_app.time"
+                                                            ) as mock_time:
+                                                                mock_time.time.side_effect = _make_time_side_effect(
+                                                                    0.0, 1.5
+                                                                )
                                                                 # Mock price container for index-based fallback
-                                                                mock_target = _make_mock_element()
-                                                                with patch.object( bot._price_sel, "_click_price_card_element", return_value=False ):
-                                                                    with patch.object(bot, "_find", return_value=Mock()):
-                                                                        with patch.object( bot, "_container_find_elements", return_value=[mock_target, mock_target], ):
-                                                                            with patch.object(bot, "_is_clickable", return_value=True):
-                                                                                with patch.object(bot, "_click_element_center"):
-                                                                                    with patch.object( bot, "_ensure_attendees_selected_on_confirm_page", return_value=True, ):
+                                                                mock_target = (
+                                                                    _make_mock_element()
+                                                                )
+                                                                with patch.object(
+                                                                    bot._price_sel,
+                                                                    "_click_price_card_element",
+                                                                    return_value=False,
+                                                                ):
+                                                                    with patch.object(
+                                                                        bot,
+                                                                        "_find",
+                                                                        return_value=Mock(),
+                                                                    ):
+                                                                        with patch.object(
+                                                                            bot,
+                                                                            "_container_find_elements",
+                                                                            return_value=[
+                                                                                mock_target,
+                                                                                mock_target,
+                                                                            ],
+                                                                        ):
+                                                                            with patch.object(
+                                                                                bot,
+                                                                                "_is_clickable",
+                                                                                return_value=True,
+                                                                            ):
+                                                                                with patch.object(
+                                                                                    bot,
+                                                                                    "_click_element_center",
+                                                                                ):
+                                                                                    with patch.object(
+                                                                                        bot,
+                                                                                        "_ensure_attendees_selected_on_confirm_page",
+                                                                                        return_value=True,
+                                                                                    ):
                                                                                         result = bot.run_ticket_grabbing()
         finally:
             _price_logger.propagate = False
@@ -3025,14 +4064,18 @@ class TestSmartWaitForElement:
 
 class TestWaitForPageState:
     def test_returns_last_probe_on_timeout(self, bot):
-        with patch.object( bot, "probe_current_page", return_value={"state": "unknown_state"} ):
+        with patch.object(
+            bot, "probe_current_page", return_value={"state": "unknown_state"}
+        ):
             with patch("mobile.damai_app.time.time", side_effect=[0.0, 10.0, 20.0]):
                 with patch("mobile.damai_app.time.sleep"):
                     result = bot.wait_for_page_state({"order_confirm_page"}, timeout=5)
         assert result["state"] == "unknown_state"
 
     def test_returns_immediately_on_matching_state(self, bot):
-        with patch.object( bot, "probe_current_page", return_value={"state": "detail_page"} ):
+        with patch.object(
+            bot, "probe_current_page", return_value={"state": "detail_page"}
+        ):
             with patch("mobile.damai_app.time.time", side_effect=[0.0, 1.0]):
                 with patch("mobile.damai_app.time.sleep"):
                     result = bot.wait_for_page_state({"detail_page"})
@@ -3089,12 +4132,24 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with patch.object( bot, "_wait_for_purchase_entry_result", return_value={"state": "sku_page"}, ):
-            with patch.object(bot, "_click_price_option_by_config_index") as price_click:
+        with patch.object(
+            bot,
+            "_wait_for_purchase_entry_result",
+            return_value={"state": "sku_page"},
+        ):
+            with patch.object(
+                bot, "_click_price_option_by_config_index"
+            ) as price_click:
                 with patch.object(bot, "_click_sku_buy_button_element") as buy_click:
                     with patch.object(bot, "_click_coordinates") as click_coords:
-                        with patch.object( bot._pipeline, "_confirm_page_ready", side_effect=[False, True] ):
-                            result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
+                        with patch.object(
+                            bot._pipeline,
+                            "_confirm_page_ready",
+                            side_effect=[False, True],
+                        ):
+                            result = bot._run_warm_validation_pipeline(
+                                start_time=_time_module.time()
+                            )
 
         assert result is True
         assert mock_d.shell.call_count >= 2
@@ -3131,12 +4186,24 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with patch.object( bot, "_wait_for_purchase_entry_result", return_value={"state": "sku_page"}, ):
-            with patch.object(bot, "_click_price_option_by_config_index") as price_click:
+        with patch.object(
+            bot,
+            "_wait_for_purchase_entry_result",
+            return_value={"state": "sku_page"},
+        ):
+            with patch.object(
+                bot, "_click_price_option_by_config_index"
+            ) as price_click:
                 with patch.object(bot, "_click_sku_buy_button_element") as buy_click:
                     with patch.object(bot, "_click_coordinates"):
-                        with patch.object( bot._pipeline, "_confirm_page_ready", side_effect=[False, True] ):
-                            result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
+                        with patch.object(
+                            bot._pipeline,
+                            "_confirm_page_ready",
+                            side_effect=[False, True],
+                        ):
+                            result = bot._run_warm_validation_pipeline(
+                                start_time=_time_module.time()
+                            )
 
         assert result is True
         assert mock_d.shell.call_count >= 2
@@ -3161,10 +4228,20 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with patch.object( bot, "_wait_for_purchase_entry_result", return_value={"state": "sku_page"}, ):
-            with patch.object(bot, "_click_price_option_by_config_index", return_value=True):
-                with patch.object(bot, "_click_sku_buy_button_element", return_value=True):
-                    with patch.object(bot._pipeline, "_confirm_page_ready", side_effect=False):
+        with patch.object(
+            bot,
+            "_wait_for_purchase_entry_result",
+            return_value={"state": "sku_page"},
+        ):
+            with patch.object(
+                bot, "_click_price_option_by_config_index", return_value=True
+            ):
+                with patch.object(
+                    bot, "_click_sku_buy_button_element", return_value=True
+                ):
+                    with patch.object(
+                        bot._pipeline, "_confirm_page_ready", side_effect=False
+                    ):
                         with patch("mobile.damai_app.time") as mock_time:
                             mock_time.time = Mock(side_effect=[100.0, 100.0, 109.0])
                             mock_time.sleep = Mock()
@@ -3189,13 +4266,29 @@ class TestWarmValidationPipeline:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
 
-        with patch.object( bot, "_wait_for_purchase_entry_result", side_effect=[None, {"state": "sku_page"}], ):
-            with patch.object( bot._pipeline, "_shell_price_and_buy_until_confirm", return_value=False ):
-                with patch.object(bot, "_click_price_option_by_config_index", return_value=True):
-                    with patch.object( bot, "_click_sku_buy_button_element", return_value=True ) as buy_click:
+        with patch.object(
+            bot,
+            "_wait_for_purchase_entry_result",
+            side_effect=[None, {"state": "sku_page"}],
+        ):
+            with patch.object(
+                bot._pipeline, "_shell_price_and_buy_until_confirm", return_value=False
+            ):
+                with patch.object(
+                    bot, "_click_price_option_by_config_index", return_value=True
+                ):
+                    with patch.object(
+                        bot, "_click_sku_buy_button_element", return_value=True
+                    ) as buy_click:
                         with patch.object(bot, "_click_coordinates") as click_coords:
-                            with patch.object( bot._pipeline, "_confirm_page_ready", side_effect=[False, True] ):
-                                result = bot._run_warm_validation_pipeline(start_time=_time_module.time())
+                            with patch.object(
+                                bot._pipeline,
+                                "_confirm_page_ready",
+                                side_effect=[False, True],
+                            ):
+                                result = bot._run_warm_validation_pipeline(
+                                    start_time=_time_module.time()
+                                )
 
         assert result is True
         detail_calls = [
@@ -3229,7 +4322,9 @@ class TestWarmValidationPipeline:
         initial_probe = {"state": "detail_page", "purchase_button": True}
 
         with patch.object(bot, "_run_warm_validation_pipeline") as pipeline:
-            with patch.object( bot, "_enter_purchase_flow_from_detail_page", return_value=None ):
+            with patch.object(
+                bot, "_enter_purchase_flow_from_detail_page", return_value=None
+            ):
                 result = bot.run_ticket_grabbing(initial_page_probe=initial_probe)
 
         pipeline.assert_not_called()  # _has_warm_pipeline_coords returned False
@@ -3258,7 +4353,11 @@ class TestRecoverToDetailPage:
         # First probe_current_page call (after dismiss_startup_popups) returns order_confirm;
         # second call (in back-loop with fast=True) returns detail_page.
         with patch.object(bot, "dismiss_startup_popups"):
-            with patch.object( bot, "probe_current_page", side_effect=[{"state": "order_confirm_page"}, detail_result], ) as probe_mock:
+            with patch.object(
+                bot,
+                "probe_current_page",
+                side_effect=[{"state": "order_confirm_page"}, detail_result],
+            ) as probe_mock:
                 with patch.object(bot, "_press_keycode_safe", return_value=True):
                     result = bot._recover_to_detail_page_for_local_retry(initial_probe)
         assert result["state"] == "detail_page"
@@ -3320,7 +4419,9 @@ class TestRushPreSelectViaXml:
         if hasattr(bot, "_pipeline"):
             bot._pipeline._device = mock_d
         with patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False):
-            with patch.object( bot, "_dump_hierarchy_xml", return_value=ET.fromstring(self.DETAIL_XML) ):
+            with patch.object(
+                bot, "_dump_hierarchy_xml", return_value=ET.fromstring(self.DETAIL_XML)
+            ):
                 result = bot._rush_preselect_and_buy_via_xml()
 
         assert result is True
@@ -3345,7 +4446,11 @@ class TestRushPreSelectViaXml:
         mock_d = Mock()
         bot.d = mock_d
         with patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False):
-            with patch.object( bot, "_dump_hierarchy_xml", return_value=ET.fromstring(self.DETAIL_XML_NO_CITY), ):
+            with patch.object(
+                bot,
+                "_dump_hierarchy_xml",
+                return_value=ET.fromstring(self.DETAIL_XML_NO_CITY),
+            ):
                 result = bot._rush_preselect_and_buy_via_xml()
 
         assert result is True
@@ -3365,7 +4470,9 @@ class TestRushPreSelectViaXml:
         mock_d = Mock()
         bot.d = mock_d
         with patch.object(bot, "_dismiss_fast_blocking_dialogs", return_value=False):
-            with patch.object( bot, "_dump_hierarchy_xml", return_value=ET.fromstring(no_buy_xml) ):
+            with patch.object(
+                bot, "_dump_hierarchy_xml", return_value=ET.fromstring(no_buy_xml)
+            ):
                 result = bot._rush_preselect_and_buy_via_xml()
 
         assert result is False
@@ -3391,8 +4498,12 @@ class TestRushPreSelectViaXml:
             "price_container": True,
             "reservation_mode": False,
         }
-        with patch.object( bot, "_rush_preselect_and_buy_via_xml", return_value=True ) as xml_method:
-            with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ):
+        with patch.object(
+            bot, "_rush_preselect_and_buy_via_xml", return_value=True
+        ) as xml_method:
+            with patch.object(
+                bot, "_wait_for_purchase_entry_result", return_value=next_probe
+            ):
                 result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         assert result == next_probe
@@ -3410,7 +4521,9 @@ class TestRushPreSelectViaXml:
         }
         with patch.object(bot, "_rush_preselect_and_buy_via_xml") as xml_method:
             with patch.object(bot, "_cached_tap", return_value=True):
-                with patch.object( bot, "_wait_for_purchase_entry_result", return_value=next_probe ):
+                with patch.object(
+                    bot, "_wait_for_purchase_entry_result", return_value=next_probe
+                ):
                     result = bot._enter_purchase_flow_from_detail_page(prepared=False)
 
         xml_method.assert_not_called()  # warm path, skip XML dump
@@ -3743,3 +4856,44 @@ class TestSaleReadyTexts:
             f"wait_for_sale_start should detect 立即预订 quickly, took {wall_elapsed:.3f}s"
         )
         assert getattr(bot, "_last_sale_ready_text", None) == "立即预订"
+
+
+# ---------------------------------------------------------------------------
+# Price failure dump (P1 #31, Step 2)
+# ---------------------------------------------------------------------------
+
+
+class TestSavePriceFailureDump:
+    def test_writes_xml_to_tmp_dir(self, bot, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        bot.d.dump_hierarchy = Mock(return_value="<hierarchy/>")
+        bot.d.screenshot = Mock()
+        result = bot._save_price_failure_dump(reason="empty cards")
+        assert result is not None
+        assert result.parent.name == "tmp"
+        assert result.suffix == ".xml"
+        assert result.read_text(encoding="utf-8") == "<hierarchy/>"
+        # screenshot best-effort
+        bot.d.screenshot.assert_called_once()
+
+    def test_returns_none_when_dump_hierarchy_empty(self, bot, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        bot.d.dump_hierarchy = Mock(return_value="")
+        result = bot._save_price_failure_dump()
+        assert result is None
+        # tmp/ created but no file written
+        assert not any(tmp_path.glob("tmp/price_dump_*.xml"))
+
+    def test_screenshot_failure_does_not_break_xml(self, bot, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        bot.d.dump_hierarchy = Mock(return_value="<hierarchy/>")
+        bot.d.screenshot = Mock(side_effect=RuntimeError("no screen"))
+        result = bot._save_price_failure_dump(reason="boom")
+        assert result is not None
+        assert result.exists()
+
+    def test_dump_hierarchy_exception_returns_none(self, bot, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        bot.d.dump_hierarchy = Mock(side_effect=RuntimeError("device gone"))
+        result = bot._save_price_failure_dump()
+        assert result is None

--- a/tests/unit/test_page_probe_panel_state.py
+++ b/tests/unit/test_page_probe_panel_state.py
@@ -1,0 +1,100 @@
+"""Unit tests for mobile.page_probe.detect_price_panel_state (P1 #31)."""
+
+from unittest.mock import MagicMock
+
+from mobile.page_probe import detect_price_panel_state
+
+
+def _driver_with_existence(matchers: dict):
+    """Mock driver where ``driver(**selector).exists`` is True iff
+    one of the (kwarg, value) pairs in ``matchers`` matches.
+    """
+    driver = MagicMock()
+
+    def _select(**kwargs):
+        for k, v in kwargs.items():
+            if (k, v) in matchers:
+                el = MagicMock()
+                el.exists = True
+                return el
+        el = MagicMock()
+        el.exists = False
+        return el
+
+    driver.side_effect = _select
+    return driver
+
+
+class TestDetectPricePanelState:
+    def test_loading_when_spinner_present(self):
+        driver = _driver_with_existence(
+            {("resourceId", "cn.damai:id/sku_loading"): True}
+        )
+        assert detect_price_panel_state(driver) == "loading"
+
+    def test_loading_when_progress_present(self):
+        driver = _driver_with_existence(
+            {("resourceId", "cn.damai:id/loading_progress"): True}
+        )
+        assert detect_price_panel_state(driver) == "loading"
+
+    def test_loading_when_view_present(self):
+        driver = _driver_with_existence(
+            {("resourceId", "cn.damai:id/loading_view"): True}
+        )
+        assert detect_price_panel_state(driver) == "loading"
+
+    def test_sold_out_text(self):
+        driver = _driver_with_existence({("text", "已售罄"): True})
+        assert detect_price_panel_state(driver) == "sold_out"
+
+    def test_sold_out_text_contains(self):
+        driver = _driver_with_existence({("textContains", "全部售罄"): True})
+        assert detect_price_panel_state(driver) == "sold_out"
+
+    def test_sold_out_no_ticket(self):
+        driver = _driver_with_existence({("text", "无票"): True})
+        assert detect_price_panel_state(driver) == "sold_out"
+
+    def test_ready_primary_container(self):
+        driver = _driver_with_existence(
+            {
+                (
+                    "resourceId",
+                    "cn.damai:id/project_detail_perform_price_flowlayout",
+                ): True
+            }
+        )
+        assert detect_price_panel_state(driver) == "ready"
+
+    def test_ready_layout_price(self):
+        driver = _driver_with_existence(
+            {("resourceId", "cn.damai:id/layout_price"): True}
+        )
+        assert detect_price_panel_state(driver) == "ready"
+
+    def test_unknown_when_nothing_matches(self):
+        driver = _driver_with_existence({})
+        assert detect_price_panel_state(driver) == "unknown"
+
+    def test_loading_takes_priority_over_sold_out(self):
+        driver = _driver_with_existence(
+            {
+                ("resourceId", "cn.damai:id/loading_progress"): True,
+                ("text", "已售罄"): True,
+            }
+        )
+        assert detect_price_panel_state(driver) == "loading"
+
+    def test_sold_out_takes_priority_over_ready(self):
+        driver = _driver_with_existence(
+            {
+                ("text", "已售罄"): True,
+                ("resourceId", "cn.damai:id/layout_price"): True,
+            }
+        )
+        assert detect_price_panel_state(driver) == "sold_out"
+
+    def test_device_exception_is_swallowed(self):
+        driver = MagicMock(side_effect=RuntimeError("device gone"))
+        assert detect_price_panel_state(driver) == "unknown"

--- a/tests/unit/test_price_selector.py
+++ b/tests/unit/test_price_selector.py
@@ -1,7 +1,99 @@
 """Unit tests for PriceSelector."""
 
 from unittest.mock import MagicMock
-from mobile.price_selector import PriceSelector
+
+import pytest
+
+from mobile.price_selector import (
+    PriceCard,
+    PriceSelector,
+    PriceSelectorError,
+    SoldOutError,
+    select_price_by_index,
+)
+
+
+# ---------------------------------------------------------------------------
+# select_price_by_index — boundary guard (P1 #31, Step 1)
+# ---------------------------------------------------------------------------
+
+
+def _card(index: int, text: str = "", **kw) -> PriceCard:
+    return PriceCard(index=index, price_text=text, **kw)
+
+
+class TestSelectPriceByIndexFunctional:
+    def test_returns_card_when_index_in_range(self):
+        cards = [_card(0, "380元"), _card(1, "580元"), _card(2, "880元")]
+        assert select_price_by_index(cards, 1) is cards[1]
+
+    def test_empty_cards_raises_with_three_reasons(self):
+        with pytest.raises(PriceSelectorError) as exc_info:
+            select_price_by_index([], 0)
+        message = str(exc_info.value)
+        assert "未发现可点击价格卡片" in message
+        assert "尚未开售" in message
+        assert "已售罄" in message
+        assert "UI 变更" in message
+
+    def test_negative_index_raises_with_available_listing(self):
+        cards = [_card(0, "380元"), _card(1, "580元")]
+        with pytest.raises(PriceSelectorError) as exc_info:
+            select_price_by_index(cards, -1)
+        message = str(exc_info.value)
+        assert "price_index=-1" in message
+        assert "[0] 380元" in message
+        assert "[1] 580元" in message
+        assert "config.jsonc" in message
+
+    def test_out_of_range_raises_with_available_listing(self):
+        cards = [_card(0, "380元"), _card(1, "580元", tag="缺货")]
+        with pytest.raises(PriceSelectorError) as exc_info:
+            select_price_by_index(cards, 5)
+        message = str(exc_info.value)
+        assert "0..1" in message
+        assert "[1] 580元 [缺货]" in message
+
+    def test_dump_writer_invoked_on_empty_cards(self, tmp_path):
+        dump_path = tmp_path / "price_dump.xml"
+        writer = MagicMock()
+        with pytest.raises(PriceSelectorError) as exc_info:
+            select_price_by_index([], 0, dump_on_fail=dump_path, dump_writer=writer)
+        writer.assert_called_once_with(dump_path)
+        assert str(dump_path) in str(exc_info.value)
+
+    def test_dump_writer_invoked_on_out_of_range(self, tmp_path):
+        dump_path = tmp_path / "price_dump.xml"
+        writer = MagicMock()
+        cards = [_card(0, "380元")]
+        with pytest.raises(PriceSelectorError):
+            select_price_by_index(cards, 9, dump_on_fail=dump_path, dump_writer=writer)
+        writer.assert_called_once_with(dump_path)
+
+    def test_dump_writer_failure_is_swallowed(self, tmp_path):
+        writer = MagicMock(side_effect=OSError("disk full"))
+        with pytest.raises(PriceSelectorError) as exc_info:
+            select_price_by_index(
+                [], 0, dump_on_fail=tmp_path / "x.xml", dump_writer=writer
+            )
+        # No "UI dump" suffix because save failed
+        assert "UI dump 已保存" not in str(exc_info.value)
+
+    def test_dump_path_without_writer_is_noop(self, tmp_path):
+        with pytest.raises(PriceSelectorError) as exc_info:
+            select_price_by_index([], 0, dump_on_fail=tmp_path / "x.xml")
+        assert "UI dump 已保存" not in str(exc_info.value)
+
+
+class TestPriceSelectorErrorTypes:
+    def test_price_selector_error_is_runtime_error(self):
+        assert issubclass(PriceSelectorError, RuntimeError)
+
+    def test_sold_out_error_is_runtime_error(self):
+        assert issubclass(SoldOutError, RuntimeError)
+
+    def test_errors_are_distinct_types(self):
+        assert PriceSelectorError is not SoldOutError
 
 
 class TestSelectByIndex:

--- a/tests/unit/test_price_selector.py
+++ b/tests/unit/test_price_selector.py
@@ -1,6 +1,6 @@
 """Unit tests for PriceSelector."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -11,6 +11,20 @@ from mobile.price_selector import (
     SoldOutError,
     select_price_by_index,
 )
+
+
+@pytest.fixture(autouse=True)
+def _force_price_panel_ready():
+    """Most legacy PriceSelector tests do not care about page_probe state.
+
+    Default to ``"ready"`` so the new pre-flight check does not turn passive
+    MagicMock device probes into accidental ``loading`` / ``sold_out``.
+    Individual state tests patch this themselves.
+    """
+    with patch(
+        "mobile.page_probe.detect_price_panel_state", return_value="ready"
+    ) as mocked:
+        yield mocked
 
 
 # ---------------------------------------------------------------------------
@@ -356,3 +370,65 @@ class TestGetPriceCoordsFromXml:
             xml_root=xml_small
         )
         assert result is not None  # retry succeeded
+
+
+# ---------------------------------------------------------------------------
+# Page-probe integration (P1 #31, Step 3)
+# ---------------------------------------------------------------------------
+
+
+class TestSelectByIndexPanelStateIntegration:
+    def _make_selector(self, *, coords=(10, 20)):
+        bot = MagicMock()
+        bot._get_price_option_coordinates_by_config_index.return_value = coords
+        selector = PriceSelector(
+            device=MagicMock(),
+            config=MagicMock(price_index=0),
+            probe=MagicMock(),
+        )
+        selector.set_bot(bot)
+        return selector
+
+    def test_sold_out_raises_sold_out_error(self, _force_price_panel_ready):
+        _force_price_panel_ready.return_value = "sold_out"
+        selector = self._make_selector()
+        with pytest.raises(SoldOutError):
+            selector.select_by_index()
+
+    def test_loading_then_ready_succeeds(self, _force_price_panel_ready):
+        _force_price_panel_ready.side_effect = ["loading", "ready"]
+        selector = self._make_selector()
+        with patch("time.sleep") as mock_sleep:
+            with patch(
+                "time.monotonic",
+                side_effect=[0.0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3],
+            ):
+                assert selector.select_by_index() is True
+        assert mock_sleep.called
+
+    def test_loading_timeout_raises_price_selector_error(
+        self, _force_price_panel_ready
+    ):
+        _force_price_panel_ready.return_value = "loading"
+        selector = self._make_selector()
+        # monotonic: first start = 0.0, deadline = 2.0; subsequent values jump past
+        with patch("time.sleep"):
+            with patch("time.monotonic", side_effect=[0.0, 0.5, 1.0, 1.5, 2.5]):
+                with pytest.raises(PriceSelectorError, match="加载超时"):
+                    selector.select_by_index()
+
+    def test_unknown_logs_warning_and_continues(self, _force_price_panel_ready):
+        _force_price_panel_ready.return_value = "unknown"
+        selector = self._make_selector()
+        with patch("mobile.price_selector.logger") as mock_logger:
+            assert selector.select_by_index() is True
+        warning_calls = [c for c in mock_logger.warning.call_args_list]
+        assert any("state=unknown" in str(c) for c in warning_calls)
+
+    def test_ready_proceeds_without_warning(self, _force_price_panel_ready):
+        _force_price_panel_ready.return_value = "ready"
+        selector = self._make_selector()
+        with patch("mobile.price_selector.logger") as mock_logger:
+            assert selector.select_by_index() is True
+        warning_calls = [c for c in mock_logger.warning.call_args_list]
+        assert not any("state=unknown" in str(c) for c in warning_calls)


### PR DESCRIPTION
## Summary
- 新增 PriceSelectorError / SoldOutError 异常 + 明细错误信息（列举可用价档）
- 价格选择失败自动保存 UI dump 到 tmp/（gitignored）便于事后分析
- page_probe 区分 loading/ready/sold_out/unknown 四态，避免误判
- Config.load_config() 增加 price_index 范围校验（负值拒绝、>50 警告）

## Test plan
- [x] poetry run test 全绿（965 passed）
- [x] 覆盖率 80.80% ≥ 80%
- [ ] 手动构造 price_index=-1 应在 config 加载期立即拒绝（已加单测覆盖）
- [ ] 手动构造无价格卡片场景，应抛 PriceSelectorError 含可用价档清单（已加单测覆盖）

## Commits (4)
- feat(mobile): #31 新增 PriceSelectorError/SoldOutError 异常 + 越界明细诊断
- feat(mobile): #31 价格选择失败自动 dump tmp/price_dump_*.xml
- feat(mobile): #31 detect_price_panel_state 区分 loading/ready/sold_out/unknown
- fix(mobile): #31 config 加载期校验 price_index 范围

## 关联
- Closes #31
- 关联 fix-plan: reference/05-fix-plans/p1-31-price-index.md