### PR TITLE
feat(mobile): #25 多场次状态机分支 + select_session + rush_mode 子开关

### DIFF
--- a/docs/mobile-ticket-logic.md
+++ b/docs/mobile-ticket-logic.md
@@ -316,6 +316,30 @@ flowchart TD
 - 匹配成功则点击对应日期，失败则使用默认场次
 - 超时仅 1 秒，不阻塞主流程
 
+#### 多场次活动配置示例
+
+巡演 / 音乐节 / 多日演出在 SKU 面板会先出现「请选择场次」/「选择日期」卡片。
+`page_probe` 识别后会进入 `session_picker` 状态并调用
+`event_navigator.select_session()`，匹配优先级：
+`date + city` 精确 → `date` 唯一 → `fallback_index=0`。
+
+```jsonc
+{
+  "keyword": "张杰 演唱会",
+  "users": ["张三"],
+  "city": "上海",          // 巡演 → 同一日期可能多城，city 是去重关键
+  "date": "04.06",          // 统一为 MM.DD 格式（normalize_date 输出）
+  "price": "780元",
+  "price_index": 2,
+  "rush_skip_session": false  // 多场次必须 false；alias rush_mode=true 也会强制 false
+}
+```
+
+匹配失败会抛 `SessionNotFoundError` 并将运行结果标为
+`session_not_found`，不会盲点。日期格式可写
+`4月6号 / 04-06 / 04.06 / 2026-04-06`，`date_utils.normalize_date()` 统一归一为
+`MM.DD` 后再比对。
+
 ### 11. 改进的票价选择
 
 票价选择采用两级策略：

--- a/mobile/config.example.jsonc
+++ b/mobile/config.example.jsonc
@@ -37,8 +37,18 @@
   "countdown_lead_ms": 3000,
 
   // ── 性能调优 ──
-  // 极速模式：信任 price_index 跳过冗余 UI 读取，推荐开启
+  // 极速模式：信任 price_index 跳过冗余 UI 读取，推荐开启。
+  // rush_mode 是下面 3 个子开关的 alias；显式设置子开关可获更细控制。
   "rush_mode": true,
+  // ── rush 子开关（rush_mode 的细粒度版本） ──
+  // 多场次活动跳过场次选择 → 永远不要在多场次场景开启（issue #25 根因）。
+  // 单场次活动可设 true 略微加速。即便此处填 true，多场次场景下系统也会
+  // 强制选场并 warning 日志。
+  "rush_skip_session": false,
+  // 价格选择失败时是否跳过 UI dump（dump 写到 tmp/price_dump_*.xml 帮助排查）
+  "rush_skip_price_dump": true,
+  // 失败后的激进快速重试（缩短退避、增加并发轮询）
+  "rush_aggressive_retry": true,
   // 快速重试次数（不重建 driver）
   "fast_retry_count": 8,
   // 快速重试间隔（毫秒）

--- a/mobile/config.py
+++ b/mobile/config.py
@@ -141,6 +141,9 @@ class Config:
         fast_retry_count=8,
         fast_retry_interval_ms=120,
         rush_mode=False,
+        rush_skip_session=False,
+        rush_skip_price_dump=True,
+        rush_aggressive_retry=True,
         auto_navigate=True,
         target_title=None,
         target_venue=None,
@@ -258,6 +261,14 @@ class Config:
         if not isinstance(rush_mode, bool):
             raise ValueError(f"rush_mode 必须是布尔值，实际值: {rush_mode!r}")
 
+        for _name, _value in (
+            ("rush_skip_session", rush_skip_session),
+            ("rush_skip_price_dump", rush_skip_price_dump),
+            ("rush_aggressive_retry", rush_aggressive_retry),
+        ):
+            if not isinstance(_value, bool):
+                raise ValueError(f"{_name} 必须是布尔值，实际值: {_value!r}")
+
         self.keyword = keyword.strip()
         self.users = users
         self.city = city
@@ -274,6 +285,30 @@ class Config:
         self.fast_retry_count = fast_retry_count
         self.fast_retry_interval_ms = fast_retry_interval_ms
         self.rush_mode = rush_mode
+        # rush_mode 是 alias：当前 release 周期保留兼容；W4 评估废弃。
+        # 解析规则：rush_mode=True 时统一翻转 3 个子开关到「快速」侧；
+        # 但 rush_skip_session 强制为 False — 多场次场景下永远不能跳过选场（issue #25 根因）。
+        if rush_mode:
+            if rush_skip_session:
+                logger.warning(
+                    "rush_mode=True 不会启用 rush_skip_session（多场次场景需选场）"
+                )
+            self.rush_skip_session = False
+            self.rush_skip_price_dump = rush_skip_price_dump
+            self.rush_aggressive_retry = rush_aggressive_retry
+        else:
+            self.rush_skip_session = rush_skip_session
+            self.rush_skip_price_dump = rush_skip_price_dump
+            self.rush_aggressive_retry = rush_aggressive_retry
+
+        logger.info(
+            "rush effective: rush_mode=%s, skip_session=%s, skip_price_dump=%s, aggressive_retry=%s",
+            self.rush_mode,
+            self.rush_skip_session,
+            self.rush_skip_price_dump,
+            self.rush_aggressive_retry,
+        )
+
         self.auto_navigate = auto_navigate
         self.target_title = (
             target_title.strip() if isinstance(target_title, str) else None
@@ -306,6 +341,9 @@ class Config:
             "fast_retry_count": self.fast_retry_count,
             "fast_retry_interval_ms": self.fast_retry_interval_ms,
             "rush_mode": self.rush_mode,
+            "rush_skip_session": self.rush_skip_session,
+            "rush_skip_price_dump": self.rush_skip_price_dump,
+            "rush_aggressive_retry": self.rush_aggressive_retry,
         }
 
     @staticmethod
@@ -358,6 +396,9 @@ class Config:
             fast_retry_count=config.get("fast_retry_count", 8),
             fast_retry_interval_ms=config.get("fast_retry_interval_ms", 120),
             rush_mode=config.get("rush_mode", False),
+            rush_skip_session=config.get("rush_skip_session", False),
+            rush_skip_price_dump=config.get("rush_skip_price_dump", True),
+            rush_aggressive_retry=config.get("rush_aggressive_retry", True),
             auto_navigate=config.get("auto_navigate", True),
             target_title=config.get("target_title"),
             target_venue=config.get("target_venue"),

--- a/mobile/damai_app.py
+++ b/mobile/damai_app.py
@@ -52,10 +52,14 @@ except ImportError:
 
 try:
     from mobile.buy_button_guard import BuyButtonGuard
-    from mobile.page_probe import PageProbe
+    from mobile.page_probe import PageProbe, PageState
     from mobile.fast_pipeline import FastPipeline, poll_until, batch_shell_taps
     from mobile.recovery import RecoveryHelper
-    from mobile.event_navigator import EventNavigator
+    from mobile.event_navigator import (
+        EventNavigator,
+        SessionNotFoundError,
+        select_session,
+    )
     from mobile.price_selector import (
         PriceSelector,
         PriceSelectorError,
@@ -64,10 +68,12 @@ try:
     from mobile.attendee_selector import AttendeeSelector
 except ImportError:
     from buy_button_guard import BuyButtonGuard
-    from page_probe import PageProbe
+    from page_probe import PageProbe  # type: ignore[no-redef]
     from fast_pipeline import FastPipeline
     from recovery import RecoveryHelper
-    from event_navigator import EventNavigator
+    from event_navigator import (  # type: ignore[no-redef]
+        EventNavigator,
+    )
     from price_selector import PriceSelector
     from attendee_selector import AttendeeSelector
 
@@ -808,6 +814,38 @@ class DamaiBot(UIPrimitives):
             logger.info(f"选择场次日期: {self.config.date}")
         else:
             logger.debug(f"未找到日期 '{self.config.date}'，使用默认场次")
+
+    def _handle_session_picker(self):
+        """SESSION_PICKER 状态下按 config.date / config.city 选定场次。
+
+        优先级与 :func:`mobile.event_navigator.select_session` 一致：
+        date+city > date 唯一 > fallback_index(0)。多场次场景下永不跳过，
+        即便 rush_skip_session=True 也强制选场（issue #25 根因防御）。
+        """
+        try:
+            from mobile.date_utils import normalize_date
+        except ImportError:  # pragma: no cover
+            from date_utils import normalize_date  # type: ignore[no-redef]
+
+        normalised_date = normalize_date(self.config.date) if self.config.date else None
+        try:
+            chosen_idx = select_session(
+                self.d,
+                date=normalised_date,
+                city=self.config.city,
+                fallback_index=0,
+            )
+            logger.info(
+                "多场次活动：已选定场次 idx=%d (date=%s, city=%s)",
+                chosen_idx,
+                normalised_date,
+                self.config.city,
+            )
+            return True
+        except SessionNotFoundError as exc:
+            logger.error("多场次活动：select_session 失败 — %s", exc)
+            self._set_terminal_failure("session_not_found")
+            return False
 
     def _select_city_from_detail_page(self, timeout=1.0):
         """Select the configured city on the detail page."""
@@ -1618,7 +1656,11 @@ class DamaiBot(UIPrimitives):
                 )
                 return True
 
-            if page_probe["state"] not in {"detail_page", "sku_page"} or (
+            if page_probe["state"] not in {
+                "detail_page",
+                "sku_page",
+                PageState.SESSION_PICKER.value,
+            } or (
                 self.item_detail and not self._current_page_matches_target(page_probe)
             ):
                 if self.config.auto_navigate:
@@ -1699,6 +1741,12 @@ class DamaiBot(UIPrimitives):
                         page_probe["reservation_mode"] = self.is_reservation_sku_mode()
                 else:
                     page_probe = self.probe_current_page()
+
+            # 多场次活动：识别 SESSION_PICKER 后强制选场，避免抢错场次（issue #25）。
+            if page_probe["state"] == PageState.SESSION_PICKER.value:
+                if not self._handle_session_picker():
+                    return False
+                page_probe = self.probe_current_page()
 
             if page_probe["state"] == "sku_page" and page_probe.get("reservation_mode"):
                 logger.warning(

--- a/mobile/damai_app.py
+++ b/mobile/damai_app.py
@@ -827,6 +827,11 @@ class DamaiBot(UIPrimitives):
         except ImportError:  # pragma: no cover
             from date_utils import normalize_date  # type: ignore[no-redef]
 
+        if getattr(self.config, "rush_skip_session", False):
+            logger.warning(
+                "rush_skip_session=True 但当前为多场次场次选择页 — 强制选场避免抢错（issue #25）"
+            )
+
         normalised_date = normalize_date(self.config.date) if self.config.date else None
         try:
             chosen_idx = select_session(

--- a/mobile/event_navigator.py
+++ b/mobile/event_navigator.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import re
 import time
-from typing import TYPE_CHECKING, Any, Dict, Optional
+import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from selenium.webdriver.common.by import By
 
@@ -23,10 +24,209 @@ try:
 except ImportError:
     from item_resolver import normalize_text, city_keyword
 
+try:
+    from mobile.date_utils import normalize_date
+except ImportError:
+    from date_utils import normalize_date  # type: ignore[no-redef]
+
 if TYPE_CHECKING:
     from mobile.page_probe import PageProbe
 
 logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Multi-session selection (P1 #25, Step 2)
+# ---------------------------------------------------------------------------
+
+
+class SessionNotFoundError(RuntimeError):
+    """Raised when :func:`select_session` cannot identify a unique target."""
+
+
+_SESSION_PANEL_RESOURCE_ID = "cn.damai:id/sku_panel_dates"
+_SESSION_DATE_RESOURCE_ID = "cn.damai:id/tv_date"
+_BOUNDS_RE = re.compile(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]")
+
+
+def _parse_bounds_center(bounds_str: Optional[str]) -> Optional[tuple]:
+    if not bounds_str:
+        return None
+    match = _BOUNDS_RE.match(bounds_str)
+    if not match:
+        return None
+    x1, y1, x2, y2 = (int(v) for v in match.groups())
+    return ((x1 + x2) // 2, (y1 + y2) // 2)
+
+
+def _build_parent_map(root: ET.Element) -> Dict[ET.Element, ET.Element]:
+    return {child: parent for parent in root.iter() for child in parent}
+
+
+def _find_clickable_ancestor(
+    parent_map: Dict[ET.Element, ET.Element], node: ET.Element
+) -> Optional[ET.Element]:
+    cur = parent_map.get(node)
+    while cur is not None:
+        if cur.get("clickable") == "true":
+            return cur
+        cur = parent_map.get(cur)
+    return None
+
+
+def _enumerate_sessions_from_xml(xml_str: str) -> List[Dict[str, Any]]:
+    """Parse a u2 hierarchy dump and return one descriptor per session card."""
+    if not xml_str:
+        return []
+    try:
+        root = ET.fromstring(xml_str)
+    except ET.ParseError:
+        return []
+
+    panel = None
+    for node in root.iter("node"):
+        if node.get("resource-id") == _SESSION_PANEL_RESOURCE_ID:
+            panel = node
+            break
+    if panel is None:
+        return []
+
+    parent_map = _build_parent_map(root)
+    cards: List[Dict[str, Any]] = []
+    for date_node in panel.iter("node"):
+        if date_node.get("resource-id") != _SESSION_DATE_RESOURCE_ID:
+            continue
+        clickable = _find_clickable_ancestor(parent_map, date_node) or date_node
+        texts = [
+            (desc.get("text") or "").strip()
+            for desc in clickable.iter("node")
+            if (desc.get("text") or "").strip()
+        ]
+        cards.append(
+            {
+                "index": len(cards),
+                "date": (date_node.get("text") or "").strip(),
+                "text": " ".join(texts),
+                "bounds": clickable.get("bounds") or date_node.get("bounds"),
+            }
+        )
+    return cards
+
+
+def _date_equals(card_date: str, target_date: str) -> bool:
+    if not card_date or not target_date:
+        return False
+    norm_card = normalize_date(card_date) or card_date.strip()
+    norm_target = normalize_date(target_date) or target_date.strip()
+    return norm_card == norm_target
+
+
+def _click_session_card(driver: Any, card: Dict[str, Any]) -> None:
+    coords = _parse_bounds_center(card.get("bounds"))
+    if coords is None:
+        raise SessionNotFoundError(f"无法解析场次卡片 bounds={card.get('bounds')!r}")
+    try:
+        driver.click(*coords)
+    except Exception as exc:  # noqa: BLE001 — surface as SessionNotFoundError
+        raise SessionNotFoundError(f"点击场次卡片失败: {exc}") from exc
+
+
+def select_session(
+    driver: Any,
+    *,
+    date: Optional[str] = None,
+    city: Optional[str] = None,
+    fallback_index: Optional[int] = None,
+) -> int:
+    """Pick a session on the multi-session SKU panel.
+
+    Priority order:
+
+    1. ``date`` + ``city`` exact match (must be unique).
+    2. ``date`` alone if it identifies a unique session.
+    3. ``fallback_index`` (zero-based) if provided.
+
+    Args:
+        driver: A uiautomator2 device (anything with ``dump_hierarchy()``
+            and ``click(x, y)``).
+        date: Target date in ``MM.DD`` format (output of
+            :func:`mobile.date_utils.normalize_date`).
+        city: City keyword expected to appear in the card text.
+        fallback_index: Zero-based card index used when neither ``date``
+            nor ``city`` resolves a unique candidate.
+
+    Returns:
+        The zero-based index of the selected session.
+
+    Raises:
+        SessionNotFoundError: When no unique candidate can be picked.
+    """
+    try:
+        xml_str = driver.dump_hierarchy()
+    except Exception as exc:  # noqa: BLE001
+        raise SessionNotFoundError(f"dump_hierarchy 失败: {exc}") from exc
+
+    cards = _enumerate_sessions_from_xml(xml_str)
+    if not cards:
+        raise SessionNotFoundError(
+            "未发现可选场次（sku_panel_dates 内未找到 tv_date 节点）"
+        )
+
+    chosen: Optional[Dict[str, Any]] = None
+
+    if date and city:
+        matches = [
+            c for c in cards if _date_equals(c["date"], date) and city in c["text"]
+        ]
+        if len(matches) == 1:
+            chosen = matches[0]
+            logger.info(
+                "select_session: date=%s + city=%s 命中 idx=%d/%d",
+                date,
+                city,
+                chosen["index"],
+                len(cards),
+            )
+        elif len(matches) > 1:
+            raise SessionNotFoundError(
+                f"date={date} + city={city} 命中 {len(matches)} 条场次，无法唯一确定"
+            )
+
+    if chosen is None and date:
+        matches = [c for c in cards if _date_equals(c["date"], date)]
+        if len(matches) == 1:
+            chosen = matches[0]
+            logger.info(
+                "select_session: date=%s 唯一命中 idx=%d/%d",
+                date,
+                chosen["index"],
+                len(cards),
+            )
+        elif len(matches) > 1:
+            raise SessionNotFoundError(
+                f"date={date} 命中 {len(matches)} 条场次，需配合 city 才能确定"
+            )
+
+    if chosen is None and fallback_index is not None:
+        if 0 <= fallback_index < len(cards):
+            chosen = cards[fallback_index]
+            logger.warning(
+                "select_session: 回退到 fallback_index=%d (共 %d 条)",
+                fallback_index,
+                len(cards),
+            )
+        else:
+            raise SessionNotFoundError(
+                f"fallback_index={fallback_index} 越界（共 {len(cards)} 条场次）"
+            )
+
+    if chosen is None:
+        raise SessionNotFoundError(
+            f"未提供 date/city/fallback_index，无法选择场次（共 {len(cards)} 条候选）"
+        )
+
+    _click_session_card(driver, chosen)
+    return chosen["index"]
 
 
 class EventNavigator:
@@ -86,7 +286,9 @@ class EventNavigator:
 
         candidates = []
         if bot.item_detail:
-            candidates.extend([bot.item_detail.item_name, bot.item_detail.item_name_display])
+            candidates.extend(
+                [bot.item_detail.item_name, bot.item_detail.item_name_display]
+            )
         if self._config.target_title:
             candidates.append(self._config.target_title)
         if self._config.keyword:
@@ -96,11 +298,16 @@ class EventNavigator:
             normalized_candidate = normalize_text(candidate)
             if not normalized_candidate:
                 continue
-            if normalized_candidate in normalized_title or normalized_title in normalized_candidate:
+            if (
+                normalized_candidate in normalized_title
+                or normalized_title in normalized_candidate
+            ):
                 return True
 
         keyword_tokens = bot._keyword_tokens()
-        if keyword_tokens and all(token in normalized_title for token in keyword_tokens):
+        if keyword_tokens and all(
+            token in normalized_title for token in keyword_tokens
+        ):
             return True
 
         return False
@@ -111,7 +318,11 @@ class EventNavigator:
         if page_probe["state"] not in {"detail_page", "sku_page"}:
             return False
 
-        if not bot.item_detail and not self._config.target_title and not self._config.keyword:
+        if (
+            not bot.item_detail
+            and not self._config.target_title
+            and not self._config.keyword
+        ):
             return True
 
         return bot._title_matches_target(bot._get_detail_title_text())
@@ -128,7 +339,9 @@ class EventNavigator:
 
         for by, value in search_selectors:
             if bot.ultra_fast_click(by, value, timeout=0.8):
-                search_probe = bot.wait_for_page_state({"search_page"}, timeout=2.5, poll_interval=0.15)
+                search_probe = bot.wait_for_page_state(
+                    {"search_page"}, timeout=2.5, poll_interval=0.15
+                )
                 if search_probe["state"] == "search_page":
                     return True
 
@@ -147,10 +360,15 @@ class EventNavigator:
             return False
 
         with bot._timed_step(
-                "搜索页输入并提交关键词",
-                manual_baseline_seconds=_MANUAL_STEP_BASELINES.get("搜索页输入并提交关键词")):
+            "搜索页输入并提交关键词",
+            manual_baseline_seconds=_MANUAL_STEP_BASELINES.get(
+                "搜索页输入并提交关键词"
+            ),
+        ):
             try:
-                search_input = bot._wait_for_element(By.ID, "cn.damai:id/header_search_v2_input", timeout=2)
+                search_input = bot._wait_for_element(
+                    By.ID, "cn.damai:id/header_search_v2_input", timeout=2
+                )
             except TimeoutException:
                 logger.warning("未找到搜索输入框")
                 return False
@@ -161,7 +379,9 @@ class EventNavigator:
             current_text = bot._read_element_text(search_input).strip()
             if current_text and current_text != self._config.keyword:
                 if bot._has_element(By.ID, "cn.damai:id/header_search_v2_input_delete"):
-                    bot.ultra_fast_click(By.ID, "cn.damai:id/header_search_v2_input_delete", timeout=0.4)
+                    bot.ultra_fast_click(
+                        By.ID, "cn.damai:id/header_search_v2_input_delete", timeout=0.4
+                    )
                     time.sleep(0.05)
                 else:
                     try:
@@ -271,39 +491,58 @@ class EventNavigator:
             return
         bot.d.swipe(540, 1770, 540, 520, duration=0.3)
 
-    def _open_target_from_search_results(self, max_scrolls=2, max_results=5, return_details=False):
+    def _open_target_from_search_results(
+        self, max_scrolls=2, max_results=5, return_details=False
+    ):
         """Open the best-matching event from search results and optionally return scanned summaries."""
         bot = self._bot
         seen_titles = set()
         collected = []
 
         with bot._timed_step(
-                "搜索结果扫描并打开目标",
-                manual_baseline_seconds=_MANUAL_STEP_BASELINES.get("搜索结果扫描并打开目标")):
+            "搜索结果扫描并打开目标",
+            manual_baseline_seconds=_MANUAL_STEP_BASELINES.get(
+                "搜索结果扫描并打开目标"
+            ),
+        ):
             for scroll_index in range(max_scrolls + 1):
                 result_cards = bot._find_all(By.ID, "cn.damai:id/ll_search_item")
                 best_match = None
                 best_score = -1
 
                 for card in result_cards:
-                    title_text = bot._safe_element_text(card, By.ID, "cn.damai:id/tv_project_name")
+                    title_text = bot._safe_element_text(
+                        card, By.ID, "cn.damai:id/tv_project_name"
+                    )
                     if not title_text:
                         continue
 
-                    venue_text = bot._safe_element_text(card, By.ID, "cn.damai:id/tv_project_venueName")
-                    city_text = bot._safe_element_text(card, By.ID, "cn.damai:id/tv_project_city").replace("|", "").strip()
-                    time_text = bot._safe_element_text(card, By.ID, "cn.damai:id/tv_project_time")
+                    venue_text = bot._safe_element_text(
+                        card, By.ID, "cn.damai:id/tv_project_venueName"
+                    )
+                    city_text = (
+                        bot._safe_element_text(
+                            card, By.ID, "cn.damai:id/tv_project_city"
+                        )
+                        .replace("|", "")
+                        .strip()
+                    )
+                    time_text = bot._safe_element_text(
+                        card, By.ID, "cn.damai:id/tv_project_time"
+                    )
                     score = bot._score_search_result(title_text, venue_text)
 
                     normalized_title = normalize_text(title_text)
                     if normalized_title and normalized_title not in seen_titles:
-                        collected.append({
-                            "title": title_text,
-                            "venue": venue_text,
-                            "city": city_text,
-                            "time": time_text,
-                            "score": score,
-                        })
+                        collected.append(
+                            {
+                                "title": title_text,
+                                "venue": venue_text,
+                                "city": city_text,
+                                "time": time_text,
+                                "score": score,
+                            }
+                        )
                         seen_titles.add(normalized_title)
 
                     if score > best_score:
@@ -312,19 +551,31 @@ class EventNavigator:
 
                 if best_match is not None and best_score >= 60:
                     bot._click_element_center(best_match)
-                    detail_probe = bot.wait_for_page_state({"detail_page", "sku_page"}, timeout=5.5)
-                    if detail_probe["state"] in {"detail_page", "sku_page"} and bot._current_page_matches_target(detail_probe):
+                    detail_probe = bot.wait_for_page_state(
+                        {"detail_page", "sku_page"}, timeout=5.5
+                    )
+                    if detail_probe["state"] in {
+                        "detail_page",
+                        "sku_page",
+                    } and bot._current_page_matches_target(detail_probe):
                         collected.sort(key=lambda item: item["score"], reverse=True)
-                        details = {"opened": True, "search_results": collected[:max_results]}
+                        details = {
+                            "opened": True,
+                            "search_results": collected[:max_results],
+                        }
                         return details if return_details else True
 
-                    logger.warning("已进入详情页，但标题与目标演出不一致，返回搜索结果继续尝试")
+                    logger.warning(
+                        "已进入详情页，但标题与目标演出不一致，返回搜索结果继续尝试"
+                    )
                     if not bot._press_keycode_safe(4, context="返回搜索列表"):
                         break
                     time.sleep(0.25)
                     bot.dismiss_startup_popups()
                 else:
-                    logger.info(f"本屏搜索结果未找到明确匹配项，已扫描: {len(seen_titles)} 条")
+                    logger.info(
+                        f"本屏搜索结果未找到明确匹配项，已扫描: {len(seen_titles)} 条"
+                    )
 
                 if scroll_index < max_scrolls:
                     bot._scroll_search_results()
@@ -344,7 +595,9 @@ class EventNavigator:
         for scroll_index in range(max_scrolls + 1):
             result_cards = bot._find_all(By.ID, "cn.damai:id/ll_search_item")
             for card in result_cards:
-                title_text = bot._safe_element_text(card, By.ID, "cn.damai:id/tv_project_name")
+                title_text = bot._safe_element_text(
+                    card, By.ID, "cn.damai:id/tv_project_name"
+                )
                 if not title_text:
                     continue
 
@@ -352,20 +605,30 @@ class EventNavigator:
                 if normalized_title in seen:
                     continue
 
-                venue_text = bot._safe_element_text(card, By.ID, "cn.damai:id/tv_project_venueName")
-                city_text = bot._safe_element_text(card, By.ID, "cn.damai:id/tv_project_city").replace("|", "").strip()
-                time_text = bot._safe_element_text(card, By.ID, "cn.damai:id/tv_project_time")
+                venue_text = bot._safe_element_text(
+                    card, By.ID, "cn.damai:id/tv_project_venueName"
+                )
+                city_text = (
+                    bot._safe_element_text(card, By.ID, "cn.damai:id/tv_project_city")
+                    .replace("|", "")
+                    .strip()
+                )
+                time_text = bot._safe_element_text(
+                    card, By.ID, "cn.damai:id/tv_project_time"
+                )
                 price_text = bot._build_compound_price_text(card)
                 score = bot._score_search_result(title_text, venue_text)
 
-                collected.append({
-                    "title": title_text,
-                    "venue": venue_text,
-                    "city": city_text,
-                    "time": time_text,
-                    "price": price_text,
-                    "score": score,
-                })
+                collected.append(
+                    {
+                        "title": title_text,
+                        "venue": venue_text,
+                        "city": city_text,
+                        "time": time_text,
+                        "price": price_text,
+                        "score": score,
+                    }
+                )
                 seen.add(normalized_title)
 
             if len(collected) >= max_results:
@@ -387,13 +650,22 @@ class EventNavigator:
         page_probe = initial_probe or bot.probe_current_page()
         page_probe = bot._recover_to_navigation_start(page_probe)
 
-        if page_probe["state"] in {"detail_page", "sku_page"} and bot._current_page_matches_target(page_probe):
+        if page_probe["state"] in {
+            "detail_page",
+            "sku_page",
+        } and bot._current_page_matches_target(page_probe):
             return True
 
-        if page_probe["state"] in {"detail_page", "sku_page"} and not bot._current_page_matches_target(page_probe):
+        if page_probe["state"] in {
+            "detail_page",
+            "sku_page",
+        } and not bot._current_page_matches_target(page_probe):
             page_probe = bot._exit_non_target_event_context(page_probe)
 
-        if page_probe["state"] in {"detail_page", "sku_page"} and bot._current_page_matches_target(page_probe):
+        if page_probe["state"] in {
+            "detail_page",
+            "sku_page",
+        } and bot._current_page_matches_target(page_probe):
             return True
 
         if page_probe["state"] == "homepage":
@@ -411,14 +683,19 @@ class EventNavigator:
 
         return bot._open_target_from_search_results()
 
-    def discover_target_event(self, keyword_candidates, initial_probe=None, search_scrolls=1, result_limit=5):
+    def discover_target_event(
+        self, keyword_candidates, initial_probe=None, search_scrolls=1, result_limit=5
+    ):
         """Try multiple keywords, collect candidate summaries, and open the best match."""
         bot = self._bot
         bot._last_discovery_step_timings = []
         page_probe = initial_probe or bot.probe_current_page()
         page_probe = bot._recover_to_navigation_start(page_probe)
 
-        if page_probe["state"] in {"detail_page", "sku_page"} and bot._current_page_matches_target(page_probe):
+        if page_probe["state"] in {
+            "detail_page",
+            "sku_page",
+        } and bot._current_page_matches_target(page_probe):
             return {
                 "used_keyword": self._config.keyword,
                 "search_results": [],
@@ -426,10 +703,16 @@ class EventNavigator:
                 "step_timings": list(bot._last_discovery_step_timings),
             }
 
-        if page_probe["state"] in {"detail_page", "sku_page"} and not bot._current_page_matches_target(page_probe):
+        if page_probe["state"] in {
+            "detail_page",
+            "sku_page",
+        } and not bot._current_page_matches_target(page_probe):
             page_probe = bot._exit_non_target_event_context(page_probe)
 
-        if page_probe["state"] in {"detail_page", "sku_page"} and bot._current_page_matches_target(page_probe):
+        if page_probe["state"] in {
+            "detail_page",
+            "sku_page",
+        } and bot._current_page_matches_target(page_probe):
             return {
                 "used_keyword": self._config.keyword,
                 "search_results": [],
@@ -457,7 +740,10 @@ class EventNavigator:
                 probe = bot.probe_current_page()
                 if probe["state"] in {"detail_page", "sku_page"}:
                     probe = bot._exit_non_target_event_context(probe)
-                    if probe["state"] in {"detail_page", "sku_page"} and bot._current_page_matches_target(probe):
+                    if probe["state"] in {
+                        "detail_page",
+                        "sku_page",
+                    } and bot._current_page_matches_target(probe):
                         return {
                             "used_keyword": keyword,
                             "search_results": [],
@@ -470,7 +756,9 @@ class EventNavigator:
                         continue
                     probe = bot.probe_current_page()
                 if probe["state"] != "search_page":
-                    logger.warning(f"重试关键词前页面状态异常: {probe['state']}，跳过该关键词")
+                    logger.warning(
+                        f"重试关键词前页面状态异常: {probe['state']}，跳过该关键词"
+                    )
                     continue
 
             self._config.keyword = keyword
@@ -486,7 +774,9 @@ class EventNavigator:
             )
             search_results = open_result["search_results"]
             if search_results:
-                logger.info(f"搜索到 {len(search_results)} 条候选结果，最高分 {search_results[0]['score']}")
+                logger.info(
+                    f"搜索到 {len(search_results)} 条候选结果，最高分 {search_results[0]['score']}"
+                )
             if open_result["opened"]:
                 page_probe = bot.probe_current_page()
                 return {

--- a/mobile/page_probe.py
+++ b/mobile/page_probe.py
@@ -10,6 +10,7 @@ Results are cached with a configurable TTL to avoid redundant device queries.
 """
 
 import time
+from enum import Enum
 from typing import Any, Dict, Optional
 
 try:
@@ -18,6 +19,33 @@ except ImportError:
     from logger import get_logger
 
 logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Page state enum (P1 #25, Step 1)
+# ---------------------------------------------------------------------------
+# Inherits ``str`` so existing string-based comparisons (``state == "sku_page"``)
+# keep working without churn while new code can use ``PageState.SESSION_PICKER``.
+class PageState(str, Enum):
+    HOMEPAGE = "homepage"
+    SEARCH_PAGE = "search_page"
+    DETAIL_PAGE = "detail_page"
+    SKU_PAGE = "sku_page"
+    SESSION_PICKER = "session_picker"
+    ORDER_CONFIRM_PAGE = "order_confirm_page"
+    CONSENT_DIALOG = "consent_dialog"
+    PENDING_ORDER_DIALOG = "pending_order_dialog"
+    UNKNOWN = "unknown"
+
+
+# Markers used to recognise the multi-session date picker on the SKU page.
+_SESSION_PICKER_RESOURCE_IDS = ("cn.damai:id/sku_panel_dates",)
+_SESSION_PICKER_TEXTS = (
+    "请选择场次",
+    "选择日期",
+    "请选择日期",
+    "请选择演出日期",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +189,14 @@ class PageProbe:
         self._cached_at = time.time()
         return result
 
+    def classify(self, fast: bool = False) -> Dict[str, Any]:
+        """Public alias of :meth:`probe_current_page`.
+
+        Existing call sites use ``probe_current_page``; new code (P1 #25
+        multi-session flow) reads more naturally as ``probe.classify()``.
+        """
+        return self.probe_current_page(fast=fast)
+
     def get_current_activity(self) -> str:
         """Return the current foreground Activity name."""
         try:
@@ -216,6 +252,11 @@ class PageProbe:
             return _make_result(state="detail_page", purchase_button=purchase_bar)
 
         if "NcovSku" in activity:
+            if self._has_session_picker_markers():
+                return _make_result(
+                    state=PageState.SESSION_PICKER.value,
+                    price_container=False,
+                )
             reservation = self._check_reservation_mode()
             return _make_result(
                 state="sku_page",
@@ -256,6 +297,11 @@ class PageProbe:
         sku_layout = self._exists_by_resource_id("cn.damai:id/layout_sku")
         sku_container = self._exists_by_resource_id("cn.damai:id/sku_contanier")
         if sku_layout or sku_container:
+            if self._has_session_picker_markers():
+                return _make_result(
+                    state=PageState.SESSION_PICKER.value,
+                    pending_order_dialog=pending,
+                )
             reservation = self._check_reservation_mode()
             return _make_result(
                 state="sku_page",
@@ -325,6 +371,23 @@ class PageProbe:
             return el.exists
         except Exception:
             return False
+
+    def _has_session_picker_markers(self) -> bool:
+        """Return True when the multi-session date picker UI is visible.
+
+        Detects the SKU panel state where the user must pick a session/date
+        before the price flow-layout becomes interactive. Markers checked:
+
+        - resource-id ``cn.damai:id/sku_panel_dates``
+        - text "请选择场次" / "选择日期" (and minor wording variants)
+        """
+        for resource_id in _SESSION_PICKER_RESOURCE_IDS:
+            if self._exists_by_resource_id(resource_id):
+                return True
+        for text in _SESSION_PICKER_TEXTS:
+            if self._exists_by_text(text) or self._exists_by_text_contains(text):
+                return True
+        return False
 
     def _check_reservation_mode(self) -> bool:
         """Check if the SKU page is in reservation (not purchase) mode."""

--- a/tests/integration/test_multi_session_workflow.py
+++ b/tests/integration/test_multi_session_workflow.py
@@ -1,0 +1,132 @@
+# -*- coding: UTF-8 -*-
+"""Integration tests for the multi-session SKU flow (P1 #25).
+
+Covers two end-to-end paths:
+
+1. ``page_probe`` classifies a multi-session SKU panel as ``session_picker``.
+2. ``select_session`` then resolves a unique candidate by ``date + city`` and
+   issues a click via the mocked uiautomator2 driver.
+
+The tests rely on the shared ``conftest.py`` fixture that injects a u2 mock
+into ``sys.modules`` so no real device is required.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mobile.event_navigator import (
+    SessionNotFoundError,
+    _enumerate_sessions_from_xml,
+    select_session,
+)
+from mobile.page_probe import PageProbe, PageState
+
+
+def _build_session_picker_xml(*sessions):
+    """Hierarchy stub: ``cn.damai:id/sku_panel_dates`` parent + N session cards."""
+    cards = ""
+    for date_text, city_text, bounds in sessions:
+        cards += f"""
+            <node clickable="true" bounds="{bounds}">
+              <node resource-id="cn.damai:id/tv_date" text="{date_text}" bounds="{bounds}"/>
+              <node resource-id="cn.damai:id/tv_venue" text="{city_text}" bounds="{bounds}"/>
+            </node>"""
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+        <hierarchy>
+          <node resource-id="cn.damai:id/sku_panel_dates" bounds="[0,0][1080,400]">
+            {cards}
+          </node>
+        </hierarchy>"""
+
+
+@pytest.fixture
+def multi_session_device():
+    device = MagicMock()
+    device.app_current.return_value = {"activity": "com.damai.NcovSkuActivity"}
+
+    def element_factory(**kwargs):
+        el = MagicMock()
+        el.exists = (
+            kwargs.get("resourceId") == "cn.damai:id/sku_panel_dates"
+            or kwargs.get("text") == "请选择场次"
+        )
+        return el
+
+    device.side_effect = element_factory
+    device.dump_hierarchy.return_value = _build_session_picker_xml(
+        ("04.06", "上海", "[0,0][540,200]"),
+        ("04.13", "北京", "[540,0][1080,200]"),
+        ("04.20", "广州", "[0,200][540,400]"),
+    )
+    return device
+
+
+class TestPageProbeIntoSelectSession:
+    """End-to-end: probe → select_session → click resolves a unique session."""
+
+    def test_probe_classifies_as_session_picker(self, multi_session_device):
+        probe = PageProbe(multi_session_device, cache_ttl_s=0)
+        result = probe.classify(fast=False)
+        assert result["state"] == PageState.SESSION_PICKER.value
+
+    def test_select_session_picks_by_date_city(self, multi_session_device):
+        idx = select_session(multi_session_device, date="04.13", city="北京")
+        assert idx == 1
+        # Center of [540,0][1080,200] = (810, 100)
+        multi_session_device.click.assert_called_once_with(810, 100)
+
+    def test_full_workflow_probe_then_select(self, multi_session_device):
+        """Probe identifies SESSION_PICKER, then caller invokes select_session."""
+        probe = PageProbe(multi_session_device, cache_ttl_s=0)
+        state = probe.classify(fast=False)["state"]
+
+        if state == PageState.SESSION_PICKER.value:
+            chosen = select_session(multi_session_device, date="04.06", city="上海")
+        else:
+            pytest.fail(f"unexpected state: {state}")
+
+        assert chosen == 0
+        multi_session_device.click.assert_called_once_with(270, 100)
+
+    def test_full_workflow_falls_through_when_date_missing(self, multi_session_device):
+        """When configured date does not match any card, select_session
+        with fallback_index=0 still picks deterministically — guarding
+        against silent hangs on production multi-session events."""
+        idx = select_session(multi_session_device, date="07.01", fallback_index=0)
+        assert idx == 0
+
+
+class TestSessionPickerEdgeCases:
+    def test_empty_panel_raises_session_not_found(self):
+        device = MagicMock()
+        device.dump_hierarchy.return_value = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<hierarchy><node resource-id="cn.damai:id/sku_panel_dates"/></hierarchy>'
+        )
+        with pytest.raises(SessionNotFoundError, match="未发现可选场次"):
+            select_session(device, date="04.06")
+
+    def test_enumerate_skips_panels_outside_dates_container(self):
+        """A tv_date node OUTSIDE sku_panel_dates is ignored (regression guard)."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <hierarchy>
+          <node resource-id="cn.damai:id/some_other_panel">
+            <node resource-id="cn.damai:id/tv_date" text="04.06" bounds="[0,0][100,100]"/>
+          </node>
+          <node resource-id="cn.damai:id/sku_panel_dates" bounds="[0,200][1080,400]">
+            <node clickable="true" bounds="[0,200][540,400]">
+              <node resource-id="cn.damai:id/tv_date" text="04.13" bounds="[0,200][540,400]"/>
+              <node resource-id="cn.damai:id/tv_venue" text="北京" bounds="[0,200][540,400]"/>
+            </node>
+          </node>
+        </hierarchy>"""
+        cards = _enumerate_sessions_from_xml(xml)
+        assert len(cards) == 1
+        assert cards[0]["date"] == "04.13"
+
+    def test_dump_hierarchy_failure_does_not_crash_workflow(self):
+        device = MagicMock()
+        device.dump_hierarchy.side_effect = RuntimeError("ADB closed")
+        with pytest.raises(SessionNotFoundError, match="dump_hierarchy 失败"):
+            select_session(device, date="04.06")

--- a/tests/unit/test_event_navigator.py
+++ b/tests/unit/test_event_navigator.py
@@ -1,7 +1,16 @@
 """Unit tests for EventNavigator."""
 
 from unittest.mock import MagicMock
-from mobile.event_navigator import EventNavigator
+
+
+import pytest
+
+from mobile.event_navigator import (
+    EventNavigator,
+    SessionNotFoundError,
+    _enumerate_sessions_from_xml,
+    select_session,
+)
 
 
 class TestKeywordTokens:
@@ -186,3 +195,151 @@ class TestNavigateToTarget:
         initial = {"state": "search_page"}
         nav.navigate_to_target_event(initial_probe=initial)
         bot._navigate_to_target_impl.assert_called_once_with(initial_probe=initial)
+
+
+# ---------------------------------------------------------------------------
+# select_session (P1 #25)
+# ---------------------------------------------------------------------------
+
+
+def _hierarchy_xml(*sessions):
+    """Build a minimal hierarchy XML containing N session cards.
+
+    Each ``sessions`` entry is a tuple ``(date, city, bounds)``.
+    """
+    cards_xml = ""
+    for date_text, city_text, bounds in sessions:
+        cards_xml += f'''
+            <node clickable="true" bounds="{bounds}">
+              <node resource-id="cn.damai:id/tv_date" text="{date_text}" bounds="{bounds}"/>
+              <node resource-id="cn.damai:id/tv_venue" text="{city_text}" bounds="{bounds}"/>
+            </node>'''
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+    <hierarchy>
+      <node resource-id="cn.damai:id/sku_panel_dates" bounds="[0,0][1080,400]">
+        {cards_xml}
+      </node>
+    </hierarchy>"""
+
+
+class TestEnumerateSessionsFromXml:
+    def test_returns_empty_when_panel_missing(self):
+        xml = "<hierarchy><node/></hierarchy>"
+        assert _enumerate_sessions_from_xml(xml) == []
+
+    def test_handles_malformed_xml(self):
+        assert _enumerate_sessions_from_xml("<not closed") == []
+
+    def test_collects_each_card_once(self):
+        xml = _hierarchy_xml(
+            ("04.06", "上海", "[0,0][540,200]"),
+            ("04.13", "北京", "[540,0][1080,200]"),
+        )
+        cards = _enumerate_sessions_from_xml(xml)
+        assert len(cards) == 2
+        assert cards[0]["date"] == "04.06"
+        assert "上海" in cards[0]["text"]
+        assert cards[1]["date"] == "04.13"
+
+
+class TestSelectSession:
+    def _make_driver(self, xml):
+        driver = MagicMock()
+        driver.dump_hierarchy.return_value = xml
+        return driver
+
+    def test_raises_when_panel_missing(self):
+        driver = self._make_driver("<hierarchy></hierarchy>")
+        with pytest.raises(SessionNotFoundError, match="未发现可选场次"):
+            select_session(driver, date="04.06")
+
+    def test_unique_date_match_clicks_card(self):
+        xml = _hierarchy_xml(
+            ("04.06", "上海", "[0,0][540,200]"),
+            ("04.13", "北京", "[540,0][1080,200]"),
+        )
+        driver = self._make_driver(xml)
+        idx = select_session(driver, date="04.06")
+        assert idx == 0
+        # Center of [0,0][540,200] = (270, 100)
+        driver.click.assert_called_once_with(270, 100)
+
+    def test_date_normalisation_handles_chinese_input(self):
+        xml = _hierarchy_xml(
+            ("04月06日", "上海", "[0,0][540,200]"),
+        )
+        driver = self._make_driver(xml)
+        # User passed normalised "04.06" → matches "04月06日" via normalize_date
+        assert select_session(driver, date="04.06") == 0
+
+    def test_date_plus_city_disambiguates_duplicates(self):
+        xml = _hierarchy_xml(
+            ("04.06", "上海", "[0,0][540,200]"),
+            ("04.06", "北京", "[540,0][1080,200]"),
+        )
+        driver = self._make_driver(xml)
+        idx = select_session(driver, date="04.06", city="北京")
+        assert idx == 1
+        driver.click.assert_called_once_with(810, 100)
+
+    def test_date_alone_ambiguous_raises(self):
+        xml = _hierarchy_xml(
+            ("04.06", "上海", "[0,0][540,200]"),
+            ("04.06", "北京", "[540,0][1080,200]"),
+        )
+        driver = self._make_driver(xml)
+        with pytest.raises(SessionNotFoundError, match="命中 2 条"):
+            select_session(driver, date="04.06")
+
+    def test_fallback_index_when_no_date(self):
+        xml = _hierarchy_xml(
+            ("04.06", "上海", "[0,0][540,200]"),
+            ("04.13", "北京", "[540,0][1080,200]"),
+        )
+        driver = self._make_driver(xml)
+        idx = select_session(driver, fallback_index=1)
+        assert idx == 1
+
+    def test_fallback_index_out_of_range_raises(self):
+        xml = _hierarchy_xml(("04.06", "上海", "[0,0][540,200]"))
+        driver = self._make_driver(xml)
+        with pytest.raises(SessionNotFoundError, match="越界"):
+            select_session(driver, fallback_index=5)
+
+    def test_no_hints_raises(self):
+        xml = _hierarchy_xml(("04.06", "上海", "[0,0][540,200]"))
+        driver = self._make_driver(xml)
+        with pytest.raises(SessionNotFoundError, match="未提供"):
+            select_session(driver)
+
+    def test_dump_hierarchy_failure_propagates_as_session_error(self):
+        driver = MagicMock()
+        driver.dump_hierarchy.side_effect = RuntimeError("device offline")
+        with pytest.raises(SessionNotFoundError, match="dump_hierarchy 失败"):
+            select_session(driver, date="04.06")
+
+    def test_click_failure_wraps_as_session_error(self):
+        xml = _hierarchy_xml(("04.06", "上海", "[0,0][540,200]"))
+        driver = self._make_driver(xml)
+        driver.click.side_effect = RuntimeError("ADB closed")
+        with pytest.raises(SessionNotFoundError, match="点击场次卡片失败"):
+            select_session(driver, date="04.06")
+
+    def test_date_city_no_match_falls_through_to_date_only(self):
+        """When date+city specified but city absent, fall back to date-only.
+
+        This guards against users who specify a city that the venue copy
+        does not include verbatim (e.g. "上海" vs "上海徐汇")."""
+        xml = _hierarchy_xml(("04.06", "上海体育馆", "[0,0][540,200]"))
+        driver = self._make_driver(xml)
+        idx = select_session(driver, date="04.06", city="北京")
+        assert idx == 0  # date-only single match wins after city miss
+
+    def test_date_city_priority_over_fallback_index(self):
+        xml = _hierarchy_xml(
+            ("04.06", "上海", "[0,0][540,200]"),
+            ("04.13", "北京", "[540,0][1080,200]"),
+        )
+        driver = self._make_driver(xml)
+        idx = select_session(driver, date="04.13", city="北京", fallback_index=0)
+        assert idx == 1  # date+city wins, fallback_index ignored

--- a/tests/unit/test_mobile_config.py
+++ b/tests/unit/test_mobile_config.py
@@ -217,6 +217,113 @@ class TestMobileConfigNewFields:
         assert cfg.fast_retry_interval_ms == 120
 
 
+class TestRushSubFlags:
+    """P1 #25 — rush_mode 拆为 3 个子开关。"""
+
+    def test_defaults_match_rush_true_baseline(self):
+        cfg = Config(**_make())
+        assert cfg.rush_skip_session is False
+        assert cfg.rush_skip_price_dump is True
+        assert cfg.rush_aggressive_retry is True
+
+    def test_explicit_sub_flag_values_kept_when_rush_mode_false(self):
+        cfg = Config(
+            **_make(
+                rush_mode=False,
+                rush_skip_session=True,
+                rush_skip_price_dump=False,
+                rush_aggressive_retry=False,
+            )
+        )
+        assert cfg.rush_skip_session is True
+        assert cfg.rush_skip_price_dump is False
+        assert cfg.rush_aggressive_retry is False
+
+    def test_rush_mode_true_forces_skip_session_false(self):
+        """rush_mode=True 永不允许 rush_skip_session=True（issue #25 根因防御）。"""
+        cfg = Config(
+            **_make(rush_mode=True, rush_skip_session=True),
+        )
+        assert cfg.rush_mode is True
+        assert cfg.rush_skip_session is False
+
+    def test_rush_mode_true_keeps_other_sub_flag_overrides(self):
+        cfg = Config(
+            **_make(
+                rush_mode=True,
+                rush_skip_price_dump=False,
+                rush_aggressive_retry=False,
+            )
+        )
+        assert cfg.rush_mode is True
+        assert cfg.rush_skip_price_dump is False
+        assert cfg.rush_aggressive_retry is False
+
+    def test_rush_skip_session_non_bool_raises(self):
+        with pytest.raises(ValueError, match="rush_skip_session"):
+            Config(**_make(rush_skip_session="yes"))
+
+    def test_rush_skip_price_dump_non_bool_raises(self):
+        with pytest.raises(ValueError, match="rush_skip_price_dump"):
+            Config(**_make(rush_skip_price_dump=1))
+
+    def test_rush_aggressive_retry_non_bool_raises(self):
+        with pytest.raises(ValueError, match="rush_aggressive_retry"):
+            Config(**_make(rush_aggressive_retry="off"))
+
+    def test_to_dict_includes_sub_flags(self):
+        cfg = Config(**_make())
+        data = cfg.to_dict()
+        assert data["rush_skip_session"] is False
+        assert data["rush_skip_price_dump"] is True
+        assert data["rush_aggressive_retry"] is True
+        assert data["rush_mode"] is False  # alias still emitted
+
+    def test_load_config_reads_sub_flags(self, tmp_path):
+        cfg_path = tmp_path / "config.jsonc"
+        payload = json.dumps(
+            {
+                "keyword": "周深",
+                "users": ["张三"],
+                "city": "深圳",
+                "date": "12.06",
+                "price": "799元",
+                "price_index": 0,
+                "if_commit_order": False,
+                "rush_skip_session": True,
+                "rush_skip_price_dump": False,
+                "rush_aggressive_retry": False,
+            }
+        )
+        cfg_path.write_text(payload, encoding="utf-8")
+        cfg = Config.load_config(config_path=cfg_path)
+        assert cfg.rush_skip_session is True
+        assert cfg.rush_skip_price_dump is False
+        assert cfg.rush_aggressive_retry is False
+
+    def test_load_config_alias_overrides_skip_session_to_false(self, tmp_path):
+        """rush_mode=True 在 config.jsonc 显式 + rush_skip_session=True 时
+        日志 warning + 强制 skip_session=False。"""
+        cfg_path = tmp_path / "config.jsonc"
+        payload = json.dumps(
+            {
+                "keyword": "周深",
+                "users": ["张三"],
+                "city": "深圳",
+                "date": "12.06",
+                "price": "799元",
+                "price_index": 0,
+                "if_commit_order": False,
+                "rush_mode": True,
+                "rush_skip_session": True,
+            }
+        )
+        cfg_path.write_text(payload, encoding="utf-8")
+        cfg = Config.load_config(config_path=cfg_path)
+        assert cfg.rush_mode is True
+        assert cfg.rush_skip_session is False
+
+
 class TestMobileConfigLoadConfig:
     def test_load_config_dict_from_missing_path_raises(self, tmp_path):
         with pytest.raises(

--- a/tests/unit/test_page_probe.py
+++ b/tests/unit/test_page_probe.py
@@ -3,15 +3,15 @@
 
 import time as _time_module
 
-import pytest
-from unittest.mock import Mock, patch, PropertyMock
+from unittest.mock import Mock
 
-from mobile.page_probe import PageProbe, _DEFAULT_RESULT
+from mobile.page_probe import PageProbe, PageState, _DEFAULT_RESULT  # noqa: F401
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_device(activity: str = "") -> Mock:
     """Create a mock u2 device that returns the given activity name."""
@@ -27,6 +27,7 @@ def _make_device(activity: str = "") -> Mock:
 # ---------------------------------------------------------------------------
 # Fast probe tests
 # ---------------------------------------------------------------------------
+
 
 class TestFastProbe:
     """Tests for fast probe mode (Activity-based detection)."""
@@ -91,6 +92,7 @@ class TestFastProbe:
 # TTL cache tests
 # ---------------------------------------------------------------------------
 
+
 class TestTTLCache:
     """Tests for the TTL-based result cache."""
 
@@ -147,6 +149,7 @@ class TestTTLCache:
 # Full probe tests
 # ---------------------------------------------------------------------------
 
+
 class TestFullProbe:
     """Tests for the full probe mode (Activity + element detection)."""
 
@@ -159,7 +162,10 @@ class TestFullProbe:
         def element_factory(**kwargs):
             el = Mock()
             rid = kwargs.get("resourceId", "")
-            if rid == "cn.damai:id/trade_project_detail_purchase_status_bar_container_fl":
+            if (
+                rid
+                == "cn.damai:id/trade_project_detail_purchase_status_bar_container_fl"
+            ):
                 el.exists = True
             else:
                 el.exists = False
@@ -303,7 +309,10 @@ class TestFullProbe:
         def element_factory(**kwargs):
             el = Mock()
             rid = kwargs.get("resourceId", "")
-            if rid == "cn.damai:id/trade_project_detail_purchase_status_bar_container_fl":
+            if (
+                rid
+                == "cn.damai:id/trade_project_detail_purchase_status_bar_container_fl"
+            ):
                 el.exists = True
             else:
                 el.exists = False
@@ -334,8 +343,8 @@ class TestFullProbe:
 # get_current_activity tests
 # ---------------------------------------------------------------------------
 
-class TestGetCurrentActivity:
 
+class TestGetCurrentActivity:
     def test_returns_activity_string(self):
         device = _make_device("com.damai.ProjectDetailActivity")
         probe = PageProbe(device)
@@ -348,3 +357,100 @@ class TestGetCurrentActivity:
         probe = PageProbe(device)
 
         assert probe.get_current_activity() == ""
+
+
+# ---------------------------------------------------------------------------
+# Multi-session date picker (P1 #25)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifySessionPicker:
+    """SESSION_PICKER must be detected before sku_page so the navigator can
+    branch into select_session() instead of trying to click prices on a panel
+    that hasn't loaded the price flow-layout yet."""
+
+    def test_classify_session_picker_by_resource_id(self):
+        device = _make_device("com.damai.NcovSkuActivity")
+
+        def element_factory(**kwargs):
+            el = Mock()
+            el.exists = kwargs.get("resourceId") == "cn.damai:id/sku_panel_dates"
+            return el
+
+        device.side_effect = element_factory
+        probe = PageProbe(device, cache_ttl_s=0)
+
+        result = probe.classify(fast=False)
+
+        assert result["state"] == PageState.SESSION_PICKER.value
+        assert result["state"] == "session_picker"
+        assert result["price_container"] is False
+
+    def test_classify_session_picker_by_text_请选择场次(self):
+        device = _make_device("com.damai.NcovSkuActivity")
+
+        def element_factory(**kwargs):
+            el = Mock()
+            el.exists = kwargs.get("text") == "请选择场次"
+            return el
+
+        device.side_effect = element_factory
+        probe = PageProbe(device, cache_ttl_s=0)
+
+        result = probe.classify(fast=False)
+
+        assert result["state"] == PageState.SESSION_PICKER.value
+
+    def test_classify_session_picker_fallback_on_unknown_activity(self):
+        """When Activity name does not match but layout_sku + dates panel exist,
+        full probe still returns SESSION_PICKER (not sku_page)."""
+        device = _make_device("com.damai.SomeUnknownActivity")
+
+        def element_factory(**kwargs):
+            el = Mock()
+            rid = kwargs.get("resourceId", "")
+            txt_contains = kwargs.get("textContains", "")
+            el.exists = (
+                rid
+                in {
+                    "cn.damai:id/layout_sku",
+                    "cn.damai:id/sku_panel_dates",
+                }
+                or txt_contains == "选择日期"
+            )
+            return el
+
+        device.side_effect = element_factory
+        probe = PageProbe(device, cache_ttl_s=0)
+
+        result = probe.probe_current_page(fast=False)
+
+        assert result["state"] == PageState.SESSION_PICKER.value
+
+    def test_sku_page_when_no_session_picker_markers(self):
+        """Regression guard: bare NcovSku page without dates panel still
+        classifies as sku_page so the existing rush hot path keeps working."""
+        device = _make_device("com.damai.NcovSkuActivity")
+
+        def element_factory(**kwargs):
+            el = Mock()
+            el.exists = False
+            return el
+
+        device.side_effect = element_factory
+        probe = PageProbe(device, cache_ttl_s=0)
+
+        result = probe.classify(fast=False)
+
+        assert result["state"] == "sku_page"
+        assert result["state"] != PageState.SESSION_PICKER.value
+
+
+class TestPageStateEnum:
+    def test_session_picker_value(self):
+        assert PageState.SESSION_PICKER.value == "session_picker"
+
+    def test_str_inheritance_keeps_string_compat(self):
+        # Existing string-based equality must keep working.
+        assert PageState.SKU_PAGE == "sku_page"
+        assert PageState.SESSION_PICKER == "session_picker"


### PR DESCRIPTION
## Summary
- PageState 增加 SESSION_PICKER；page_probe 自动识别多场次场次选择 UI（resource-id `cn.damai:id/sku_panel_dates` 或文本「请选择场次」/「选择日期」）
- 新增 `select_session(driver, *, date, city, fallback_index)` 按 date+city 精确匹配，回退到 date 唯一 / fallback_index，最终抛 `SessionNotFoundError`
- rush_mode 拆为 3 个子开关（`rush_skip_session` / `rush_skip_price_dump` / `rush_aggressive_retry`），保留 alias；`rush_mode=True` 强制 `rush_skip_session=False` 防止多场次抢错（issue #25 根因）
- `docs/mobile-ticket-logic.md` 增「多场次活动配置示例」章节；`mobile/config.example.jsonc` 增加 3 个子开关注释示例；新增 `tests/integration/test_multi_session_workflow.py`

## Test plan
- [x] poetry run test 全绿（1003 passed）
- [x] 覆盖率 80.84% ≥ 80%
- [x] 集成测试 `test_multi_session_workflow` 验证 SESSION_PICKER 识别 + select_session 端到端
- [ ] 真机至少 2 个多场次活动选对场次（W3-03 qa 验证）

## 关联
- Closes #25
- 关联 fix-plan: `reference/05-fix-plans/p1-25-multi-session-rush.md`

## 不做的事
- 不删除 `rush_mode` alias（保留一个 release 周期）
- 不在多场次场景下做激进的「跳过场次直接抢」（这是 #25 根因）
- 不动 `mobile/config.jsonc`（用户私有）