### PR TITLE
fix(mobile): P2 修复栈 — #28 首页 + #23 搜索 + #24 unknown 状态

### DIFF
--- a/mobile/event_navigator.py
+++ b/mobile/event_navigator.py
@@ -35,6 +35,18 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+# Re-export the page-recovery helpers so callers and tests can keep importing
+# from ``mobile.event_navigator``.  Implementations live in
+# :mod:`mobile.page_helpers` to keep this module under the 800-line ceiling.
+from mobile.page_helpers import (  # noqa: E402, F401
+    HomeNotReadyError,
+    _build_parent_map,
+    _find_clickable_ancestor,
+    _parse_bounds_center,
+    wait_for_home_ready,
+)
+
+
 # ---------------------------------------------------------------------------
 # Multi-session selection (P1 #25, Step 2)
 # ---------------------------------------------------------------------------
@@ -46,32 +58,6 @@ class SessionNotFoundError(RuntimeError):
 
 _SESSION_PANEL_RESOURCE_ID = "cn.damai:id/sku_panel_dates"
 _SESSION_DATE_RESOURCE_ID = "cn.damai:id/tv_date"
-_BOUNDS_RE = re.compile(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]")
-
-
-def _parse_bounds_center(bounds_str: Optional[str]) -> Optional[tuple]:
-    if not bounds_str:
-        return None
-    match = _BOUNDS_RE.match(bounds_str)
-    if not match:
-        return None
-    x1, y1, x2, y2 = (int(v) for v in match.groups())
-    return ((x1 + x2) // 2, (y1 + y2) // 2)
-
-
-def _build_parent_map(root: ET.Element) -> Dict[ET.Element, ET.Element]:
-    return {child: parent for parent in root.iter() for child in parent}
-
-
-def _find_clickable_ancestor(
-    parent_map: Dict[ET.Element, ET.Element], node: ET.Element
-) -> Optional[ET.Element]:
-    cur = parent_map.get(node)
-    while cur is not None:
-        if cur.get("clickable") == "true":
-            return cur
-        cur = parent_map.get(cur)
-    return None
 
 
 def _enumerate_sessions_from_xml(xml_str: str) -> List[Dict[str, Any]]:

--- a/mobile/event_navigator.py
+++ b/mobile/event_navigator.py
@@ -40,9 +40,12 @@ logger = get_logger(__name__)
 # :mod:`mobile.page_helpers` to keep this module under the 800-line ceiling.
 from mobile.page_helpers import (  # noqa: E402, F401
     HomeNotReadyError,
+    SearchAmbiguousError,
+    SearchEmptyError,
     _build_parent_map,
     _find_clickable_ancestor,
     _parse_bounds_center,
+    select_search_result,
     wait_for_home_ready,
 )
 

--- a/mobile/page_helpers.py
+++ b/mobile/page_helpers.py
@@ -1,0 +1,189 @@
+# -*- coding: UTF-8 -*-
+"""Page-level recovery helpers for the Damai mobile flow.
+
+Houses thin recovery functions that surround the main navigator:
+
+- :func:`wait_for_home_ready` — polls the homepage state with a timeout,
+  dumping the UI hierarchy on failure (P2 #28).
+
+Kept in a separate module so :mod:`mobile.event_navigator` stays under the
+800-line ceiling.  :mod:`mobile.event_navigator` re-exports the public names
+so callers/tests can import either path.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+try:
+    from mobile.logger import get_logger
+except ImportError:  # pragma: no cover - test-only fallback
+    from logger import get_logger  # type: ignore[no-redef]
+
+if TYPE_CHECKING:
+    from mobile.page_probe import PageProbe
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class HomeNotReadyError(RuntimeError):
+    """Raised when :func:`wait_for_home_ready` cannot see the Damai homepage."""
+
+
+# ---------------------------------------------------------------------------
+# Shared XML helpers (used by select_session in event_navigator and by the
+# new recovery helpers below).
+# ---------------------------------------------------------------------------
+
+
+_BOUNDS_RE = re.compile(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]")
+
+
+def _parse_bounds_center(bounds_str: Optional[str]) -> Optional[tuple]:
+    if not bounds_str:
+        return None
+    match = _BOUNDS_RE.match(bounds_str)
+    if not match:
+        return None
+    x1, y1, x2, y2 = (int(v) for v in match.groups())
+    return ((x1 + x2) // 2, (y1 + y2) // 2)
+
+
+def _build_parent_map(root: ET.Element) -> Dict[ET.Element, ET.Element]:
+    return {child: parent for parent in root.iter() for child in parent}
+
+
+def _find_clickable_ancestor(
+    parent_map: Dict[ET.Element, ET.Element], node: ET.Element
+) -> Optional[ET.Element]:
+    cur = parent_map.get(node)
+    while cur is not None:
+        if cur.get("clickable") == "true":
+            return cur
+        cur = parent_map.get(cur)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# UI dump helpers (XML-only — no screenshots, per P2 brief)
+# ---------------------------------------------------------------------------
+
+
+def _safe_dump_hierarchy(driver: Any) -> str:
+    try:
+        return driver.dump_hierarchy() or ""
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("dump_hierarchy 失败: %s", exc)
+        return ""
+
+
+def _dump_ui(driver: Any, dump_dir: str, scene: str) -> Optional[str]:
+    """Persist the current UI hierarchy to ``<dump_dir>/<scene>_<ts>.xml``.
+
+    Returns the file path on success, or ``None`` if dumping failed.  Failures
+    never propagate — the caller still raises whatever error triggered the dump.
+    """
+    try:
+        os.makedirs(dump_dir, exist_ok=True)
+        ts = time.strftime("%Y%m%d_%H%M%S")
+        path = os.path.join(dump_dir, f"{scene}_{ts}.xml")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(_safe_dump_hierarchy(driver))
+        return path
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("UI dump 写入失败 (%s): %s", scene, exc)
+        return None
+
+
+def _summarise_ui(xml_str: str, max_items: int = 10) -> Dict[str, List[str]]:
+    """Extract visible texts and resource_ids from a hierarchy dump for logging."""
+    texts: List[str] = []
+    ids: List[str] = []
+    if not xml_str:
+        return {"texts": texts, "resource_ids": ids}
+    try:
+        root = ET.fromstring(xml_str)
+    except ET.ParseError:
+        return {"texts": texts, "resource_ids": ids}
+    for node in root.iter("node"):
+        text = (node.get("text") or "").strip()
+        if text:
+            texts.append(text)
+        rid = (node.get("resource-id") or "").strip()
+        if rid:
+            ids.append(rid)
+    return {"texts": texts[:max_items], "resource_ids": ids[:max_items]}
+
+
+# ---------------------------------------------------------------------------
+# Issue #28 — wait_for_home_ready
+# ---------------------------------------------------------------------------
+
+
+def wait_for_home_ready(
+    driver: Any,
+    probe: "PageProbe",
+    *,
+    timeout: float = 8.0,
+    poll_interval: float = 0.2,
+    dump_dir: str = "tmp",
+) -> Dict[str, Any]:
+    """Wait for the Damai homepage state to be classified.
+
+    Polls ``probe.classify()`` until ``state == "homepage"`` or until ``timeout``
+    seconds have elapsed.  On timeout, dumps the UI hierarchy to
+    ``<dump_dir>/home_probe_<ts>.xml``, logs visible key texts + resource_ids,
+    and raises :class:`HomeNotReadyError`.
+
+    Args:
+        driver: A uiautomator2 device exposing ``dump_hierarchy()``.
+        probe: A :class:`mobile.page_probe.PageProbe` used to classify state.
+        timeout: Maximum seconds to wait for the homepage. Defaults to 8s.
+        poll_interval: Seconds between probe attempts.
+        dump_dir: Directory to write hierarchy dumps.
+
+    Returns:
+        The probe classification dict whose ``state`` is ``"homepage"``.
+
+    Raises:
+        HomeNotReadyError: When the homepage state is not detected before
+            ``timeout`` elapses.
+    """
+    deadline = time.time() + max(0.0, float(timeout))
+    last_result: Optional[Dict[str, Any]] = None
+    while True:
+        try:
+            probe.invalidate_cache()
+        except AttributeError:
+            pass
+        last_result = probe.classify()
+        state = (last_result or {}).get("state")
+        if state == "homepage":
+            return last_result
+        if time.time() >= deadline:
+            break
+        time.sleep(poll_interval)
+
+    dump_path = _dump_ui(driver, dump_dir, "home_probe")
+    snapshot = _summarise_ui(_safe_dump_hierarchy(driver))
+    logger.warning(
+        "wait_for_home_ready 超时: timeout=%.1fs state=%s dump=%s texts=%s ids=%s",
+        timeout,
+        (last_result or {}).get("state"),
+        dump_path,
+        snapshot["texts"],
+        snapshot["resource_ids"],
+    )
+    raise HomeNotReadyError(
+        f"首页未就绪 (timeout={timeout:.1f}s, "
+        f"state={(last_result or {}).get('state')}, dump={dump_path})"
+    )

--- a/mobile/page_helpers.py
+++ b/mobile/page_helpers.py
@@ -1,14 +1,16 @@
 # -*- coding: UTF-8 -*-
 """Page-level recovery helpers for the Damai mobile flow.
 
-Houses thin recovery functions that surround the main navigator:
+Houses two thin recovery functions that surround the main navigator:
 
 - :func:`wait_for_home_ready` — polls the homepage state with a timeout,
   dumping the UI hierarchy on failure (P2 #28).
+- :func:`select_search_result` — waits for the search results list and
+  picks 0/1/N results with deterministic fallback rules (P2 #23).
 
 Kept in a separate module so :mod:`mobile.event_navigator` stays under the
-800-line ceiling.  :mod:`mobile.event_navigator` re-exports the public names
-so callers/tests can import either path.
+800-line ceiling.  :mod:`mobile.event_navigator` re-exports the public
+names so callers/tests can import either path.
 """
 
 from __future__ import annotations
@@ -39,13 +41,29 @@ class HomeNotReadyError(RuntimeError):
     """Raised when :func:`wait_for_home_ready` cannot see the Damai homepage."""
 
 
+class SearchEmptyError(RuntimeError):
+    """Raised when :func:`select_search_result` finds zero result cards."""
+
+
+class SearchAmbiguousError(RuntimeError):
+    """Raised when :func:`select_search_result` cannot disambiguate >1 results
+    in strict mode (no fallback to the first result is allowed).
+    """
+
+
 # ---------------------------------------------------------------------------
-# Shared XML helpers (used by select_session in event_navigator and by the
-# new recovery helpers below).
+# UI dump helpers (XML-only — no screenshots, per P2 brief)
 # ---------------------------------------------------------------------------
 
 
 _BOUNDS_RE = re.compile(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]")
+_HOME_READY_RESOURCE_IDS = (
+    "cn.damai:id/pioneer_homepage_header_search_btn",
+    "cn.damai:id/homepage_header_search",
+    "cn.damai:id/homepage_header_search_layout",
+)
+_SEARCH_RESULT_RESOURCE_ID = "cn.damai:id/ll_search_item"
+_SEARCH_RESULT_TITLE_RESOURCE_ID = "cn.damai:id/tv_project_name"
 
 
 def _parse_bounds_center(bounds_str: Optional[str]) -> Optional[tuple]:
@@ -71,11 +89,6 @@ def _find_clickable_ancestor(
             return cur
         cur = parent_map.get(cur)
     return None
-
-
-# ---------------------------------------------------------------------------
-# UI dump helpers (XML-only — no screenshots, per P2 brief)
-# ---------------------------------------------------------------------------
 
 
 def _safe_dump_hierarchy(driver: Any) -> str:
@@ -187,3 +200,162 @@ def wait_for_home_ready(
         f"首页未就绪 (timeout={timeout:.1f}s, "
         f"state={(last_result or {}).get('state')}, dump={dump_path})"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #23 — select_search_result
+# ---------------------------------------------------------------------------
+
+
+def _enumerate_search_results_from_xml(xml_str: str) -> List[Dict[str, Any]]:
+    """Parse a u2 hierarchy dump and return one descriptor per search result card."""
+    if not xml_str:
+        return []
+    try:
+        root = ET.fromstring(xml_str)
+    except ET.ParseError:
+        return []
+
+    results: List[Dict[str, Any]] = []
+    for node in root.iter("node"):
+        if node.get("resource-id") != _SEARCH_RESULT_RESOURCE_ID:
+            continue
+        title = ""
+        for desc in node.iter("node"):
+            if desc.get("resource-id") == _SEARCH_RESULT_TITLE_RESOURCE_ID:
+                title = (desc.get("text") or "").strip()
+                break
+        results.append(
+            {
+                "index": len(results),
+                "title": title,
+                "bounds": node.get("bounds"),
+            }
+        )
+    return results
+
+
+def _click_search_result(driver: Any, item: Dict[str, Any]) -> None:
+    coords = _parse_bounds_center(item.get("bounds"))
+    if coords is None:
+        raise RuntimeError(f"无法解析搜索结果 bounds={item.get('bounds')!r}")
+    driver.click(*coords)
+
+
+def _fuzzy_match(target: str, title: str) -> bool:
+    if not target or not title:
+        return False
+    t = target.strip().lower()
+    h = title.strip().lower()
+    if not t or not h:
+        return False
+    return t in h or h in t
+
+
+def select_search_result(
+    driver: Any,
+    *,
+    keyword: str = "",
+    target_title: Optional[str] = None,
+    timeout: float = 5.0,
+    poll_interval: float = 0.2,
+    strict: bool = False,
+    dump_dir: str = "tmp",
+) -> Dict[str, Any]:
+    """Wait for the search result list, then pick a result with 0/1/N rules.
+
+    Polls ``driver.dump_hierarchy()`` every ``poll_interval`` seconds for up to
+    ``timeout`` seconds, then applies these branches:
+
+    - **0 results** → dump UI, log ``keyword``, raise :class:`SearchEmptyError`.
+    - **1 result** → click it and return its descriptor.
+    - **N results** → fuzzy-match against ``target_title``.  On match, click it.
+      Otherwise, click the first card (when ``strict=False``) or raise
+      :class:`SearchAmbiguousError` (when ``strict=True``).
+
+    Args:
+        driver: u2 device exposing ``dump_hierarchy()`` and ``click(x, y)``.
+        keyword: Original search keyword — logged on empty results to aid
+            debugging of split/normalisation issues.
+        target_title: Optional title fragment for fuzzy matching when N>1.
+        timeout: Maximum seconds to wait for at least one result card.
+        poll_interval: Seconds between hierarchy polls (default 0.2 → 5s/25 polls).
+        strict: When True and no card matches ``target_title``, raise
+            :class:`SearchAmbiguousError` instead of falling back to the first.
+        dump_dir: Directory for failure UI dumps (created if missing).
+
+    Returns:
+        The chosen result descriptor (``{index, title, bounds}``).
+
+    Raises:
+        SearchEmptyError: No result cards visible after ``timeout`` seconds.
+        SearchAmbiguousError: ``strict=True`` and N>1 with no fuzzy match.
+    """
+    deadline = time.time() + max(0.0, float(timeout))
+    results: List[Dict[str, Any]] = []
+    while True:
+        results = _enumerate_search_results_from_xml(_safe_dump_hierarchy(driver))
+        if results:
+            break
+        if time.time() >= deadline:
+            break
+        time.sleep(poll_interval)
+
+    if not results:
+        dump_path = _dump_ui(driver, dump_dir, "search_probe")
+        logger.warning(
+            "search_result 0 条 keyword=%r timeout=%.1fs dump=%s",
+            keyword,
+            timeout,
+            dump_path,
+        )
+        raise SearchEmptyError(
+            f"搜索结果为空 (keyword={keyword!r}, timeout={timeout:.1f}s, "
+            f"dump={dump_path})"
+        )
+
+    if len(results) == 1:
+        chosen = results[0]
+        logger.info(
+            "select_search_result: 唯一结果 idx=0 title=%r",
+            chosen.get("title"),
+        )
+        _click_search_result(driver, chosen)
+        return chosen
+
+    if target_title:
+        for item in results:
+            if _fuzzy_match(target_title, item.get("title") or ""):
+                logger.info(
+                    "select_search_result: 模糊匹配 idx=%d title=%r target=%r",
+                    item["index"],
+                    item.get("title"),
+                    target_title,
+                )
+                _click_search_result(driver, item)
+                return item
+
+    if strict:
+        dump_path = _dump_ui(driver, dump_dir, "search_probe")
+        titles = [r.get("title") for r in results[:5]]
+        logger.warning(
+            "search_result 歧义 keyword=%r target_title=%r titles=%s dump=%s",
+            keyword,
+            target_title,
+            titles,
+            dump_path,
+        )
+        raise SearchAmbiguousError(
+            f"搜索结果歧义 (共 {len(results)} 条, target_title={target_title!r}, "
+            f"dump={dump_path})"
+        )
+
+    chosen = results[0]
+    logger.warning(
+        "select_search_result: %d 条结果未匹配 target_title=%r，回退到 idx=0 title=%r",
+        len(results),
+        target_title,
+        chosen.get("title"),
+    )
+    _click_search_result(driver, chosen)
+    return chosen

--- a/mobile/page_probe.py
+++ b/mobile/page_probe.py
@@ -9,9 +9,10 @@ Provides two probe modes:
 Results are cached with a configurable TTL to avoid redundant device queries.
 """
 
+import os
 import time
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 try:
     from mobile.logger import get_logger
@@ -143,7 +144,13 @@ class PageProbe:
     """
 
     def __init__(
-        self, device: Any, config: Any = None, cache_ttl_s: float = 0.5
+        self,
+        device: Any,
+        config: Any = None,
+        cache_ttl_s: float = 0.5,
+        *,
+        unknown_threshold: int = 3,
+        dump_dir: str = "tmp",
     ) -> None:
         self._device = device
         self._config = config
@@ -151,6 +158,13 @@ class PageProbe:
         self._cache_ttl_s = cache_ttl_s
         self._cached_result: Optional[Dict[str, Any]] = None
         self._cached_at: float = 0.0
+        # P2 #24 — consecutive-unknown alerting
+        self._unknown_threshold = max(1, int(unknown_threshold))
+        self._consecutive_unknown_count = 0
+        self._dump_dir = dump_dir
+        self.dumped_xml_path: Optional[str] = None
+        # P2 #24 — recovery override
+        self._forced_state: Optional[str] = None
 
     def set_bot(self, bot) -> None:
         """Set DamaiBot reference for delegation (e.g. reservation_mode check)."""
@@ -170,6 +184,14 @@ class PageProbe:
         Returns:
             A dict describing the page state and key element presence.
         """
+        # P2 #24 — recovery short-circuit: if a known state has been forced,
+        # return it without touching the device.
+        if self._forced_state is not None:
+            result = _make_result(state=self._forced_state)
+            self._cached_result = result
+            self._cached_at = time.time()
+            return result
+
         now = time.time()
         if (
             self._cached_result is not None
@@ -187,7 +209,67 @@ class PageProbe:
 
         self._cached_result = result
         self._cached_at = time.time()
+        self._track_unknown(result)
         return result
+
+    def force_state(self, state: Optional[Union["PageState", str]]) -> None:
+        """Force the probe to return a known state on subsequent calls.
+
+        Used by recovery modules that have external knowledge of the current
+        page (e.g. just dismissed a dialog and know we are back on detail_page)
+        to bypass the slower element-based classification.
+
+        Pass ``None`` to clear the override and resume normal probing.
+        """
+        if state is None:
+            self._forced_state = None
+            self.invalidate_cache()
+            logger.info("PageProbe.force_state: cleared override")
+            return
+        state_value = state.value if isinstance(state, PageState) else str(state)
+        self._forced_state = state_value
+        self._consecutive_unknown_count = 0
+        self.invalidate_cache()
+        logger.info("PageProbe.force_state: %s", state_value)
+
+    def _track_unknown(self, result: Dict[str, Any]) -> None:
+        """Count consecutive unknown classifications and dump UI on threshold."""
+        if (result or {}).get("state") != PageState.UNKNOWN.value:
+            self._consecutive_unknown_count = 0
+            return
+        self._consecutive_unknown_count += 1
+        if self._consecutive_unknown_count == self._unknown_threshold:
+            logger.warning(
+                "UNKNOWN_THRESHOLD reached after %d classifications",
+                self._consecutive_unknown_count,
+            )
+            self.dumped_xml_path = self._dump_unknown_xml()
+
+    def _dump_unknown_xml(self) -> Optional[str]:
+        """Persist the current UI hierarchy to ``<dump_dir>/page_probe_unknown_<ts>.xml``.
+
+        Returns the file path on success, or ``None`` if dumping failed.
+        Failures never raise — alerting is best-effort.
+        """
+        try:
+            os.makedirs(self._dump_dir, exist_ok=True)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("page probe dump dir create failed: %s", exc)
+            return None
+        try:
+            xml = self._device.dump_hierarchy() or ""
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("page probe dump_hierarchy failed: %s", exc)
+            xml = ""
+        ts = time.strftime("%Y%m%d_%H%M%S")
+        path = os.path.join(self._dump_dir, f"page_probe_unknown_{ts}.xml")
+        try:
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(xml)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("page probe dump write failed: %s", exc)
+            return None
+        return path
 
     def classify(self, fast: bool = False) -> Dict[str, Any]:
         """Public alias of :meth:`probe_current_page`.

--- a/tests/unit/test_event_navigator.py
+++ b/tests/unit/test_event_navigator.py
@@ -8,8 +8,11 @@ import pytest
 from mobile.event_navigator import (
     EventNavigator,
     HomeNotReadyError,
+    SearchAmbiguousError,
+    SearchEmptyError,
     SessionNotFoundError,
     _enumerate_sessions_from_xml,
+    select_search_result,
     select_session,
     wait_for_home_ready,
 )
@@ -398,3 +401,118 @@ class TestWaitForHomeReady:
         content = dumps[0].read_text(encoding="utf-8")
         assert "登录" in content
         assert "cn.damai:id/login_btn" in content
+
+
+# ---------------------------------------------------------------------------
+# select_search_result (P2 #23)
+# ---------------------------------------------------------------------------
+
+
+def _search_result_xml(*items):
+    """Build a hierarchy with N ``ll_search_item`` cards.
+
+    Each ``items`` entry is a tuple ``(title, bounds)``.
+    """
+    cards = ""
+    for title, bounds in items:
+        cards += (
+            f'<node resource-id="cn.damai:id/ll_search_item" '
+            f'clickable="true" bounds="{bounds}">'
+            f'<node resource-id="cn.damai:id/tv_project_name" text="{title}"/>'
+            f"</node>"
+        )
+    return f'<?xml version="1.0" encoding="UTF-8"?><hierarchy>{cards}</hierarchy>'
+
+
+class TestSelectSearchResult:
+    def _make_driver(self, xml):
+        driver = MagicMock()
+        driver.dump_hierarchy.return_value = xml
+        return driver
+
+    def test_search_result_zero_results_logs_keyword(self, tmp_path):
+        driver = self._make_driver('<?xml version="1.0" encoding="UTF-8"?><hierarchy/>')
+        with pytest.raises(SearchEmptyError) as exc_info:
+            select_search_result(
+                driver,
+                keyword="周杰伦演唱会",
+                timeout=0.1,
+                poll_interval=0.02,
+                dump_dir=str(tmp_path),
+            )
+        # keyword surfaced in exception message for debugging
+        assert "周杰伦演唱会" in str(exc_info.value)
+        assert "搜索结果为空" in str(exc_info.value)
+        # dump persisted
+        dumps = list(tmp_path.glob("search_probe_*.xml"))
+        assert len(dumps) == 1
+
+    def test_search_result_single_auto_select(self, tmp_path):
+        xml = _search_result_xml(("周杰伦演唱会上海站", "[0,0][1080,400]"))
+        driver = self._make_driver(xml)
+        chosen = select_search_result(
+            driver,
+            keyword="周杰伦",
+            timeout=0.5,
+            poll_interval=0.02,
+            dump_dir=str(tmp_path),
+        )
+        assert chosen["title"] == "周杰伦演唱会上海站"
+        # Center of [0,0][1080,400] = (540, 200)
+        driver.click.assert_called_once_with(540, 200)
+
+    def test_search_result_ambiguous_falls_back(self, tmp_path):
+        xml = _search_result_xml(
+            ("无关演出A", "[0,0][1080,200]"),
+            ("无关演出B", "[0,200][1080,400]"),
+        )
+        driver = self._make_driver(xml)
+        chosen = select_search_result(
+            driver,
+            keyword="周杰伦",
+            target_title="周杰伦",
+            timeout=0.2,
+            poll_interval=0.02,
+            dump_dir=str(tmp_path),
+        )
+        # Fuzzy match fails → fallback to first card (non-strict default)
+        assert chosen["title"] == "无关演出A"
+        assert chosen["index"] == 0
+        # Center of [0,0][1080,200] = (540, 100)
+        driver.click.assert_called_once_with(540, 100)
+
+    def test_search_result_strict_ambiguous_raises(self, tmp_path):
+        xml = _search_result_xml(
+            ("无关A", "[0,0][1080,200]"),
+            ("无关B", "[0,200][1080,400]"),
+        )
+        driver = self._make_driver(xml)
+        with pytest.raises(SearchAmbiguousError, match="歧义"):
+            select_search_result(
+                driver,
+                keyword="周杰伦",
+                target_title="周杰伦",
+                strict=True,
+                timeout=0.2,
+                poll_interval=0.02,
+                dump_dir=str(tmp_path),
+            )
+        dumps = list(tmp_path.glob("search_probe_*.xml"))
+        assert len(dumps) == 1
+
+    def test_search_result_target_title_fuzzy_matches_second(self, tmp_path):
+        xml = _search_result_xml(
+            ("无关演出", "[0,0][1080,200]"),
+            ("周杰伦2026演唱会", "[0,200][1080,400]"),
+        )
+        driver = self._make_driver(xml)
+        chosen = select_search_result(
+            driver,
+            keyword="周杰伦",
+            target_title="周杰伦",
+            timeout=0.2,
+            poll_interval=0.02,
+            dump_dir=str(tmp_path),
+        )
+        assert chosen["title"] == "周杰伦2026演唱会"
+        driver.click.assert_called_once_with(540, 300)

--- a/tests/unit/test_event_navigator.py
+++ b/tests/unit/test_event_navigator.py
@@ -7,9 +7,11 @@ import pytest
 
 from mobile.event_navigator import (
     EventNavigator,
+    HomeNotReadyError,
     SessionNotFoundError,
     _enumerate_sessions_from_xml,
     select_session,
+    wait_for_home_ready,
 )
 
 
@@ -343,3 +345,56 @@ class TestSelectSession:
         driver = self._make_driver(xml)
         idx = select_session(driver, date="04.13", city="北京", fallback_index=0)
         assert idx == 1  # date+city wins, fallback_index ignored
+
+
+# ---------------------------------------------------------------------------
+# wait_for_home_ready (P2 #28)
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForHomeReady:
+    def test_returns_immediately_when_homepage(self):
+        driver = MagicMock()
+        probe = MagicMock()
+        probe.classify.return_value = {"state": "homepage"}
+        result = wait_for_home_ready(driver, probe, timeout=0.5, poll_interval=0.05)
+        assert result["state"] == "homepage"
+        probe.invalidate_cache.assert_called()
+
+    def test_polls_until_homepage_appears(self):
+        driver = MagicMock()
+        probe = MagicMock()
+        probe.classify.side_effect = [
+            {"state": "unknown"},
+            {"state": "unknown"},
+            {"state": "homepage"},
+        ]
+        result = wait_for_home_ready(driver, probe, timeout=2.0, poll_interval=0.01)
+        assert result["state"] == "homepage"
+        assert probe.classify.call_count == 3
+
+    def test_home_page_probe_timeout(self, tmp_path):
+        driver = MagicMock()
+        driver.dump_hierarchy.return_value = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            "<hierarchy>"
+            '<node text="登录" resource-id="cn.damai:id/login_btn"/>'
+            "</hierarchy>"
+        )
+        probe = MagicMock()
+        probe.classify.return_value = {"state": "unknown"}
+
+        with pytest.raises(HomeNotReadyError, match="首页未就绪"):
+            wait_for_home_ready(
+                driver,
+                probe,
+                timeout=0.1,
+                poll_interval=0.02,
+                dump_dir=str(tmp_path),
+            )
+
+        dumps = list(tmp_path.glob("home_probe_*.xml"))
+        assert len(dumps) == 1, f"expected single dump, got {dumps}"
+        content = dumps[0].read_text(encoding="utf-8")
+        assert "登录" in content
+        assert "cn.damai:id/login_btn" in content

--- a/tests/unit/test_page_probe.py
+++ b/tests/unit/test_page_probe.py
@@ -454,3 +454,139 @@ class TestPageStateEnum:
         # Existing string-based equality must keep working.
         assert PageState.SKU_PAGE == "sku_page"
         assert PageState.SESSION_PICKER == "session_picker"
+
+
+# ---------------------------------------------------------------------------
+# Unknown threshold + force_state (P2 #24)
+# ---------------------------------------------------------------------------
+
+
+import os  # noqa: E402
+
+
+class TestUnknownThreshold:
+    def test_unknown_state_threshold_alerts(self, tmp_path):
+        # Empty activity + no element matches → state="unknown"
+        device = _make_device(activity="")
+        device.dump_hierarchy.return_value = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<hierarchy><node text="无法识别页面"/></hierarchy>'
+        )
+        probe = PageProbe(
+            device,
+            cache_ttl_s=0,
+            unknown_threshold=2,
+            dump_dir=str(tmp_path),
+        )
+
+        # First unknown — counter only, no dump yet.
+        r1 = probe.probe_current_page()
+        assert r1["state"] == "unknown"
+        assert probe.dumped_xml_path is None
+
+        # Second unknown — threshold reached.
+        r2 = probe.probe_current_page()
+        assert r2["state"] == "unknown"
+        assert probe.dumped_xml_path is not None
+        assert os.path.exists(probe.dumped_xml_path)
+        # Dump filename matches the agreed-upon convention.
+        assert os.path.basename(probe.dumped_xml_path).startswith("page_probe_unknown_")
+        # Hierarchy content was written.
+        with open(probe.dumped_xml_path, encoding="utf-8") as fh:
+            assert "无法识别页面" in fh.read()
+
+    def test_unknown_counter_resets_on_known_state(self, tmp_path):
+        device = _make_device(activity="")
+        device.dump_hierarchy.return_value = "<hierarchy/>"
+        probe = PageProbe(
+            device,
+            cache_ttl_s=0,
+            unknown_threshold=2,
+            dump_dir=str(tmp_path),
+        )
+
+        # First unknown.
+        assert probe.probe_current_page()["state"] == "unknown"
+        assert probe.dumped_xml_path is None
+
+        # Switch device to a known activity (homepage) to reset the counter.
+        device.app_current.return_value = {"activity": "cn.damai.homepage.MainActivity"}
+        assert probe.probe_current_page()["state"] == "homepage"
+        assert probe.dumped_xml_path is None
+
+        # Back to unknown — only one consecutive, still no dump.
+        device.app_current.return_value = {"activity": ""}
+        assert probe.probe_current_page()["state"] == "unknown"
+        assert probe.dumped_xml_path is None
+
+        # Second consecutive unknown — threshold (2) reached.
+        assert probe.probe_current_page()["state"] == "unknown"
+        assert probe.dumped_xml_path is not None
+        assert os.path.exists(probe.dumped_xml_path)
+
+    def test_unknown_threshold_clamps_to_min_one(self, tmp_path):
+        device = _make_device(activity="")
+        device.dump_hierarchy.return_value = "<hierarchy/>"
+        probe = PageProbe(
+            device,
+            cache_ttl_s=0,
+            unknown_threshold=0,
+            dump_dir=str(tmp_path),
+        )
+        # threshold=0 is clamped to 1 → first unknown triggers immediately.
+        probe.probe_current_page()
+        assert probe.dumped_xml_path is not None
+
+
+class TestForceState:
+    def test_force_state_overrides(self):
+        # Device would normally classify as unknown.
+        device = _make_device(activity="")
+        probe = PageProbe(device, cache_ttl_s=0)
+
+        probe.force_state(PageState.HOMEPAGE)
+
+        result = probe.probe_current_page()
+        assert result["state"] == "homepage"
+        # Forced state must not touch the device.
+        device.app_current.assert_not_called()
+
+    def test_force_state_accepts_string(self):
+        device = _make_device(activity="")
+        probe = PageProbe(device, cache_ttl_s=0)
+
+        probe.force_state("sku_page")
+        assert probe.probe_current_page()["state"] == "sku_page"
+
+    def test_force_state_clear_returns_to_probe(self):
+        device = _make_device(activity="cn.damai.homepage.MainActivity")
+        probe = PageProbe(device, cache_ttl_s=0)
+
+        probe.force_state(PageState.SKU_PAGE)
+        assert probe.probe_current_page()["state"] == "sku_page"
+
+        probe.force_state(None)
+        # Real probing resumes after override is cleared.
+        assert probe.probe_current_page()["state"] == "homepage"
+
+    def test_force_state_resets_unknown_counter(self, tmp_path):
+        device = _make_device(activity="")
+        device.dump_hierarchy.return_value = "<hierarchy/>"
+        probe = PageProbe(
+            device,
+            cache_ttl_s=0,
+            unknown_threshold=2,
+            dump_dir=str(tmp_path),
+        )
+        # Trip one unknown.
+        probe.probe_current_page()
+        assert probe.dumped_xml_path is None
+
+        # Force a known state — counter resets.
+        probe.force_state(PageState.HOMEPAGE)
+        probe.probe_current_page()
+        probe.force_state(None)
+
+        # One more unknown — only 1 consecutive after reset, no dump.
+        probe.probe_current_page()
+        assert probe.dumped_xml_path is None


### PR DESCRIPTION
## Summary
- **#28** 首页探测超时 + UI dump (`HomeNotReadyError`)
- **#23** 搜索结果列表可见性等待，区分 0/1/N 结果分流（`SearchEmptyError` / `SearchAmbiguousError`）
- **#24** `page_probe` 连续 unknown 阈值告警 + 自动 dump + `force_state` 接口

3 个 commit，每个 issue 一个：
1. `68628b8` fix(mobile): #28 首页探测加超时 + UI dump + HomeNotReadyError
2. `42af7ab` fix(mobile): #23 搜索结果可见性等待 + 0/1/N 结果分流
3. `e0eee1e` fix(mobile): #24 page_probe unknown 阈值告警 + 自动 dump + force_state

## 实现要点

### 模块布局
- 新增 `mobile/page_helpers.py`：承载 `wait_for_home_ready` / `select_search_result` / 三种新异常 + 共享 XML helpers，控制 `event_navigator.py` 仍在 800 行内。
- `event_navigator.py` 重新导出新名字，向后兼容（既有调用方与测试均可继续从 `mobile.event_navigator` 导入）。

### 异常体系（全部继承 `RuntimeError` 保持向后兼容）
- `HomeNotReadyError`
- `SearchEmptyError`
- `SearchAmbiguousError`
- 已有 `SessionNotFoundError`（未改）

### 落盘约定
- `tmp/home_probe_<ts>.xml`
- `tmp/search_probe_<ts>.xml`
- `tmp/page_probe_unknown_<ts>.xml`
- 命名统一 `<scene>_<ts>.xml`，`tmp/` 已在 `.gitignore`

## 阻塞应对（按 brief 备注）
- #23 报告中提到的 keyword 拆分（"AAA 演唱会" → "AAA"）需求，已在 commit message 与本 PR 体记录，**不在本 PR 实施**，留给后续 issue。
- #24 阈值告警走 `logger.warning`，未引入 metric 系统。
- `force_state` 与 recovery 模块未发现死锁，正常交付。

## Test plan
- [x] `poetry run pytest --cov=mobile --cov-fail-under=80` 全绿（1018 passed，coverage 80.95%）
- [x] 触类单测：`tests/unit/test_event_navigator.py`（43 passed）+ `tests/unit/test_page_probe.py`（35 passed）
- [ ] 真机抽样验证（W3-03 qa）

## 关联
- Closes #28
- Closes #23
- Closes #24