### PR TITLE
ci(ops): self-hosted runner 真机 E2E POC（dry-run）

### DIFF
--- a/.github/workflows/_e2e_dryrun.yml
+++ b/.github/workflows/_e2e_dryrun.yml
@@ -1,0 +1,55 @@
+name: E2E (dry-run, manual only)
+
+# 实验性 self-hosted runner 真机 E2E 框架。
+# 决策档案：reference/decisions/D-003-self-hosted-runner.md（status=postponed）
+# 启用条件：D-003 升级为 accepted 后，把 jobs.e2e.if 改成 true 并配置 self-hosted runner。
+# 当前默认不执行，仅保留 workflow_dispatch 入口供未来手动触发使用。
+
+on:
+  workflow_dispatch:
+    inputs:
+      android_device:
+        description: "目标设备（与 self-hosted runner label 对应）"
+        required: true
+        default: "pixel-7"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: e2e-dryrun-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: E2E probe (${{ inputs.android_device }})
+    if: false # D-003 = postponed；启用前请阅读 reference/decisions/D-003-self-hosted-runner.md
+    runs-on: [self-hosted, linux, android]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Probe run (read-only)
+        run: bash mobile/scripts/start_ticket_grabbing.sh --probe --yes
+
+      - name: Hot-path benchmark
+        run: bash mobile/scripts/benchmark_hot_path.sh --runs 3
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts-${{ github.run_id }}
+          path: tmp/
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- 新增 `.github/workflows/_e2e_dryrun.yml`：self-hosted runner 真机 E2E 框架，默认 `if: false` 不执行；保留 `workflow_dispatch` 入口供未来手动触发
- 调研报告 `reference/decisions/D-003-self-hosted-runner.md`（gitignored）：评估 4 方案（家用机+Tailscale / 云真机 / Mac mini 机柜 / 维持现状）后接受方案 D，status=`postponed`，预埋框架等待触发条件
- `reference/08-ops-runbook.md`（gitignored）：第 6 节新增「self-hosted runner（实验性）」，含启用条件 / 启用步骤 / 紧急下线 SOP；原第 6 节顺延为第 7 节

## Test plan

- [x] workflow 文件 yaml 语法正确（GitHub UI 渲染时不报红，新 workflow 出现在 Actions 列表）
- [x] 默认不会触发任何 job（`on:` 仅 `workflow_dispatch`，且 `jobs.e2e.if: false`）
- [x] manual_dispatch 入口存在但 job 跳过（GitHub UI 出现 "Run workflow" 按钮 + `android_device` 输入；触发后 job skipped 不消耗分钟）
- [x] 不动 `test.yml` / `release.yml`（本 PR 仅新增文件）
- [x] 不暴露任何 token / secrets

## 决策结论

**D-003 = D（维持现状，手工真机回归）** — postponed。

主要理由：
1. A/C 把 runner 开到团队成员个人/办公网络，攻击面（runner 进程权限 + secrets 读取 + adb-over-network）显著大于「滞后 1-7 天」的成本
2. B（云真机）在大麦风控前等于无效覆盖
3. W4-03 把 `tests/manual/` 标准化成 templates+history（PR #47），单次回归 30 分钟，人工方案 ROI 比预期高
4. 当前 issue 队列没有「真机回归滞后导致大量用户阻塞」的实例

预埋而非真启用：保留 workflow + 决策档案，让未来 ops 想推进时不用从零写 yaml。

## 关联

- Refs `reference/06-test-gap-analysis.md` 真机 E2E 长期目标段落
- 决策档案：`reference/decisions/D-003-self-hosted-runner.md`（gitignored）
- 真机回归 SOP：`tests/manual/runbook.md`（W4-03 已交付）