### PR TITLE
feat(mobile): 可观测性增强（结构化日志 + 失败工件）

### DIFF
--- a/mobile/damai_app/orchestrator.py
+++ b/mobile/damai_app/orchestrator.py
@@ -12,12 +12,20 @@ sibling submodules: ``sale_waiter``, ``purchase_flow``,
 from __future__ import annotations
 
 import re
+import sys
 import time
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
 from selenium.webdriver.common.by import By
+
+try:
+    from mobile.env_snapshot import detect_damai_app_version
+    from mobile.logger import log_event
+except ImportError:  # pragma: no cover
+    from env_snapshot import detect_damai_app_version  # type: ignore[no-redef]
+    from logger import log_event  # type: ignore[no-redef]
 
 from . import (
     ANDROID_UIAUTOMATOR,
@@ -97,6 +105,27 @@ class DamaiBot(
             self._navigator._probe = self._page_probe
             self._recovery = RecoveryHelper(self.d, self._page_probe, self._navigator)
             self._price_sel._probe = self._page_probe
+
+        if setup_driver:
+            self._emit_boot_snapshot()
+
+    def _emit_boot_snapshot(self) -> None:
+        """Emit a one-shot ``event=boot`` log line with environment metadata."""
+        try:
+            serial = getattr(self.config, "serial", None) or getattr(
+                self.config, "device_serial", None
+            )
+            damai_version = detect_damai_app_version(serial=serial) or "unknown"
+            log_event(
+                logger,
+                "boot",
+                py_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+                damai_version=damai_version,
+                device=serial or "unknown",
+                rush_mode=bool(getattr(self.config, "rush_mode", False)),
+            )
+        except Exception:  # pragma: no cover — boot logging must never crash startup
+            logger.debug("boot snapshot failed (suppressed)", exc_info=True)
 
     def _ensure_pipeline(self):
         """Lazily create the FastPipeline if not yet initialised (e.g. in tests)."""
@@ -1018,6 +1047,12 @@ class DamaiBot(
 
         except Exception as e:
             logger.error(f"抢票过程发生错误: {e}")
+            try:
+                from .recovery_strategies import capture_failure_artifacts
+
+                capture_failure_artifacts(self, "run_ticket_grabbing", error=e)
+            except Exception:  # pragma: no cover — failure capture must not crash
+                logger.debug("failure artifact capture failed", exc_info=True)
             return False
         finally:
             time.sleep(0.05)

--- a/mobile/damai_app/purchase_flow.py
+++ b/mobile/damai_app/purchase_flow.py
@@ -7,10 +7,18 @@ change).  Hosts the detail→purchase entry path and the fast submit retry loop.
 
 from __future__ import annotations
 
+import logging
+import time
+
 from . import (
     _SALE_READY_TEXT_REGEX_OR,
     logger,
 )
+
+try:
+    from mobile.logger import log_event
+except ImportError:  # pragma: no cover
+    from logger import log_event  # type: ignore[no-redef]
 
 try:
     from mobile.ui_primitives import ANDROID_UIAUTOMATOR
@@ -138,6 +146,7 @@ class PurchaseFlowMixin:
         """Attempt submit quickly and retry within the confirm page before falling back."""
         attempt_count = 3
         has_submitted_once = False
+        t0 = time.monotonic()
         for attempt in range(attempt_count):
             submit_success = False
             if self.ultra_fast_click(*submit_selectors[0], timeout=0.35):
@@ -154,16 +163,50 @@ class PurchaseFlowMixin:
                 if has_submitted_once:
                     followup_result = self.verify_order_result(timeout=2)
                     if followup_result != "timeout":
+                        log_event(
+                            logger,
+                            "order_submitted",
+                            success=followup_result not in ("timeout", "failed"),
+                            result=followup_result,
+                            attempts=attempt + 1,
+                            duration_ms=int((time.monotonic() - t0) * 1000),
+                        )
                         return followup_result
+                log_event(
+                    logger,
+                    "order_submitted",
+                    level=logging.WARNING,
+                    success=False,
+                    result="button_not_found",
+                    attempts=attempt + 1,
+                    duration_ms=int((time.monotonic() - t0) * 1000),
+                )
                 return "timeout"
 
             has_submitted_once = True
             verify_timeout = 1.2 if attempt < attempt_count - 1 else 3
             result = self.verify_order_result(timeout=verify_timeout)
             if result != "timeout":
+                log_event(
+                    logger,
+                    "order_submitted",
+                    success=result not in ("timeout", "failed"),
+                    result=result,
+                    attempts=attempt + 1,
+                    duration_ms=int((time.monotonic() - t0) * 1000),
+                )
                 return result
             logger.warning(
                 f"提交后暂未确认结果，快速重试提交 {attempt + 2}/{attempt_count}"
             )
 
+        log_event(
+            logger,
+            "order_submitted",
+            level=logging.WARNING,
+            success=False,
+            result="timeout",
+            attempts=attempt_count,
+            duration_ms=int((time.monotonic() - t0) * 1000),
+        )
         return "timeout"

--- a/mobile/damai_app/recovery_strategies.py
+++ b/mobile/damai_app/recovery_strategies.py
@@ -8,9 +8,23 @@ recovery loops shared between the cold-path and warm-path retries.
 
 from __future__ import annotations
 
+import hashlib
+import json
+import logging
+import os
 import time
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 from . import logger
+
+try:
+    from mobile.env_snapshot import detect_damai_app_version
+    from mobile.logger import log_event
+except ImportError:  # pragma: no cover
+    from env_snapshot import detect_damai_app_version  # type: ignore[no-redef]
+    from logger import log_event  # type: ignore[no-redef]
 
 try:
     from mobile.ui_primitives import ANDROID_UIAUTOMATOR
@@ -21,6 +35,168 @@ try:
     from selenium.webdriver.common.by import By
 except ModuleNotFoundError:  # pragma: no cover
     raise
+
+
+# Failure artifacts root.  Tests override via the ``root`` argument so we
+# can lazy-resolve here without binding to a CWD at import time.
+def _default_failure_root() -> Path:
+    project_root = Path(__file__).resolve().parents[2]
+    return project_root / "tmp" / "failures"
+
+
+_FAILURE_TS_TZ = timezone(timedelta(hours=8))
+
+
+def _slugify_scene(scene: str) -> str:
+    """Compress ``scene`` into a filesystem-safe slug ([a-z0-9_-]+)."""
+    cleaned = "".join(
+        c if c.isalnum() or c in ("-", "_") else "_" for c in scene.lower()
+    )
+    cleaned = cleaned.strip("_-") or "scene"
+    return cleaned[:48]
+
+
+def _config_hash(cfg: Any) -> str:
+    """Stable short hash of a config object's public attributes."""
+    if cfg is None:
+        return "none"
+    try:
+        if hasattr(cfg, "__dict__"):
+            payload = {
+                k: repr(v) for k, v in vars(cfg).items() if not k.startswith("_")
+            }
+        else:
+            payload = {"repr": repr(cfg)}
+        encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    except Exception:
+        encoded = repr(cfg)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:12]
+
+
+def capture_failure_artifacts(
+    bot,
+    scene: str,
+    *,
+    error: Optional[BaseException] = None,
+    extra: Optional[Dict[str, Any]] = None,
+    root: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Persist UI XML, screenshot, and metadata for a failed run.
+
+    Output: ``tmp/failures/<YYYYmmdd-HHMMSS-mmm>_<scene>.{xml,png,json}``.
+    Best-effort — every step is wrapped so logging failures never crash the
+    caller (already inside an ``except`` block).
+
+    Args:
+        bot: A ``DamaiBot`` (or stand-in) exposing ``d`` (uiautomator2 device)
+            and ``config``.
+        scene: Short tag identifying the failure context (e.g. ``run_ticket``).
+        error: Optional exception that triggered the dump.
+        extra: Optional metadata fields merged into the JSON payload.
+        root: Override directory.  Defaults to ``<repo>/tmp/failures``.
+
+    Returns:
+        A dict describing which artifacts were written: keys ``xml``, ``png``,
+        ``json`` map to the absolute path (str) or ``None`` when that artifact
+        could not be produced.
+    """
+    out_root = root or _default_failure_root()
+    try:
+        out_root.mkdir(parents=True, exist_ok=True)
+    except Exception:  # pragma: no cover — directory creation is best-effort
+        log_event(
+            logger,
+            "failure_capture_skipped",
+            level=logging.WARNING,
+            scene=scene,
+            reason="mkdir_failed",
+            root=str(out_root),
+        )
+        return {"xml": None, "png": None, "json": None}
+
+    ts = datetime.now(tz=_FAILURE_TS_TZ).strftime("%Y%m%d-%H%M%S-%f")[:-3]
+    base = out_root / f"{ts}_{_slugify_scene(scene)}"
+    xml_path = base.with_suffix(".xml")
+    png_path = base.with_suffix(".png")
+    json_path = base.with_suffix(".json")
+
+    written: Dict[str, Any] = {"xml": None, "png": None, "json": None}
+    screenshot_failed = False
+
+    device = getattr(bot, "d", None)
+
+    try:
+        if device is not None and hasattr(device, "dump_hierarchy"):
+            xml_str = device.dump_hierarchy()
+            if isinstance(xml_str, bytes):
+                xml_path.write_bytes(xml_str)
+            else:
+                xml_path.write_text(xml_str or "", encoding="utf-8")
+            written["xml"] = str(xml_path)
+    except Exception as exc:
+        logger.debug(f"dump_hierarchy failed during artifact capture: {exc}")
+
+    try:
+        if device is not None and hasattr(device, "screenshot"):
+            shot = device.screenshot()
+            if shot is None:
+                screenshot_failed = True
+            elif hasattr(shot, "save"):
+                shot.save(str(png_path))
+                written["png"] = str(png_path)
+            elif isinstance(shot, (bytes, bytearray)):
+                png_path.write_bytes(bytes(shot))
+                written["png"] = str(png_path)
+            else:
+                screenshot_failed = True
+        else:
+            screenshot_failed = True
+    except Exception as exc:
+        screenshot_failed = True
+        logger.debug(f"screenshot failed during artifact capture: {exc}")
+
+    cfg = getattr(bot, "config", None)
+    serial = (
+        getattr(cfg, "serial", None)
+        or getattr(cfg, "device_serial", None)
+        or os.environ.get("ANDROID_SERIAL")
+    )
+    metadata: Dict[str, Any] = {
+        "timestamp": ts,
+        "scene": scene,
+        "device": serial or "unknown",
+        "damai_version": detect_damai_app_version(serial=serial) or "unknown",
+        "config_hash": _config_hash(cfg),
+        "screenshot_failed": screenshot_failed,
+        "xml_path": written["xml"],
+        "png_path": written["png"],
+    }
+    if error is not None:
+        metadata["error_type"] = type(error).__name__
+        metadata["error_message"] = str(error)
+    if extra:
+        metadata.update(extra)
+
+    try:
+        json_path.write_text(
+            json.dumps(metadata, ensure_ascii=False, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        written["json"] = str(json_path)
+    except Exception as exc:  # pragma: no cover
+        logger.debug(f"failure metadata write failed: {exc}")
+
+    log_event(
+        logger,
+        "failure_captured",
+        level=logging.WARNING,
+        scene=scene,
+        xml=written["xml"] is not None,
+        png=written["png"] is not None,
+        json=written["json"] is not None,
+        screenshot_failed=screenshot_failed,
+    )
+    return written
 
 
 class RecoveryStrategiesMixin:

--- a/mobile/damai_app/sale_waiter.py
+++ b/mobile/damai_app/sale_waiter.py
@@ -9,6 +9,7 @@ patches still take effect via the package's mirror hook.
 
 from __future__ import annotations
 
+import logging
 import time
 from datetime import datetime, timezone, timedelta
 
@@ -18,6 +19,11 @@ from . import (
     _CTA_READY_KEYWORDS,
     logger,
 )
+
+try:
+    from mobile.logger import log_event
+except ImportError:  # pragma: no cover
+    from logger import log_event  # type: ignore[no-redef]
 
 try:
     from mobile.item_resolver import normalize_text
@@ -124,21 +130,43 @@ class SaleWaiterMixin:
             time.sleep(sleep_seconds)
 
         # Use BuyButtonGuard for precise button-text monitoring
+        guard_t0 = time.monotonic()
         if hasattr(self, "_guard") and self._guard.wait_until_safe(
             timeout_s=8.0, poll_ms=50
         ):
-            logger.info("BuyButtonGuard 检测到可购买按钮")
+            log_event(
+                logger,
+                "sale_ready",
+                source="buy_button_guard",
+                cta_text=None,
+                polls=None,
+                duration_ms=int((time.monotonic() - guard_t0) * 1000),
+            )
             return
 
         # Tight polling loop with multiple purchase signals until the page becomes actionable.
         deadline = sell_time + timedelta(seconds=8)
         polls = 0
+        loop_t0 = time.monotonic()
         while datetime.now(tz=_tz_shanghai) < deadline:
             polls += 1
             if self._is_sale_ready():
                 cta_text = getattr(self, "_last_sale_ready_text", None) or "?"
-                logger.info(f"CTA_MATCH: text={cta_text!r} polls={polls} (开售已开始)")
+                log_event(
+                    logger,
+                    "sale_ready",
+                    source="poll_loop",
+                    cta_text=cta_text,
+                    polls=polls,
+                    duration_ms=int((time.monotonic() - loop_t0) * 1000),
+                )
                 return
             time.sleep(0.08)
 
-        logger.warning(f"等待开售超时（轮询 {polls} 次），继续执行")
+        log_event(
+            logger,
+            "sale_wait_timeout",
+            level=logging.WARNING,
+            polls=polls,
+            duration_ms=int((time.monotonic() - loop_t0) * 1000),
+        )

--- a/mobile/env_snapshot.py
+++ b/mobile/env_snapshot.py
@@ -1,0 +1,90 @@
+# -*- coding: UTF-8 -*-
+"""Environment snapshot helpers for boot-time observability.
+
+Used by ``DamaiBot.__init__`` to record a structured ``event=boot`` log line
+including the runtime Python version, the installed Damai app version (when
+detectable via ``adb``) and the bound device serial.
+
+Failure semantics: every helper here is best-effort.  Missing ``adb``,
+unbound device, or unexpected ``pm dump`` output all map to ``None`` so the
+caller can record ``damai_version=unknown`` instead of crashing the boot.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from typing import Optional
+
+# Damai Android package id (matches Config.app_package default).
+_DAMAI_PACKAGE = "cn.damai"
+
+# `adb shell pm dump cn.damai` exposes the version near the start, e.g.:
+#     versionName=10.6.1
+#     versionCode=10060100
+_VERSION_NAME_RE = re.compile(r"versionName=([^\s]+)")
+
+
+def _run_adb_pm_dump(
+    serial: Optional[str] = None,
+    package: str = _DAMAI_PACKAGE,
+    timeout_s: float = 3.0,
+) -> Optional[str]:
+    """Invoke ``adb shell pm dump <package>`` and return stdout, or None on any failure.
+
+    Args:
+        serial: Optional device serial; when given, ``-s <serial>`` is added.
+        package: Android package to dump (defaults to Damai).
+        timeout_s: Subprocess timeout in seconds.
+    """
+    if shutil.which("adb") is None:
+        return None
+
+    cmd = ["adb"]
+    if serial:
+        cmd.extend(["-s", serial])
+    cmd.extend(["shell", "pm", "dump", package])
+
+    try:
+        result = subprocess.run(  # noqa: S603 — adb is a trusted binary
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if result.returncode != 0:
+        return None
+    return result.stdout or None
+
+
+def detect_damai_app_version(
+    serial: Optional[str] = None,
+    *,
+    package: str = _DAMAI_PACKAGE,
+    _runner=None,
+) -> Optional[str]:
+    """Return the installed Damai app ``versionName`` (e.g. ``"10.6.1"``).
+
+    Args:
+        serial: Optional device serial passed to ``adb -s``.
+        package: Android package id to query.
+        _runner: Test seam — callable matching :func:`_run_adb_pm_dump`'s
+            signature.  Production callers should not set this.
+
+    Returns:
+        The ``versionName`` string, or ``None`` if adb is unavailable, the
+        device cannot be reached, or no ``versionName=...`` line is present.
+    """
+    runner = _runner or _run_adb_pm_dump
+    output = runner(serial=serial, package=package)
+    if not output:
+        return None
+    match = _VERSION_NAME_RE.search(output)
+    if not match:
+        return None
+    return match.group(1).strip() or None

--- a/mobile/event_navigator.py
+++ b/mobile/event_navigator.py
@@ -7,6 +7,7 @@ while the actual implementation lives here.
 
 from __future__ import annotations
 
+import logging
 import re
 import time
 import xml.etree.ElementTree as ET
@@ -17,7 +18,7 @@ from selenium.webdriver.common.by import By
 from mobile.ui_primitives import ANDROID_UIAUTOMATOR
 from selenium.common.exceptions import TimeoutException
 
-from mobile.logger import get_logger
+from mobile.logger import get_logger, log_event
 
 try:
     from mobile.item_resolver import normalize_text, city_keyword
@@ -150,13 +151,28 @@ def select_session(
     Raises:
         SessionNotFoundError: When no unique candidate can be picked.
     """
+
+    def _emit_err(scene: str, type_name: str = "SessionNotFoundError", **extra):
+        log_event(
+            logger,
+            "error",
+            level=logging.ERROR,
+            type=type_name,
+            scene=scene,
+            date=date,
+            city=city,
+            **extra,
+        )
+
     try:
         xml_str = driver.dump_hierarchy()
     except Exception as exc:  # noqa: BLE001
+        _emit_err("select_session.dump_hierarchy", type_name=type(exc).__name__)
         raise SessionNotFoundError(f"dump_hierarchy 失败: {exc}") from exc
 
     cards = _enumerate_sessions_from_xml(xml_str)
     if not cards:
+        _emit_err("select_session.no_cards")
         raise SessionNotFoundError(
             "未发现可选场次（sku_panel_dates 内未找到 tv_date 节点）"
         )
@@ -169,14 +185,17 @@ def select_session(
         ]
         if len(matches) == 1:
             chosen = matches[0]
-            logger.info(
-                "select_session: date=%s + city=%s 命中 idx=%d/%d",
-                date,
-                city,
-                chosen["index"],
-                len(cards),
+            log_event(
+                logger,
+                "session_selected",
+                match="date+city",
+                date=date,
+                city=city,
+                index=chosen["index"],
+                total=len(cards),
             )
         elif len(matches) > 1:
+            _emit_err("select_session.ambiguous_date_city", matches=len(matches))
             raise SessionNotFoundError(
                 f"date={date} + city={city} 命中 {len(matches)} 条场次，无法唯一确定"
             )
@@ -185,13 +204,17 @@ def select_session(
         matches = [c for c in cards if _date_equals(c["date"], date)]
         if len(matches) == 1:
             chosen = matches[0]
-            logger.info(
-                "select_session: date=%s 唯一命中 idx=%d/%d",
-                date,
-                chosen["index"],
-                len(cards),
+            log_event(
+                logger,
+                "session_selected",
+                match="date",
+                date=date,
+                city=None,
+                index=chosen["index"],
+                total=len(cards),
             )
         elif len(matches) > 1:
+            _emit_err("select_session.ambiguous_date_only", matches=len(matches))
             raise SessionNotFoundError(
                 f"date={date} 命中 {len(matches)} 条场次，需配合 city 才能确定"
             )
@@ -199,17 +222,26 @@ def select_session(
     if chosen is None and fallback_index is not None:
         if 0 <= fallback_index < len(cards):
             chosen = cards[fallback_index]
-            logger.warning(
-                "select_session: 回退到 fallback_index=%d (共 %d 条)",
-                fallback_index,
-                len(cards),
+            log_event(
+                logger,
+                "session_selected",
+                level=logging.WARNING,
+                match="fallback_index",
+                index=fallback_index,
+                total=len(cards),
             )
         else:
+            _emit_err(
+                "select_session.fallback_out_of_range",
+                fallback_index=fallback_index,
+                total=len(cards),
+            )
             raise SessionNotFoundError(
                 f"fallback_index={fallback_index} 越界（共 {len(cards)} 条场次）"
             )
 
     if chosen is None:
+        _emit_err("select_session.no_criteria", total=len(cards))
         raise SessionNotFoundError(
             f"未提供 date/city/fallback_index，无法选择场次（共 {len(cards)} 条候选）"
         )

--- a/mobile/logger.py
+++ b/mobile/logger.py
@@ -3,10 +3,12 @@
 Unified logging framework for HaTickets mobile module.
 
 Usage:
-    from logger import get_logger
+    from logger import get_logger, log_event
     logger = get_logger(__name__)
     logger.info("消息内容")
+    log_event(logger, "sale_ready", cta_text="立即购票", polls=12, duration_ms=480)
 """
+
 import logging
 import os
 from datetime import datetime, timezone, timedelta
@@ -15,7 +17,9 @@ from typing import Optional, Set
 # Asia/Shanghai timezone (UTC+8)
 _TZ_SHANGHAI = timezone(timedelta(hours=8))
 
-_LOG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hatickets_mobile.log")
+_LOG_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "hatickets_mobile.log"
+)
 
 _CONSOLE_FORMAT = "%(asctime)s [%(levelname)s] %(message)s"
 _FILE_FORMAT = "%(asctime)s [%(levelname)s] %(name)s:%(lineno)d - %(message)s"
@@ -34,7 +38,9 @@ _ANSI_COLORS = {
 class _ShanghaiFormatter(logging.Formatter):
     """Logging formatter that uses Asia/Shanghai timezone for timestamps."""
 
-    def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
+    def formatTime(
+        self, record: logging.LogRecord, datefmt: Optional[str] = None
+    ) -> str:
         dt = datetime.fromtimestamp(record.created, tz=_TZ_SHANGHAI)
         if datefmt:
             return dt.strftime(datefmt)
@@ -115,3 +121,47 @@ def get_logger(name: str) -> logging.Logger:
         _configured_loggers.add(name)
 
     return logger
+
+
+def _format_event_value(value) -> str:
+    """Render a field value for structured event logs (no whitespace, quote-safe)."""
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    text = str(value)
+    # Collapse whitespace so a single line stays parseable as `key=value` pairs.
+    text = " ".join(text.split())
+    if not text:
+        return '""'
+    if any(c in text for c in (" ", "\t", "=", '"')):
+        text = text.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{text}"'
+    return text
+
+
+def log_event(
+    logger: logging.Logger,
+    event: str,
+    *,
+    level: int = logging.INFO,
+    **fields,
+) -> None:
+    """Emit a structured event log line.
+
+    Output shape: ``event=<name> key1=value1 key2=value2``.  Values containing
+    whitespace, ``=`` or quotes are quoted/escaped so the line stays grep-able
+    and downstream-parseable.
+
+    Args:
+        logger: Target logger (typically obtained via :func:`get_logger`).
+        event: Short snake_case event name (e.g. ``sale_ready``).
+        level: Logging level (default :data:`logging.INFO`).
+        **fields: Arbitrary key/value pairs serialized to the log line.
+    """
+    parts = [f"event={_format_event_value(event)}"]
+    for key, value in fields.items():
+        parts.append(f"{key}={_format_event_value(value)}")
+    logger.log(level, " ".join(parts))

--- a/tests/unit/test_env_snapshot.py
+++ b/tests/unit/test_env_snapshot.py
@@ -1,0 +1,137 @@
+# -*- coding: UTF-8 -*-
+"""Tests for mobile.env_snapshot."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mobile.env_snapshot import _run_adb_pm_dump, detect_damai_app_version
+
+
+# ---------------------------------------------------------------------------
+# detect_damai_app_version (uses _runner injection — no subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectDamaiAppVersion:
+    def test_returns_version_when_pm_dump_contains_version_name(self):
+        runner = MagicMock(
+            return_value=(
+                "Packages:\n"
+                "  Package [cn.damai]:\n"
+                "    versionName=10.6.1\n"
+                "    versionCode=10060100\n"
+            )
+        )
+        assert detect_damai_app_version(_runner=runner) == "10.6.1"
+        runner.assert_called_once_with(serial=None, package="cn.damai")
+
+    def test_passes_serial_through_to_runner(self):
+        runner = MagicMock(return_value="versionName=9.5.0")
+        detect_damai_app_version(serial="emulator-5554", _runner=runner)
+        runner.assert_called_once_with(serial="emulator-5554", package="cn.damai")
+
+    def test_returns_none_when_runner_returns_none(self):
+        runner = MagicMock(return_value=None)
+        assert detect_damai_app_version(_runner=runner) is None
+
+    def test_returns_none_when_runner_returns_empty_string(self):
+        runner = MagicMock(return_value="")
+        assert detect_damai_app_version(_runner=runner) is None
+
+    def test_returns_none_when_no_version_name_line(self):
+        runner = MagicMock(return_value="Packages:\n  No matching packages\n")
+        assert detect_damai_app_version(_runner=runner) is None
+
+    def test_returns_none_when_version_name_value_is_empty(self):
+        runner = MagicMock(return_value="versionName=\nversionCode=1")
+        assert detect_damai_app_version(_runner=runner) is None
+
+    def test_picks_first_version_name_when_multiple_present(self):
+        runner = MagicMock(return_value="versionName=10.6.1\nversionName=9.0.0")
+        assert detect_damai_app_version(_runner=runner) == "10.6.1"
+
+    def test_custom_package_is_forwarded(self):
+        runner = MagicMock(return_value="versionName=1.0.0")
+        detect_damai_app_version(package="com.other.app", _runner=runner)
+        runner.assert_called_once_with(serial=None, package="com.other.app")
+
+
+# ---------------------------------------------------------------------------
+# _run_adb_pm_dump — real-ish behavior with mocked subprocess
+#
+# NOTE: Avoid Python 3.10's parenthesised ``with (..., ...)`` syntax to keep
+# the suite parseable on the project's Python 3.8 baseline.
+# ---------------------------------------------------------------------------
+
+
+class TestRunAdbPmDump:
+    def test_returns_none_when_adb_not_on_path(self):
+        with patch("mobile.env_snapshot.shutil.which", return_value=None):
+            assert _run_adb_pm_dump() is None
+
+    def test_calls_subprocess_run_with_expected_command(self):
+        completed = subprocess.CompletedProcess(
+            args=["adb"], returncode=0, stdout="versionName=1.2.3", stderr=""
+        )
+        with patch("mobile.env_snapshot.shutil.which", return_value="/usr/bin/adb"):
+            with patch(
+                "mobile.env_snapshot.subprocess.run", return_value=completed
+            ) as mock_run:
+                assert _run_adb_pm_dump(serial=None) == "versionName=1.2.3"
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["adb", "shell", "pm", "dump", "cn.damai"]
+
+    def test_includes_serial_flag_when_provided(self):
+        completed = subprocess.CompletedProcess(
+            args=["adb"], returncode=0, stdout="ok", stderr=""
+        )
+        with patch("mobile.env_snapshot.shutil.which", return_value="/usr/bin/adb"):
+            with patch(
+                "mobile.env_snapshot.subprocess.run", return_value=completed
+            ) as mock_run:
+                _run_adb_pm_dump(serial="dev1")
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["adb", "-s", "dev1", "shell", "pm", "dump", "cn.damai"]
+
+    def test_returns_none_on_non_zero_exit(self):
+        completed = subprocess.CompletedProcess(
+            args=["adb"], returncode=1, stdout="", stderr="error"
+        )
+        with patch("mobile.env_snapshot.shutil.which", return_value="/usr/bin/adb"):
+            with patch("mobile.env_snapshot.subprocess.run", return_value=completed):
+                assert _run_adb_pm_dump() is None
+
+    def test_returns_none_on_subprocess_timeout(self):
+        with patch("mobile.env_snapshot.shutil.which", return_value="/usr/bin/adb"):
+            with patch(
+                "mobile.env_snapshot.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="adb", timeout=3.0),
+            ):
+                assert _run_adb_pm_dump() is None
+
+    def test_returns_none_on_oserror(self):
+        with patch("mobile.env_snapshot.shutil.which", return_value="/usr/bin/adb"):
+            with patch(
+                "mobile.env_snapshot.subprocess.run",
+                side_effect=FileNotFoundError("adb missing at runtime"),
+            ):
+                assert _run_adb_pm_dump() is None
+
+    def test_returns_none_when_stdout_is_empty(self):
+        completed = subprocess.CompletedProcess(
+            args=["adb"], returncode=0, stdout="", stderr=""
+        )
+        with patch("mobile.env_snapshot.shutil.which", return_value="/usr/bin/adb"):
+            with patch("mobile.env_snapshot.subprocess.run", return_value=completed):
+                assert _run_adb_pm_dump() is None
+
+
+@pytest.mark.unit
+def test_detect_damai_app_version_smoke_with_real_runner_path_missing(monkeypatch):
+    """End-to-end smoke: with adb not on PATH, the public API returns None."""
+    monkeypatch.setattr("mobile.env_snapshot.shutil.which", lambda _name: None)
+    assert detect_damai_app_version() is None

--- a/tests/unit/test_mobile_logger.py
+++ b/tests/unit/test_mobile_logger.py
@@ -10,10 +10,12 @@ from mobile.logger import (
     _ShanghaiFormatter,
     _supports_color,
     get_logger,
+    log_event,
     _ANSI_COLORS,
     _ANSI_RESET,
     _DATE_FORMAT,
     _configured_loggers,
+    _format_event_value,
 )
 
 
@@ -207,3 +209,105 @@ class TestGetLogger:
         finally:
             lgr1.handlers.clear()
             _configured_loggers.discard(name)
+
+
+# ---------------------------------------------------------------------------
+# _format_event_value
+# ---------------------------------------------------------------------------
+
+
+class TestFormatEventValue:
+    def test_none_renders_none(self):
+        assert _format_event_value(None) == "none"
+
+    def test_bool_renders_lowercase(self):
+        assert _format_event_value(True) == "true"
+        assert _format_event_value(False) == "false"
+
+    def test_int_renders_plain(self):
+        assert _format_event_value(42) == "42"
+
+    def test_float_renders_plain(self):
+        assert _format_event_value(1.25) == "1.25"
+
+    def test_simple_string_unquoted(self):
+        assert _format_event_value("ready") == "ready"
+
+    def test_empty_string_quoted(self):
+        assert _format_event_value("") == '""'
+
+    def test_string_with_space_is_quoted(self):
+        assert _format_event_value("立即 购票") == '"立即 购票"'
+
+    def test_string_with_equals_is_quoted(self):
+        assert _format_event_value("a=b") == '"a=b"'
+
+    def test_string_with_double_quote_is_escaped(self):
+        assert _format_event_value('say "hi"') == '"say \\"hi\\""'
+
+    def test_multiline_collapsed(self):
+        assert _format_event_value("line1\nline2") == '"line1 line2"'
+
+
+# ---------------------------------------------------------------------------
+# log_event
+# ---------------------------------------------------------------------------
+
+
+class TestLogEvent:
+    def _make_capturing_logger(self, name: str):
+        lgr = logging.getLogger(name)
+        lgr.handlers.clear()
+        lgr.setLevel(logging.DEBUG)
+        lgr.propagate = False
+        captured = []
+
+        class CaptureHandler(logging.Handler):
+            def emit(self, record):
+                captured.append((record.levelno, record.getMessage()))
+
+        lgr.addHandler(CaptureHandler())
+        return lgr, captured
+
+    def test_emits_event_at_info_by_default(self):
+        lgr, captured = self._make_capturing_logger("test_log_event_default")
+        log_event(lgr, "sale_ready", cta_text="立即购票", polls=12, duration_ms=480)
+        assert len(captured) == 1
+        level, msg = captured[0]
+        assert level == logging.INFO
+        assert msg.startswith("event=sale_ready ")
+        # Plain CJK without whitespace stays unquoted (single-token field).
+        assert "cta_text=立即购票" in msg
+        assert "polls=12" in msg
+        assert "duration_ms=480" in msg
+
+    def test_explicit_level_respected(self):
+        lgr, captured = self._make_capturing_logger("test_log_event_error")
+        log_event(
+            lgr,
+            "error",
+            level=logging.ERROR,
+            type="SoldOutError",
+            scene="price_select",
+        )
+        assert captured[0][0] == logging.ERROR
+        assert "event=error" in captured[0][1]
+        assert "type=SoldOutError" in captured[0][1]
+        assert "scene=price_select" in captured[0][1]
+
+    def test_no_fields_renders_event_only(self):
+        lgr, captured = self._make_capturing_logger("test_log_event_bare")
+        log_event(lgr, "boot")
+        assert captured[0][1] == "event=boot"
+
+    def test_none_field_renders_none_token(self):
+        lgr, captured = self._make_capturing_logger("test_log_event_none")
+        log_event(lgr, "boot", damai_version=None)
+        assert "damai_version=none" in captured[0][1]
+
+    def test_field_order_preserved(self):
+        lgr, captured = self._make_capturing_logger("test_log_event_order")
+        log_event(lgr, "session_selected", date="2026-05-30", city="北京", index=2)
+        msg = captured[0][1]
+        # Order: event → date → city → index
+        assert msg.index("date=") < msg.index("city=") < msg.index("index=")

--- a/tests/unit/test_recovery_artifacts.py
+++ b/tests/unit/test_recovery_artifacts.py
@@ -1,0 +1,275 @@
+# -*- coding: UTF-8 -*-
+"""Tests for mobile.damai_app.recovery_strategies.capture_failure_artifacts.
+
+The helper is exercised standalone (no real device, no real Damai package);
+fakes simulate a uiautomator2 device's ``dump_hierarchy()`` and
+``screenshot()`` to keep these tests hermetic and fast.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mobile.damai_app.recovery_strategies import (
+    _config_hash,
+    _slugify_scene,
+    capture_failure_artifacts,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeConfig:
+    def __init__(self, *, serial="device-A", rush_mode=True, sell_start_time=None):
+        self.serial = serial
+        self.rush_mode = rush_mode
+        self.sell_start_time = sell_start_time
+
+
+class _FakeImage:
+    """Minimal stand-in for a uiautomator2 ``screenshot()`` PIL Image."""
+
+    def __init__(self):
+        self.saved_to = None
+
+    def save(self, path):
+        self.saved_to = path
+        Path(path).write_bytes(b"\x89PNG\r\n\x1a\n-fake-")
+
+
+class _FakeDevice:
+    def __init__(self, *, xml="<hierarchy/>", screenshot_kind="image"):
+        self._xml = xml
+        self._screenshot_kind = screenshot_kind
+        self.dump_calls = 0
+        self.screenshot_calls = 0
+
+    def dump_hierarchy(self):
+        self.dump_calls += 1
+        if isinstance(self._xml, BaseException):
+            raise self._xml
+        return self._xml
+
+    def screenshot(self):
+        self.screenshot_calls += 1
+        kind = self._screenshot_kind
+        if isinstance(kind, BaseException):
+            raise kind
+        if kind == "image":
+            return _FakeImage()
+        if kind == "bytes":
+            return b"\x89PNG\r\n\x1a\n-fake-bytes"
+        if kind == "none":
+            return None
+        if kind == "weird":
+            return object()
+        raise AssertionError(f"unhandled fake screenshot kind: {kind}")
+
+
+class _FakeBot:
+    def __init__(self, *, device=None, config=None):
+        self.d = device
+        self.config = config
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_version_detect():
+    """Force detect_damai_app_version to return a stable string in tests."""
+    with patch(
+        "mobile.damai_app.recovery_strategies.detect_damai_app_version",
+        return_value="10.6.1",
+    ) as mocked:
+        yield mocked
+
+
+# ---------------------------------------------------------------------------
+# capture_failure_artifacts — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureFailureArtifactsHappyPath:
+    def test_writes_xml_png_and_metadata(self, tmp_path: Path, patched_version_detect):
+        device = _FakeDevice(xml="<hierarchy>ok</hierarchy>")
+        bot = _FakeBot(device=device, config=_FakeConfig())
+        result = capture_failure_artifacts(
+            bot,
+            "run_ticket_grabbing",
+            error=RuntimeError("boom"),
+            extra={"step": "submit_order"},
+            root=tmp_path,
+        )
+
+        # All three artifacts produced.
+        assert result["xml"] is not None
+        assert result["png"] is not None
+        assert result["json"] is not None
+
+        xml_path = Path(result["xml"])
+        png_path = Path(result["png"])
+        json_path = Path(result["json"])
+
+        # File contents land where expected.
+        assert xml_path.read_text(encoding="utf-8") == "<hierarchy>ok</hierarchy>"
+        assert png_path.read_bytes().startswith(b"\x89PNG")
+
+        meta = json.loads(json_path.read_text(encoding="utf-8"))
+        assert meta["scene"] == "run_ticket_grabbing"
+        assert meta["device"] == "device-A"
+        assert meta["damai_version"] == "10.6.1"
+        assert meta["error_type"] == "RuntimeError"
+        assert meta["error_message"] == "boom"
+        assert meta["screenshot_failed"] is False
+        assert meta["step"] == "submit_order"
+        assert "config_hash" in meta and len(meta["config_hash"]) == 12
+
+    def test_screenshot_bytes_path_writes_png(
+        self, tmp_path: Path, patched_version_detect
+    ):
+        device = _FakeDevice(screenshot_kind="bytes")
+        bot = _FakeBot(device=device, config=_FakeConfig())
+        result = capture_failure_artifacts(bot, "scene-X", root=tmp_path)
+        assert result["png"] is not None
+        assert Path(result["png"]).read_bytes().startswith(b"\x89PNG")
+
+    def test_filename_pattern_includes_timestamp_and_scene(
+        self, tmp_path: Path, patched_version_detect
+    ):
+        bot = _FakeBot(device=_FakeDevice(), config=_FakeConfig())
+        result = capture_failure_artifacts(bot, "Run Ticket / Grabbing!", root=tmp_path)
+        # Slug is lowercased, non-alnum collapsed to underscores.
+        for art in (result["xml"], result["png"], result["json"]):
+            stem = Path(art).stem
+            assert "run_ticket___grabbing" in stem
+            # Timestamp prefix YYYYMMDD-HHMMSS-mmm
+            assert stem[8] == "-"
+            assert stem[15] == "-"
+
+
+# ---------------------------------------------------------------------------
+# capture_failure_artifacts — degraded paths
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureFailureArtifactsDegraded:
+    def test_screenshot_failure_records_flag_and_no_png(
+        self, tmp_path: Path, patched_version_detect
+    ):
+        device = _FakeDevice(screenshot_kind=RuntimeError("camera blocked"))
+        bot = _FakeBot(device=device, config=_FakeConfig())
+        result = capture_failure_artifacts(bot, "scene-broken-cam", root=tmp_path)
+
+        assert result["xml"] is not None
+        assert result["png"] is None
+        assert result["json"] is not None
+
+        meta = json.loads(Path(result["json"]).read_text(encoding="utf-8"))
+        assert meta["screenshot_failed"] is True
+        assert meta["png_path"] is None
+
+    def test_screenshot_returns_none_records_flag(
+        self, tmp_path: Path, patched_version_detect
+    ):
+        device = _FakeDevice(screenshot_kind="none")
+        bot = _FakeBot(device=device, config=_FakeConfig())
+        result = capture_failure_artifacts(bot, "scene-none", root=tmp_path)
+        meta = json.loads(Path(result["json"]).read_text(encoding="utf-8"))
+        assert result["png"] is None
+        assert meta["screenshot_failed"] is True
+
+    def test_screenshot_unexpected_type_records_flag(
+        self, tmp_path: Path, patched_version_detect
+    ):
+        device = _FakeDevice(screenshot_kind="weird")
+        bot = _FakeBot(device=device, config=_FakeConfig())
+        result = capture_failure_artifacts(bot, "scene-weird", root=tmp_path)
+        meta = json.loads(Path(result["json"]).read_text(encoding="utf-8"))
+        assert result["png"] is None
+        assert meta["screenshot_failed"] is True
+
+    def test_xml_dump_failure_still_writes_metadata(
+        self, tmp_path: Path, patched_version_detect
+    ):
+        device = _FakeDevice(xml=RuntimeError("uiautomator dead"))
+        bot = _FakeBot(device=device, config=_FakeConfig())
+        result = capture_failure_artifacts(bot, "scene-no-xml", root=tmp_path)
+
+        assert result["xml"] is None
+        assert result["json"] is not None
+        meta = json.loads(Path(result["json"]).read_text(encoding="utf-8"))
+        assert meta["xml_path"] is None
+
+    def test_no_device_attached_only_metadata_written(
+        self, tmp_path: Path, patched_version_detect
+    ):
+        bot = _FakeBot(device=None, config=_FakeConfig(serial=None))
+        result = capture_failure_artifacts(bot, "no-device", root=tmp_path)
+
+        assert result["xml"] is None
+        assert result["png"] is None
+        assert result["json"] is not None
+        meta = json.loads(Path(result["json"]).read_text(encoding="utf-8"))
+        assert meta["device"] == "unknown"
+        assert meta["screenshot_failed"] is True
+
+    def test_unknown_damai_version_when_detect_returns_none(self, tmp_path: Path):
+        bot = _FakeBot(device=_FakeDevice(), config=_FakeConfig())
+        with patch(
+            "mobile.damai_app.recovery_strategies.detect_damai_app_version",
+            return_value=None,
+        ):
+            result = capture_failure_artifacts(bot, "vmiss", root=tmp_path)
+        meta = json.loads(Path(result["json"]).read_text(encoding="utf-8"))
+        assert meta["damai_version"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Helpers — _slugify_scene / _config_hash
+# ---------------------------------------------------------------------------
+
+
+class TestSlugifyScene:
+    def test_lowercases_and_replaces_non_alphanum(self):
+        assert _slugify_scene("Run Ticket!") == "run_ticket"
+
+    def test_collapses_to_default_when_all_punctuation(self):
+        assert _slugify_scene("///") == "scene"
+
+    def test_truncates_long_input(self):
+        long = "a" * 200
+        assert len(_slugify_scene(long)) == 48
+
+
+class TestConfigHash:
+    def test_none_config_returns_constant(self):
+        assert _config_hash(None) == "none"
+
+    def test_same_config_produces_same_hash(self):
+        cfg = _FakeConfig(serial="X", rush_mode=True)
+        h1 = _config_hash(cfg)
+        h2 = _config_hash(_FakeConfig(serial="X", rush_mode=True))
+        assert h1 == h2
+        assert len(h1) == 12
+
+    def test_different_config_produces_different_hash(self):
+        a = _config_hash(_FakeConfig(serial="X"))
+        b = _config_hash(_FakeConfig(serial="Y"))
+        assert a != b
+
+    def test_falls_back_to_repr_when_vars_unavailable(self):
+        class NoDict:
+            __slots__ = ()
+
+        h = _config_hash(NoDict())
+        assert isinstance(h, str) and len(h) == 12


### PR DESCRIPTION
## Summary

- **mobile/logger.py 新增 `log_event(event, *, level, **fields)`**：把热路径关键事件统一成 `event=name k=v ...` 形式，方便 grep/聚合。空格 / `=` / 引号 / None / bool 自动转义。
- **关键热路径事件统一改为 log_event 输出**：
  - `wait_for_sale_start` 命中：`event=sale_ready source=poll_loop|buy_button_guard cta_text=... polls=N duration_ms=...`
  - `_submit_order_fast` 完成：`event=order_submitted success=true|false result=... attempts=N duration_ms=...`
  - `select_session` 命中：`event=session_selected match=date+city|date|fallback_index date=... city=... index=N total=N`
  - `select_session` 抛 `*Error` 前：`event=error type=SessionNotFoundError scene=... date=... city=...`
- **启动期环境快照**（`mobile/env_snapshot.py` + `DamaiBot._emit_boot_snapshot`）：
  - `adb shell pm dump cn.damai` → `versionName` 解析
  - adb 不在 PATH / 超时 / 非零退出 / 无 versionName → 一律降级 `damai_version=unknown`
  - `event=boot py_version=3.X damai_version=10.6.1 device=... rush_mode=true`
- **失败时自动 dump UI XML + 截图 + metadata 到 `tmp/failures/`**（`mobile/damai_app/recovery_strategies.capture_failure_artifacts`）：
  - 文件名 `<YYYYmmdd-HHMMSS-mmm>_<scene>.{xml,png,json}`
  - metadata 含 device / damai_version / config_hash / error_type / error_message / screenshot_failed
  - 截图失败仅记 XML，标 `screenshot_failed=True`
  - 挂载点：`run_ticket_grabbing` 顶层 `except Exception`
- **D-002 desktop/ 处理决策**已写入 `reference/decisions/D-002-desktop-cleanup.md`（gitignored，不入 PR），结论 = **A 完全删除**，等 W4-05 PM 月度评审后另开 PR 实施。

## Test plan

- [x] `poetry run pytest --cov=mobile --cov-fail-under=80` → **81.47% / 1067 passed + 1 xfailed**（≥80% 门槛）
- [x] 模拟失败时 `tmp/failures/` 生成 ≥3 个文件（xml/png/json）— 由 `tests/unit/test_recovery_artifacts.py` 覆盖
- [x] 启动日志含 `event=boot py_version=... damai_version=... device=... rush_mode=...`
- [x] `tests/unit/test_env_snapshot.py` 16 例覆盖 adb 不在 PATH / 超时 / OSError / 非零退出 / 空 stdout / 多 versionName 等场景
- [x] `tests/unit/test_mobile_logger.py` +15 例覆盖 `_format_event_value` 与 `log_event` 各路径
- [ ] 真机 boot snapshot 验证（需要 Android 设备 + cn.damai 已安装；本地 mock 已绿）

## 关联

- Refs `reference/03-tech-assessment.md` 可观测性建议
- Note: desktop/ 处理决策记录在 `reference/decisions/D-002-desktop-cleanup.md`（gitignored），等 W4-05 评审决议